### PR TITLE
fix: populate real metadata in getPositionHistory() and getLatestUserBalance() (#67)

### DIFF
--- a/src/agent/__tests__/agent.test.ts
+++ b/src/agent/__tests__/agent.test.ts
@@ -177,6 +177,53 @@ describe('Agent System', () => {
         expect(pos.amount).toBeTruthy();
       });
     });
+
+    it('should compute currentValue as principalAmount + yieldAmount', () => {
+      const snapshots = [
+        { principalAmount: 1000, yieldAmount: 40, expectedCurrentValue: '1040' },
+        { principalAmount: 5000, yieldAmount: 250, expectedCurrentValue: '5250' },
+        { principalAmount: 100, yieldAmount: 0, expectedCurrentValue: '100' },
+      ];
+
+      snapshots.forEach(({ principalAmount, yieldAmount, expectedCurrentValue }) => {
+        const currentValue = (principalAmount + yieldAmount).toString();
+        expect(currentValue).toBe(expectedCurrentValue);
+      });
+    });
+
+    it('should populate userId and walletAddress from joined position', () => {
+      const mockSnapshot = {
+        positionId: 'pos-1',
+        principalAmount: { toNumber: () => 1000 },
+        yieldAmount: { toNumber: () => 50 },
+        apy: { toNumber: () => 5.0 },
+        snapshotAt: new Date('2024-01-15'),
+        position: {
+          userId: 'user-abc',
+          protocolName: 'Blend',
+          user: { id: 'user-abc', walletAddress: 'GABC123' },
+        },
+      };
+
+      const result = {
+        userId: mockSnapshot.position.userId,
+        walletAddress: mockSnapshot.position.user.walletAddress,
+        positionId: mockSnapshot.positionId,
+        protocolName: mockSnapshot.position.protocolName,
+        amount: mockSnapshot.principalAmount.toNumber().toString(),
+        currentValue: (mockSnapshot.principalAmount.toNumber() + mockSnapshot.yieldAmount.toNumber()).toString(),
+        apy: mockSnapshot.apy.toNumber(),
+        snapshotAt: mockSnapshot.snapshotAt,
+      };
+
+      expect(result.userId).toBe('user-abc');
+      expect(result.walletAddress).toBe('GABC123');
+      expect(result.protocolName).toBe('Blend');
+      expect(result.currentValue).toBe('1050');
+      expect(result.userId).not.toBe('');
+      expect(result.walletAddress).not.toBe('');
+      expect(result.protocolName).not.toBe('');
+    });
   });
 
   describe('Agent Loop - Cron Scheduling', () => {

--- a/src/agent/snapshotter.ts
+++ b/src/agent/snapshotter.ts
@@ -110,18 +110,27 @@ export async function getPositionHistory(
           gte: cutoffDate,
         },
       },
+      include: {
+        position: {
+          include: {
+            user: {
+              select: { id: true, walletAddress: true },
+            },
+          },
+        },
+      },
       orderBy: {
         snapshotAt: 'asc',
       },
     });
 
     return snapshots.map((snapshot: any) => ({
-      userId: '', // Would need to join with position
-      walletAddress: '',
+      userId: snapshot.position.userId,
+      walletAddress: snapshot.position.user.walletAddress,
       positionId,
-      protocolName: '', // Would need to join with position
+      protocolName: snapshot.position.protocolName,
       amount: snapshot.principalAmount.toString(),
-      currentValue: snapshot.principalAmount.toString(), // Simplified
+      currentValue: (snapshot.principalAmount.toNumber() + snapshot.yieldAmount.toNumber()).toString(),
       apy: snapshot.apy.toNumber(),
       snapshotAt: snapshot.snapshotAt,
     }));
@@ -172,6 +181,15 @@ export async function getLatestUserBalance(positionId: string): Promise<UserBala
       where: {
         positionId,
       },
+      include: {
+        position: {
+          include: {
+            user: {
+              select: { id: true, walletAddress: true },
+            },
+          },
+        },
+      },
       orderBy: {
         snapshotAt: 'desc',
       },
@@ -182,12 +200,12 @@ export async function getLatestUserBalance(positionId: string): Promise<UserBala
     }
 
     return {
-      userId: '',
-      walletAddress: '',
+      userId: snapshot.position.userId,
+      walletAddress: snapshot.position.user.walletAddress,
       positionId,
-      protocolName: '',
+      protocolName: snapshot.position.protocolName,
       amount: snapshot.principalAmount.toString(),
-      currentValue: snapshot.principalAmount.toString(),
+      currentValue: (snapshot.principalAmount.toNumber() + snapshot.yieldAmount.toNumber()).toString(),
       apy: snapshot.apy.toNumber(),
       snapshotAt: snapshot.snapshotAt,
     };


### PR DESCRIPTION
## Summary

- Adds an `include` clause to both `getPositionHistory()` and `getLatestUserBalance()` in `src/agent/snapshotter.ts` to join `yieldSnapshot → position → user`
- Replaces the empty-string placeholders (`userId: ''`, `walletAddress: ''`, `protocolName: ''`) with actual values from the joined records
- Computes `currentValue` as `principalAmount + yieldAmount` instead of echoing `principalAmount` alone

## Test plan

- [ ] `getPositionHistory(positionId)` returns snapshots with non-empty `userId`, `walletAddress`, and `protocolName`
- [ ] `currentValue` equals `principalAmount + yieldAmount` for each snapshot
- [ ] `getLatestUserBalance(positionId)` returns the same real metadata on a single snapshot
- [ ] History endpoint returns accurate data for existing positions
- [ ] Run `npm test -- src/agent/__tests__/agent.test.ts` — new tests for metadata population and currentValue calculation pass

Closes #67