### PR TITLE
neuro backend implementation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -39,6 +39,37 @@ Comprehensive reference for all backend endpoints defined in src/routes.
 
 ---
 
+## Rate Limiting
+
+All rate-limited routes return the following headers on every response:
+
+| Header | Description |
+|---|---|
+| `RateLimit-Limit` | Maximum requests allowed in the current window |
+| `RateLimit-Remaining` | Requests remaining in the current window |
+| `RateLimit-Reset` | Seconds until the window resets |
+| `RateLimit-Policy` | Policy string per IETF draft: `<limit>;w=<window-seconds>` (e.g. `100;w=900`) |
+
+On `429 Too Many Requests` responses, an additional header is included:
+
+| Header | Description |
+|---|---|
+| `Retry-After` | Seconds the client should wait before retrying |
+
+Default limits by route group:
+
+| Limiter | Max requests | Window | Policy header |
+|---|---|---|---|
+| Global (all routes) | 100 | 15 min | `100;w=900` |
+| Auth (`/api/auth/*`) | 20 | 15 min | `20;w=900` |
+| Admin (`/api/admin/*`) | 10 | 15 min | `10;w=900` |
+| Webhook | 30 | 1 min | `30;w=60` |
+| Internal / agent | 500 | 1 min | `500;w=60` |
+
+Limits are configurable via environment variables (e.g. `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MS`). Trusted IPs (`TRUSTED_IPS`) and requests bearing a valid `X-Internal-Token` (`INTERNAL_SERVICE_TOKEN`) bypass rate limiting entirely.
+
+---
+
 ## Health
 
 ### GET /health

--- a/package-lock.json
+++ b/package-lock.json
@@ -4448,6 +4448,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -61,12 +61,12 @@ function getRouteGroup(path: string): string {
 }
 
 /**
- * Handler called when rate limit is exceeded.
+ * Handler called when rate limit is exceeded. Sets Retry-After before responding.
  */
 function handleRateLimitExceeded(
   req: any,
   res: any,
-  options: { limiterType: string }
+  options: { limiterType: string; windowMs: number }
 ): void {
   const routeGroup = getRouteGroup(req.path)
   recordRateLimitHit(routeGroup, options.limiterType)
@@ -78,9 +78,56 @@ function handleRateLimitExceeded(
     limiterType: options.limiterType,
   })
 
+  const resetTime = req.rateLimit?.resetTime as Date | undefined
+  const retryAfter = resetTime
+    ? Math.max(0, Math.ceil((resetTime.getTime() - Date.now()) / 1000))
+    : Math.ceil(options.windowMs / 1000)
+
+  res.setHeader('Retry-After', String(retryAfter))
   res.status(429).json({
     error: 'Too many requests. Please try again later.',
   })
+}
+
+// ── Rate limiter factory ───────────────────────────────────────────────────
+
+export interface BuildRateLimiterOptions {
+  windowMs: number
+  max: number
+  skip?: (req: Request) => boolean
+  limiterType: string
+  message?: string
+}
+
+/**
+ * Creates a rate-limiting middleware with IETF-standard response headers:
+ *   RateLimit-Limit / RateLimit-Remaining / RateLimit-Reset  (draft-6, every response)
+ *   RateLimit-Policy                                          (IETF draft, every response)
+ *   Retry-After                                               (seconds until reset, 429 only)
+ */
+export function buildRateLimiter(
+  opts: BuildRateLimiterOptions
+): (req: Request, res: Response, next: NextFunction) => void {
+  const policy = `${opts.max};w=${Math.ceil(opts.windowMs / 1000)}`
+
+  const limiter = rateLimit({
+    windowMs: opts.windowMs,
+    max: opts.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: opts.skip,
+    message: { error: opts.message ?? 'Too many requests. Please try again later.' },
+    handler: (req: any, res: any) =>
+      handleRateLimitExceeded(req, res, {
+        limiterType: opts.limiterType,
+        windowMs: opts.windowMs,
+      }),
+  })
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader('RateLimit-Policy', policy)
+    limiter(req, res, next)
+  }
 }
 
 // ── Rate limiters ──────────────────────────────────────────────────────────
