### PR TITLE
fix(stellar): parse asset + protocol from event topics, no USDC/vault fallback

### DIFF
--- a/docs/COMPLETION_REPORT.md
+++ b/docs/COMPLETION_REPORT.md
@@ -397,17 +397,20 @@ Wait 5 seconds and repeat
 ## Known Limitations & Future Improvements
 
 ### Current Limitations
-- Asset symbol hardcoded to 'USDC' (TODO: extract from event)
-- Protocol name hardcoded to 'vault' (TODO: extract from event)
-- Network hardcoded to 'MAINNET' (TODO: get from config)
+- Network resolved from config rather than per-event payload
+
+### Resolved
+- Asset symbol and protocol name are now parsed directly from event
+  topics (`topic[1]` and `topic[2]` respectively). Events that omit
+  either topic now flow to the DLQ rather than being persisted under
+  the legacy `USDC` / `vault` defaults — see #65.
 
 ### Future Improvements
-1. Extract asset symbol and protocol from event data
-2. Implement dead-letter queue for failed events
-3. Add metrics and monitoring
-4. Batch process events for better throughput
-5. Add event validation and schema checking
-6. Implement retry logic with exponential backoff
+1. Implement dead-letter queue for failed events
+2. Add metrics and monitoring
+3. Batch process events for better throughput
+4. Add event validation and schema checking
+5. Implement retry logic with exponential backoff
 
 ---
 

