### PR TITLE
fix: read Stellar network and contract ID from config (#66)

### DIFF
--- a/src/stellar/client.ts
+++ b/src/stellar/client.ts
@@ -5,9 +5,9 @@ import {
   Transaction,
   TransactionBuilder,
 } from '@stellar/stellar-sdk';
+import { config } from '../config';
 import { TransactionResult } from './types';
 
-const RPC_URL = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
 export function resolveNetworkPassphrase(network: string | undefined): string {
   switch (network?.toLowerCase()) {
     case 'mainnet':
@@ -23,7 +23,8 @@ export function resolveNetworkPassphrase(network: string | undefined): string {
   }
 }
 
-const NETWORK_PASSPHRASE = resolveNetworkPassphrase(process.env.STELLAR_NETWORK);
+const RPC_URL = config.stellar.rpcUrl;
+const NETWORK_PASSPHRASE = resolveNetworkPassphrase(config.stellar.network);
 
 let agentKeypair: Keypair | null = null;
 let rpcServer: rpc.Server | null = null;

--- a/src/stellar/contract.ts
+++ b/src/stellar/contract.ts
@@ -11,9 +11,10 @@ import {
 } from '@stellar/stellar-sdk';
 import { getRpcServer, getNetworkPassphrase, getAgentKeypair, submitTransaction, waitForConfirmation } from './client';
 import { getKeypairForUser } from './wallet';
+import { config } from '../config';
 import { OnChainBalance, TransactionResult } from './types';
 
-const VAULT_CONTRACT_ID = process.env.VAULT_CONTRACT_ID || '';
+const VAULT_CONTRACT_ID = config.stellar.vaultContractId;
 const STROOPS_PER_TOKEN = 10_000_000n;
 
 export type VaultWriteMethod = 'deposit' | 'withdraw';

--- a/src/stellar/events.ts
+++ b/src/stellar/events.ts
@@ -22,7 +22,7 @@ import {
   recordDbOperation
 } from '../utils/metrics';
 
-const VAULT_CONTRACT_ID = process.env.VAULT_CONTRACT_ID || '';
+const VAULT_CONTRACT_ID = config.stellar.vaultContractId;
 const POLL_INTERVAL_MS = 5000;
 
 const prisma = new PrismaClient();
@@ -147,10 +147,11 @@ export function extractProtocolName(event: ContractEvent): string {
  * Extract network from config (canonical source of truth).
  */
 function extractNetwork(): Network {
-  const n = config.stellar.network.toUpperCase();
-  if (n === 'TESTNET') return Network.TESTNET;
-  if (n === 'FUTURENET') return Network.FUTURENET;
-  return Network.MAINNET;
+  switch (config.stellar.network) {
+    case 'testnet': return Network.TESTNET;
+    case 'futurenet': return Network.FUTURENET;
+    case 'mainnet': return Network.MAINNET;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Routes all Stellar env reads (RPC URL, network passphrase, vault contract ID) through the central `config` object in `src/stellar/client.ts` and `src/stellar/contract.ts`
- Replaces the implicit `MAINNET` fallback in `extractNetwork()` (`events.ts`) with an exhaustive `switch` on the validated config value, so the compiler enforces coverage of all three network variants
- Deployments now control the network entirely via `STELLAR_NETWORK=testnet|mainnet|futurenet`

## Test plan

- [ ] Set `STELLAR_NETWORK=testnet` and verify `extractNetwork()` returns `Network.TESTNET`
- [ ] Set `STELLAR_NETWORK=futurenet` and verify `extractNetwork()` returns `Network.FUTURENET`
- [ ] Set `STELLAR_NETWORK=mainnet` and verify `extractNetwork()` returns `Network.MAINNET`
- [ ] Confirm invalid network value still throws at config load time (validated in `config/env.ts`)
- [ ] Run existing test suite: `npm test`

Closes #66