@@ -89,78 +136,57 @@ function handleRateLimitExceeded(
  * Global rate limiter — applied to every route.
  * Defaults: 100 req / 15 min (env: RATE_LIMIT_MAX / RATE_LIMIT_WINDOW_MS).
  */
-export const rateLimiter = rateLimit({
+export const rateLimiter = buildRateLimiter({
   windowMs: config.security.rateLimit.windowMs,
   max: config.security.rateLimit.max,
-  standardHeaders: true,
-  legacyHeaders: false,
   skip: skipUnlessLimited,
-  message: {
-    error: 'Too many requests. Please try again later.',
-  },
-  handler: (req, res) => handleRateLimitExceeded(req, res, { limiterType: 'global' }),
+  limiterType: 'global',
 })
 
 /**
  * Auth rate limiter — stricter, to resist credential stuffing & brute force.
  * Defaults: 20 req / 15 min (env: AUTH_RATE_LIMIT_MAX / AUTH_RATE_LIMIT_WINDOW_MS).
  */
-export const authRateLimiter = rateLimit({
+export const authRateLimiter = buildRateLimiter({
   windowMs: config.security.authRateLimit.windowMs,
   max: config.security.authRateLimit.max,
-  standardHeaders: true,
-  legacyHeaders: false,
   skip: isTrusted,
-  message: {
-    error: 'Too many authentication attempts. Please try again in 15 minutes.',
-  },
-  handler: (req, res) => handleRateLimitExceeded(req, res, { limiterType: 'auth' }),
+  limiterType: 'auth',
+  message: 'Too many authentication attempts. Please try again in 15 minutes.',
 })
 
 /**
  * Admin rate limiter — tightest limits for management/sensitive operations.
  * Defaults: 10 req / 15 min (env: ADMIN_RATE_LIMIT_MAX / ADMIN_RATE_LIMIT_WINDOW_MS).
  */
-export const adminRateLimiter = rateLimit({
+export const adminRateLimiter = buildRateLimiter({
   windowMs: config.security.adminRateLimit.windowMs,
   max: config.security.adminRateLimit.max,
-  standardHeaders: true,
-  legacyHeaders: false,
   skip: isHealthProbe,
-  message: {
-    error: 'Too many requests to the admin API. Please try again later.',
-  },
-  handler: (req, res) => handleRateLimitExceeded(req, res, { limiterType: 'admin' }),
+  limiterType: 'admin',
+  message: 'Too many requests to the admin API. Please try again later.',
 })
 
 /**
  * Webhook rate limiter — applied to unauthenticated inbound webhooks.
  * Defaults: 30 req / 1 min (env: WEBHOOK_RATE_LIMIT_MAX / WEBHOOK_RATE_LIMIT_WINDOW_MS).
  */
-export const webhookRateLimiter = rateLimit({
+export const webhookRateLimiter = buildRateLimiter({
   windowMs: config.security.webhookRateLimit.windowMs,
   max: config.security.webhookRateLimit.max,
-  standardHeaders: true,
-  legacyHeaders: false,
   skip: isTrusted,
-  message: {
-    error: 'Too many webhook requests. Please try again later.',
-  },
-  handler: (req, res) => handleRateLimitExceeded(req, res, { limiterType: 'webhook' }),
+  limiterType: 'webhook',
+  message: 'Too many webhook requests. Please try again later.',
 })
 
 /**
  * Internal / agent rate limiter — higher throughput for service-to-service calls.
  * Defaults: 500 req / 1 min (env: INTERNAL_RATE_LIMIT_MAX / INTERNAL_RATE_LIMIT_WINDOW_MS).
  */
-export const internalRateLimiter = rateLimit({
+export const internalRateLimiter = buildRateLimiter({
   windowMs: config.security.internalRateLimit.windowMs,
   max: config.security.internalRateLimit.max,
-  standardHeaders: true,
-  legacyHeaders: false,
   skip: isTrusted,
-  message: {
-    error: 'Too many requests from this service. Please slow down.',
-  },
-  handler: (req, res) => handleRateLimitExceeded(req, res, { limiterType: 'internal' }),
+  limiterType: 'internal',
+  message: 'Too many requests from this service. Please slow down.',
 })

--- a/tests/integration/rateLimiter.integration.test.ts
+++ b/tests/integration/rateLimiter.integration.test.ts
@@ -1,0 +1,100 @@
+import express from 'express'
+import request from 'supertest'
+import { rateLimiter, buildRateLimiter } from '../../src/middleware/rateLimiter'
+
+jest.mock('../../src/utils/metrics', () => ({
+  recordRateLimitHit: jest.fn(),
+}))
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}))
+
+jest.mock('../../src/config/env', () => ({
+  config: {
+    security: {
+      rateLimit: { windowMs: 900000, max: 100 },
+      authRateLimit: { windowMs: 900000, max: 20 },
+      adminRateLimit: { windowMs: 900000, max: 10 },
+      webhookRateLimit: { windowMs: 60000, max: 30 },
+      internalRateLimit: { windowMs: 60000, max: 500 },
+      trustedIps: [],
+      internalServiceToken: '',
+    },
+  },
+}))
+
+function buildTestApp(middleware: ReturnType<typeof buildRateLimiter>) {
+  const app = express()
+  app.use(middleware)
+  app.get('/test', (_req, res) => res.status(200).json({ ok: true }))
+  return app
+}
+
+describe('rate limiter – IETF rate-limit headers', () => {
+  describe('normal (non-throttled) responses', () => {
+    it('sets RateLimit-Limit, RateLimit-Remaining, and RateLimit-Reset', async () => {
+      const app = buildTestApp(rateLimiter)
+      const res = await request(app).get('/test')
+
+      expect(res.status).toBe(200)
+      expect(res.headers).toHaveProperty('ratelimit-limit')
+      expect(res.headers).toHaveProperty('ratelimit-remaining')
+      expect(res.headers).toHaveProperty('ratelimit-reset')
+    })
+
+    it('sets RateLimit-Policy with correct limit and window', async () => {
+      const app = buildTestApp(rateLimiter)
+      const res = await request(app).get('/test')
+
+      // global limiter: 100 req / 900 s
+      expect(res.headers['ratelimit-policy']).toBe('100;w=900')
+    })
+
+    it('reflects the configured limit and window in RateLimit-Policy for custom limiters', async () => {
+      const limiter = buildRateLimiter({ windowMs: 60000, max: 30, limiterType: 'test' })
+      const app = buildTestApp(limiter)
+      const res = await request(app).get('/test')
+
+      expect(res.headers['ratelimit-policy']).toBe('30;w=60')
+    })
+  })
+
+  describe('throttled (429) responses', () => {
+    it('returns 429 after the request budget is exhausted', async () => {
+      const limiter = buildRateLimiter({ windowMs: 60000, max: 1, limiterType: 'test' })
+      const app = buildTestApp(limiter)
+
+      await request(app).get('/test') // uses up the single allowed request
+      const res = await request(app).get('/test')
+
+      expect(res.status).toBe(429)
+      expect(res.body.error).toContain('Too many requests')
+    })
+
+    it('sets Retry-After (positive integer, seconds) on 429 responses', async () => {
+      const limiter = buildRateLimiter({ windowMs: 60000, max: 1, limiterType: 'test' })
+      const app = buildTestApp(limiter)
+
+      await request(app).get('/test')
+      const res = await request(app).get('/test')
+
+      expect(res.status).toBe(429)
+      const retryAfter = Number(res.headers['retry-after'])
+      expect(Number.isInteger(retryAfter)).toBe(true)
+      expect(retryAfter).toBeGreaterThan(0)
+      expect(retryAfter).toBeLessThanOrEqual(60)
+    })
+
+    it('sets RateLimit-Policy on 429 responses', async () => {
+      const limiter = buildRateLimiter({ windowMs: 60000, max: 1, limiterType: 'test' })
+      const app = buildTestApp(limiter)
+
+      await request(app).get('/test')
+      const res = await request(app).get('/test')
+
+      expect(res.status).toBe(429)
+      expect(res.headers['ratelimit-policy']).toBe('1;w=60')
+    })
+  })
+})


### PR DESCRIPTION
Summary
Dead letter queue events can only be retried by the automated retry loop. Admins need a way to manually trigger a retry for specific events — useful during incident recovery without a redeployment.

Proposed Solution
Add POST /api/admin/dlq/:eventId/retry endpoint in src/routes/admin.ts
Add GET /api/admin/dlq with pagination to list DLQ events with their error reasons
Add DELETE /api/admin/dlq/:eventId to permanently discard an unrecoverable event
Require write admin scope (ties into issue #215)
Log each manual action in AdminAuditLog
Acceptance Criteria
 List endpoint returns paginated DLQ events with error metadata
 Retry endpoint re-queues event and resets retry count
 Discard endpoint marks event as discarded (soft delete, not hard delete)
 All actions appear in audit log
 Unit and integration tests for each endpoint
 
 implemented all these 
Closes #229 
Closes #228 
Closes #217 
Closes #216