### PR TITLE
feat: yield analytics endpoints and non-custodial wallet support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import protocolsRouter from './routes/protocols'
 import depositRouter from './routes/deposit'
 import withdrawRouter from './routes/withdraw'
 import vaultRouter from './routes/vault'
+import analyticsRouter from './routes/analytics'
 
 const app = express()
 
@@ -44,6 +45,7 @@ app.use('/api/protocols', protocolsRouter)
 app.use('/api/deposit', depositRouter)
 app.use('/api/withdraw', withdrawRouter)
 app.use('/api/vault', vaultRouter)
+app.use('/api/analytics', analyticsRouter)
 
 // Global error handler — must always be last
 app.use(errorHandler)

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -1,0 +1,132 @@
+import { Router, Request, Response } from 'express'
+import { z } from 'zod'
+import db from '../db'
+import { requireAuth, enforceUserAccess } from '../middleware/auth'
+
+const router = Router()
+
+const periodSchema = z.object({
+  period: z.enum(['7d', '30d', '90d']).default('30d'),
+})
+
+function periodToDays(period: string): number {
+  return period === '7d' ? 7 : period === '30d' ? 30 : 90
+}
+
+/**
+ * GET /analytics/apy-history
+ * Returns APY snapshots over time for a user's positions (graph-ready).
+ */
+router.get('/apy-history', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.auth!.userId
+  const parsed = periodSchema.safeParse(req.query)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Validation error', details: parsed.error.flatten() })
+  }
+
+  const fromDate = new Date(Date.now() - periodToDays(parsed.data.period) * 86400_000)
+
+  const snapshots = await db.yieldSnapshot.findMany({
+    where: { position: { userId }, snapshotAt: { gte: fromDate } },
+    orderBy: { snapshotAt: 'asc' },
+    select: { snapshotAt: true, apy: true, positionId: true },
+  })
+
+  const points = snapshots.map((s) => ({
+    date: s.snapshotAt.toISOString().slice(0, 10),
+    apy: Number(s.apy),
+    positionId: s.positionId,
+  }))
+
+  return res.status(200).json({ userId, period: parsed.data.period, points })
+})
+
+/**
+ * GET /analytics/user-yield
+ * Returns cumulative and period yield earned by the authenticated user.
+ */
+router.get('/user-yield', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.auth!.userId
+  const parsed = periodSchema.safeParse(req.query)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Validation error', details: parsed.error.flatten() })
+  }
+
+  const fromDate = new Date(Date.now() - periodToDays(parsed.data.period) * 86400_000)
+
+  const [positions, snapshots] = await Promise.all([
+    db.position.findMany({ where: { userId }, select: { yieldEarned: true, assetSymbol: true } }),
+    db.yieldSnapshot.findMany({
+      where: { position: { userId }, snapshotAt: { gte: fromDate } },
+      orderBy: { snapshotAt: 'asc' },
+      select: { snapshotAt: true, yieldAmount: true, apy: true },
+    }),
+  ])
+
+  const totalYield = positions.reduce((sum, p) => sum + Number(p.yieldEarned), 0)
+  const periodYield = snapshots.reduce((sum, s) => sum + Number(s.yieldAmount), 0)
+  const averageApy =
+    snapshots.length > 0
+      ? snapshots.reduce((sum, s) => sum + Number(s.apy), 0) / snapshots.length
+      : 0
+
+  const points = snapshots.map((s) => ({
+    date: s.snapshotAt.toISOString().slice(0, 10),
+    yieldAmount: Number(s.yieldAmount),
+    apy: Number(s.apy),
+  }))
+
+  return res.status(200).json({
+    userId,
+    period: parsed.data.period,
+    totalYield,
+    periodYield,
+    averageApy,
+    points,
+  })
+})
+
+/**
+ * GET /analytics/protocol-performance
+ * Returns historical APY rates per protocol (graph-ready).
+ */
+router.get('/protocol-performance', async (req: Request, res: Response) => {
+  const parsed = periodSchema.safeParse(req.query)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Validation error', details: parsed.error.flatten() })
+  }
+
+  const fromDate = new Date(Date.now() - periodToDays(parsed.data.period) * 86400_000)
+
+  const rates = await db.protocolRate.findMany({
+    where: { fetchedAt: { gte: fromDate } },
+    orderBy: { fetchedAt: 'asc' },
+    select: {
+      protocolName: true,
+      assetSymbol: true,
+      supplyApy: true,
+      tvl: true,
+      fetchedAt: true,
+      network: true,
+    },
+  })
+
+  // Group by protocol for graph-ready output
+  const byProtocol: Record<string, { protocol: string; asset: string; network: string; points: { date: string; apy: number; tvl: number | null }[] }> = {}
+
+  for (const r of rates) {
+    const key = `${r.protocolName}:${r.assetSymbol}:${r.network}`
+    if (!byProtocol[key]) {
+      byProtocol[key] = { protocol: r.protocolName, asset: r.assetSymbol, network: r.network, points: [] }
+    }
+    byProtocol[key].points.push({
+      date: r.fetchedAt.toISOString().slice(0, 10),
+      apy: Number(r.supplyApy),
+      tvl: r.tvl !== null ? Number(r.tvl) : null,
+    })
+  }
+
+  return res.status(200).json({ period: parsed.data.period, protocols: Object.values(byProtocol) })
+})
+
+export default router