--- a/src/stellar/__tests__/events.helpers.test.ts
+++ b/src/stellar/__tests__/events.helpers.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the event metadata extraction helpers (#65).
+ *
+ * Exercises asset symbol + protocol name parsing across multiple
+ * non-USDC assets and protocols, plus the failure paths that #65 added
+ * so that malformed events flow to the DLQ instead of being silently
+ * persisted under the legacy `USDC`/`vault` defaults.
+ */
+
+import type { ContractEvent } from '../types';
+import { Network } from '@prisma/client';
+
+// Mock scValToNative so we can dictate what each topic decodes to
+// without having to construct real xdr.ScVal values per test.
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    scValToNative: jest.fn((sv: unknown) => (sv as { __native?: unknown })?.__native),
+  };
+});
+
+// Avoid spinning a real PrismaClient on import.
+jest.mock('@prisma/client', () => {
+  const enums = jest.requireActual('@prisma/client');
+  return {
+    ...enums,
+    PrismaClient: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+// Avoid the dlq module pulling in a Prisma connection too.
+jest.mock('../dlq', () => ({
+  DeadLetterQueue: { add: jest.fn(), retryAll: jest.fn() },
+}));
+
+import {
+  extractAssetSymbol,
+  extractProtocolName,
+} from '../events';
+
+/** Build a topic placeholder that the mocked `scValToNative` will decode into the given value. */
+const topic = (decoded: unknown): any => ({ __native: decoded });
+
+const baseEvent = (topics: any[]): ContractEvent => ({
+  type: 'deposit',
+  ledger: 12345,
+  txHash: 'tx-abc',
+  contractId: 'CTEST',
+  topics: topics as any,
+  value: topic({}) as any,
+});
+
+describe('extractAssetSymbol (#65)', () => {
+  it.each([
+    ['USDC'],
+    ['XLM'],
+    ['EURC'],
+    ['yXLM'],
+    ['BTCLN'],
+  ])('returns the dynamic asset symbol "%s" from topic[1]', symbol => {
+    const event = baseEvent([
+      topic('deposit'),
+      topic(symbol),
+      topic('aave'),
+    ]);
+    expect(extractAssetSymbol(event)).toBe(symbol);
+  });
+
+  it('throws when topic[1] is missing entirely (no silent USDC fallback)', () => {
+    const event = baseEvent([topic('deposit')]);
+    expect(() => extractAssetSymbol(event)).toThrow(/Missing asset symbol topic/);
+  });
+
+  it('throws when topic[1] is not a string (e.g. numeric encoding)', () => {
+    const event = baseEvent([topic('deposit'), topic(42), topic('aave')]);
+    expect(() => extractAssetSymbol(event)).toThrow(
+      /asset symbol topic at index 1 is not a non-empty string/
+    );
+  });
+
+  it('throws when topic[1] decodes to an empty string', () => {
+    const event = baseEvent([topic('deposit'), topic(''), topic('aave')]);
+    expect(() => extractAssetSymbol(event)).toThrow(
+      /asset symbol topic at index 1 is not a non-empty string/
+    );
+  });
+
+  it('wraps the underlying decode error with event context', () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    (scValToNative as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('xdr decode boom');
+    });
+    const event = baseEvent([topic('deposit'), topic('XLM'), topic('aave')]);
+    expect(() => extractAssetSymbol(event)).toThrow(/Failed to decode asset symbol/);
+  });
+});
+
+describe('extractProtocolName (#65)', () => {
+  it.each([
+    ['vault'],
+    ['aave'],
+    ['blend'],
+    ['compound'],
+    ['stellar-dex'],
+  ])('returns the dynamic protocol name "%s" from topic[2]', protocol => {
+    const event = baseEvent([
+      topic('deposit'),
+      topic('XLM'),
+      topic(protocol),
+    ]);
+    expect(extractProtocolName(event)).toBe(protocol);
+  });
+
+  it('throws when topic[2] is missing (no silent vault fallback)', () => {
+    const event = baseEvent([topic('deposit'), topic('XLM')]);
+    expect(() => extractProtocolName(event)).toThrow(
+      /Missing protocol name topic/
+    );
+  });
+
+  it('throws when topic[2] is not a string', () => {
+    const event = baseEvent([
+      topic('deposit'),
+      topic('XLM'),
+      topic({ wrong: 'shape' }),
+    ]);
+    expect(() => extractProtocolName(event)).toThrow(
+      /protocol name topic at index 2 is not a non-empty string/
+    );
+  });
+
+  it('throws when topic[2] decodes to an empty string', () => {
+    const event = baseEvent([topic('deposit'), topic('XLM'), topic('')]);
+    expect(() => extractProtocolName(event)).toThrow(
+      /protocol name topic at index 2 is not a non-empty string/
+    );
+  });
+});
+
+describe('Event parsing carries dynamic asset + protocol through to parsed events (#65)', () => {
+  // We re-import the module-scoped parsers via the public surface; the
+  // exported handleEvent uses the same parsers and is exercised end-to-end
+  // in stellar.test.ts. Here we just verify the parsed object shape using
+  // the helpers + a hand-built event payload.
+  it('non-USDC + non-vault metadata flows through to the parsed event shape', () => {
+    const event = baseEvent([
+      topic('deposit'),
+      topic('EURC'),
+      topic('blend'),
+    ]);
+    const assetSymbol = extractAssetSymbol(event);
+    const protocolName = extractProtocolName(event);
+    const network = Network.TESTNET;
+    expect({ assetSymbol, protocolName, network }).toEqual({
+      assetSymbol: 'EURC',
+      protocolName: 'blend',
+      network: 'TESTNET',
+    });
+  });
+});

--- a/src/stellar/events.ts
+++ b/src/stellar/events.ts
@@ -77,38 +77,56 @@ export function getEventMetrics(): Readonly<EventMetrics> {
   return { ...metrics };
 }
 
-// --- Event context extraction helpers (Issue #51) ---
+// --- Event context extraction helpers (Issues #51, #65) ---
 
 /**
- * Extract asset symbol from event topics or value.
- * Topics[1] carries the asset symbol when present; falls back to 'USDC'.
+ * Read a string topic at the given index. Throws when the topic is
+ * missing or doesn't decode to a non-empty string — #65 explicitly
+ * removes the previous USDC/vault fallbacks so malformed events flow
+ * through to the DLQ instead of silently being persisted as USDC.
  */
-function extractAssetSymbol(event: ContractEvent): string {
-  if (event.topics.length > 1) {
-    try {
-      const raw = scValToNative(event.topics[1]);
-      if (typeof raw === 'string' && raw.length > 0) return raw;
-    } catch {
-      // fall through to default
-    }
+function readStringTopic(
+  event: ContractEvent,
+  index: number,
+  label: string
+): string {
+  if (event.topics.length <= index) {
+    throw new Error(
+      `[Event] Missing ${label} topic at index ${index} (txHash=${event.txHash}, type=${event.type})`
+    );
   }
-  return 'USDC';
+  let raw: unknown;
+  try {
+    raw = scValToNative(event.topics[index]);
+  } catch (err) {
+    throw new Error(
+      `[Event] Failed to decode ${label} topic at index ${index} (txHash=${event.txHash}): ${
+        err instanceof Error ? err.message : 'unknown decode error'
+      }`
+    );
+  }
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error(
+      `[Event] ${label} topic at index ${index} is not a non-empty string (txHash=${event.txHash}, got=${typeof raw})`
+    );
+  }
+  return raw;
 }
 
 /**
- * Extract protocol name from event topics or value.
- * Topics[2] carries the protocol name when present; falls back to 'vault'.
+ * Extract asset symbol from event topics. Topic[1] carries the asset.
+ * Throws when missing — see {@link readStringTopic}.
  */
-function extractProtocolName(event: ContractEvent): string {
-  if (event.topics.length > 2) {
-    try {
-      const raw = scValToNative(event.topics[2]);
-      if (typeof raw === 'string' && raw.length > 0) return raw;
-    } catch {
-      // fall through to default
-    }
-  }
-  return 'vault';
+export function extractAssetSymbol(event: ContractEvent): string {
+  return readStringTopic(event, 1, 'asset symbol');
+}
+
+/**
+ * Extract protocol name from event topics. Topic[2] carries the protocol.
+ * Throws when missing — see {@link readStringTopic}.
+ */
+export function extractProtocolName(event: ContractEvent): string {
+  return readStringTopic(event, 2, 'protocol name');
 }
 
 /**

--- a/tests/unit/stellar/enhanced_events.test.ts
+++ b/tests/unit/stellar/enhanced_events.test.ts
@@ -47,13 +47,20 @@ describe('Vault Enhanced Events Tests', () => {
 
     describe('Batch Processing (Issue #55)', () => {
         it('should process a batch of valid events in a transaction', async () => {
+            // Issue #65 — events must carry asset (topics[1]) and protocol
+            // (topics[2]) string topics or they flow to the DLQ instead of
+            // being persisted. The test events below were updated to match.
             const events = [
                 {
                     type: 'deposit' as const,
                     ledger: 100,
                     txHash: 'tx_batch_1',
                     contractId: CONTRACT_ID,
-                    topics: [stellarSdk.nativeToScVal('deposit')],
+                    topics: [
+                        stellarSdk.nativeToScVal('deposit', { type: 'string' }),
+                        stellarSdk.nativeToScVal('USDC', { type: 'string' }),
+                        stellarSdk.nativeToScVal('vault', { type: 'string' }),
+                    ],
                     value: stellarSdk.nativeToScVal({ user: WALLET, amount: 1000n, shares: 100n })
                 },
                 {
@@ -61,7 +68,11 @@ describe('Vault Enhanced Events Tests', () => {
                     ledger: 101,
                     txHash: 'tx_batch_2',
                     contractId: CONTRACT_ID,
-                    topics: [stellarSdk.nativeToScVal('withdraw')],
+                    topics: [
+                        stellarSdk.nativeToScVal('withdraw', { type: 'string' }),
+                        stellarSdk.nativeToScVal('USDC', { type: 'string' }),
+                        stellarSdk.nativeToScVal('vault', { type: 'string' }),
+                    ],
                     value: stellarSdk.nativeToScVal({ user: WALLET, amount: 500n, shares: 50n })
                 }
             ];


### PR DESCRIPTION
## Summary

closes #65

Removes the legacy `'USDC'` and `'vault'` fallbacks from the Stellar event listener so event metadata is sourced entirely from the on-chain topics.

- `extractAssetSymbol` reads `topic[1]`; throws when missing, non-string, or empty.
- `extractProtocolName` reads `topic[2]`; same semantics.
- Both are now exported so the new tests can pin the contract directly.
- Malformed events flow through `handleEvent` → `DeadLetterQueue.add` (unchanged), instead of being silently persisted as `USDC` / `vault`.
- `docs/COMPLETION_REPORT.md`: drops the resolved TODOs and documents the new failure semantics.

## Acceptance criteria

- [x] Event processing uses dynamic values for asset and protocol (no fallback constant in the code path).
- [x] No hardcoded `USDC` or `vault` in event-metadata code paths.
- [x] Unit tests validate metadata extraction for multiple assets (USDC, XLM, EURC, yXLM, BTCLN) and protocols (vault, aave, blend, compound, stellar-dex), plus the missing / non-string / empty failure paths and a decode-error wrap.

## Out of scope (kept for clarity)

- `src/agent/scanner.ts` and `src/agent/router.ts` still use `USDC` as the protocol-rates scanning asset; widening that to a multi-asset scan is a separate concern from the event listener fix this issue scopes.
- Network resolution still comes from `config.stellar.network`, which is the intended source of truth per the existing `extractNetwork()` helper.

## Test plan

- [ ] CI: `pnpm test` — new `events.helpers.test.ts` passes.
- [ ] CI: lint/typecheck unchanged.
- [ ] Manual / soak: send a deposit event missing `topic[1]` to a test env and confirm it lands in the DLQ instead of being persisted under the old `USDC` default.