--- a/src/routes/vault.ts
+++ b/src/routes/vault.ts
@@ -1,10 +1,12 @@
 import { Router, Request, Response } from 'express'
+import { z } from 'zod'
 import db from '../db'
 import { requireAuth } from '../middleware/auth'
 import {
   getActiveProtocol,
   getOnChainAPY,
   getOnChainBalance,
+  buildUnsignedVaultTransaction,
 } from '../stellar/contract'
 
 const router = Router()
@@ -46,6 +48,38 @@ router.get('/balance', requireAuth, async (req: Request, res: Response) => {
   return res.status(200).json({
     balance: toNumber(onChain.balance),
     shares: toNumber(onChain.shares),
+  })
+})
+
+const buildTransactionSchema = z.object({
+  type: z.enum(['deposit', 'withdraw']),
+  amount: z.number().positive(),
+})
+
+/**
+ * POST /vault/build-transaction
+ * Builds an unsigned XDR transaction for the user to sign client-side (non-custodial).
+ * The backend never holds or decrypts private keys for this flow.
+ */
+router.post('/build-transaction', requireAuth, async (req: Request, res: Response) => {
+  const parsed = buildTransactionSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Validation error', details: parsed.error.flatten() })
+  }
+
+  const walletAddress = req.auth!.walletAddress
+
+  const unsignedXdr = await buildUnsignedVaultTransaction(
+    parsed.data.type,
+    walletAddress,
+    parsed.data.amount,
+  )
+
+  return res.status(200).json({
+    xdr: unsignedXdr,
+    type: parsed.data.type,
+    amount: parsed.data.amount,
+    walletAddress,
   })
 })
 

--- a/src/stellar/contract.ts
+++ b/src/stellar/contract.ts
@@ -208,3 +208,23 @@ export async function withdrawForUser(
 ): Promise<TransactionResult> {
   return executeCustodialVaultOperation('withdraw', userId, userAddress, amount);
 }
+
+/**
+ * Build an unsigned XDR transaction for non-custodial signing.
+ * The backend constructs and prepares the transaction but never signs it.
+ * The client (e.g. Freighter) signs and submits the returned XDR.
+ */
+export async function buildUnsignedVaultTransaction(
+  method: VaultWriteMethod,
+  userAddress: string,
+  amount: number,
+): Promise<string> {
+  const server = getRpcServer();
+  const userScVal = nativeToScVal(userAddress, { type: 'address' });
+  const amountScVal = nativeToScVal(toContractAmount(amount), { type: 'i128' });
+
+  const tx = await buildContractCall(method, [userScVal, amountScVal], userAddress);
+  const prepared = await server.prepareTransaction(tx);
+
+  return prepared.toXDR();
+}


### PR DESCRIPTION
## Summary

Implements two assigned issues:

### Closes #61 — Yield Analytics & Historical Performance Endpoints

Added three graph-ready analytics endpoints under `/api/analytics`:

- `GET /api/analytics/apy-history` — APY snapshots over time per user position (auth required). Supports `?period=7d|30d|90d`.
- `GET /api/analytics/user-yield` — Cumulative and period yield earned by the authenticated user, with per-day breakdown. Supports `?period=7d|30d|90d`.
- `GET /api/analytics/protocol-performance` — Historical APY and TVL per protocol, grouped for graph rendering. Public endpoint. Supports `?period=7d|30d|90d`.

All responses are graph-ready (array of `{ date, value }` points).

### Closes #60 — Non-Custodial Wallet Support (User-Signed Transactions)

Added `POST /api/vault/build-transaction` (auth required):

- Backend builds and prepares the Stellar contract invocation transaction (deposit or withdraw) using the user's public wallet address.
- Returns the unsigned XDR string — the backend **never signs** this transaction.
- The client (e.g. Freighter) signs the XDR and submits it independently.
- Backend private keys are never involved in this flow.

## Files Changed

- `src/routes/analytics.ts` — new analytics router
- `src/routes/vault.ts` — added `POST /build-transaction` endpoint
- `src/stellar/contract.ts` — added `buildUnsignedVaultTransaction` helper
- `src/index.ts` — registered `/api/analytics` router

## Testing

- TypeScript build passes with no errors (`npx tsc --noEmit`)