### PR TITLE
Feat/wallet key rotation

### DIFF
--- a/prisma/migrations/20260626224106_add_key_version_to_wallet/migration.sql
+++ b/prisma/migrations/20260626224106_add_key_version_to_wallet/migration.sql
@@ -1,0 +1,76 @@
+-- DropIndex
+DROP INDEX "dead_letter_events_status_createdAt_idx";
+
+-- AlterTable
+ALTER TABLE "custodial_wallets" ADD COLUMN     "keyVersion" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateTable
+CREATE TABLE "admin_api_keys" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "hash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "admin_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "admin_audit_logs" (
+    "id" TEXT NOT NULL,
+    "adminKeyId" TEXT,
+    "adminName" TEXT,
+    "adminRole" TEXT,
+    "action" TEXT NOT NULL,
+    "target" TEXT,
+    "result" TEXT NOT NULL,
+    "details" JSONB,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "method" TEXT,
+    "path" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "admin_api_keys_name_key" ON "admin_api_keys"("name");
+
+-- CreateIndex
+CREATE INDEX "admin_api_keys_role_idx" ON "admin_api_keys"("role");
+
+-- CreateIndex
+CREATE INDEX "admin_api_keys_revokedAt_idx" ON "admin_api_keys"("revokedAt");
+
+-- CreateIndex
+CREATE INDEX "admin_api_keys_expiresAt_idx" ON "admin_api_keys"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_adminKeyId_idx" ON "admin_audit_logs"("adminKeyId");
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_action_idx" ON "admin_audit_logs"("action");
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_result_idx" ON "admin_audit_logs"("result");
+
+-- CreateIndex
+CREATE INDEX "admin_audit_logs_createdAt_idx" ON "admin_audit_logs"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "custodial_wallets_keyVersion_idx" ON "custodial_wallets"("keyVersion");
+
+-- CreateIndex
+CREATE INDEX "protocol_rates_protocolName_assetSymbol_fetchedAt_idx" ON "protocol_rates"("protocolName", "assetSymbol", "fetchedAt");
+
+-- CreateIndex
+CREATE INDEX "yield_snapshots_positionId_snapshotAt_idx" ON "yield_snapshots"("positionId", "snapshotAt");
+
+-- AddForeignKey
+ALTER TABLE "admin_audit_logs" ADD CONSTRAINT "admin_audit_logs_adminKeyId_fkey" FOREIGN KEY ("adminKeyId") REFERENCES "admin_api_keys"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -305,10 +305,12 @@ model CustodialWallet {
   encryptedSecret String
   iv              String
   authTag         String
+  keyVersion      Int      @default(1)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
   @@index([userId])
+  @@index([keyVersion])
   @@map("custodial_wallets")
 }
 

--- a/scripts/rotate-wallet-key.ts
+++ b/scripts/rotate-wallet-key.ts
@@ -246,15 +246,15 @@ async function rotateWalletKeys(
     console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     console.log('');
 
-    console.log('🔍 Counting custodial wallets...');
-    metrics.totalWallets = await prisma.custodialWallet.count();
+    console.log('🔍 Counting custodial wallets on v1...');
+    metrics.totalWallets = await prisma.custodialWallet.count({ where: { keyVersion: 1 } });
 
     if (metrics.totalWallets === 0) {
-      console.log('✅ No wallets to rotate.');
+      console.log('✅ No v1 wallets to rotate.');
       return finalizeMetrics(metrics);
     }
 
-    console.log(`📊 Found ${metrics.totalWallets} wallet(s) to rotate.`);
+    console.log(`📊 Found ${metrics.totalWallets} v1 wallet(s) to rotate.`);
     console.log(`🔐 Mode: ${dryRun ? 'DRY RUN (no changes)' : 'LIVE ROTATION'}`);
     console.log(`📋 Rotation ID: ${metrics.rotationId}`);
     console.log('');
@@ -267,21 +267,18 @@ async function rotateWalletKeys(
     }, 2000); // Log progress every 2 seconds
 
     try {
-      // Paginate with skip/take rather than loading the whole table at once.
-      // (Using skip/take instead of a cursor on `id` so this works regardless
-      // of whether your schema's id is a string (cuid/uuid) or a number —
-      // adjust to cursor-based pagination if this table grows very large,
-      // since skip-based pagination gets more expensive at high offsets.)
-      let skip = 0;
+      let cursor: string | undefined;
       // eslint-disable-next-line no-constant-condition
       while (true) {
         const batch = await prisma.custodialWallet.findMany({
+          where: { keyVersion: 1 },
           take: BATCH_SIZE,
-          skip,
+          ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
           orderBy: { id: 'asc' },
         });
 
         if (batch.length === 0) break;
+        cursor = batch[batch.length - 1].id;
 
         for (const wallet of batch) {
           const startedAt = Date.now();
@@ -303,6 +300,7 @@ async function rotateWalletKeys(
                   encryptedSecret: encrypted,
                   iv,
                   authTag,
+                  keyVersion: 2,
                   updatedAt: new Date(),
                 },
               });
@@ -314,8 +312,7 @@ async function rotateWalletKeys(
             recordError(metrics, wallet.id, wallet.userId, errorMsg);
           }
         }
-
-        skip += batch.length;
+        // Cursor already updated at the start of the loop
       }
     } finally {
       clearInterval(logInterval);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -711,4 +711,45 @@ router.get(
   },
 )
 
+/**
+ * GET /api/admin/wallets/rotation-status
+ * Reports the progress of wallet key rotation.
+ * Required scope: keys:read
+ */
+router.get(
+  '/wallets/rotation-status',
+  requireAdminScope('keys:read'),
+  async (req: Request, res: Response) => {
+    try {
+      const totalWallets = await prisma.custodialWallet.count()
+      const v1Wallets = await prisma.custodialWallet.count({ where: { keyVersion: 1 } })
+      const v2Wallets = await prisma.custodialWallet.count({ where: { keyVersion: 2 } })
+
+      const percentV1 = totalWallets === 0 ? 0 : (v1Wallets / totalWallets) * 100
+
+      auditLog(req, res, 'GET_ROTATION_STATUS', 'success', { totalWallets, v1Wallets, percentV1 })
+
+      res.status(200).json({
+        success: true,
+        data: {
+          totalWallets,
+          v1Wallets,
+          v2Wallets,
+          percentV1,
+          isRotationComplete: v1Wallets === 0,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    } catch (error) {
+      logger.error('[Admin] Failed to get rotation status', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+      auditLog(req, res, 'GET_ROTATION_STATUS', 'failure', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+      res.status(500).json({ success: false, error: 'Failed to get rotation status' })
+    }
+  },
+)
+
 export default router

--- a/src/stellar/wallet.ts
+++ b/src/stellar/wallet.ts
@@ -165,6 +165,7 @@ export async function createCustodialWallet(userId: string) {
       encryptedSecret: encrypted,
       iv,
       authTag,
+      keyVersion: 2,
     },
   });
 
@@ -199,6 +200,26 @@ export async function getKeypairForUser(userId: string): Promise<Keypair> {
 
   if (keyUsed === 'fallback') {
     logger.debug(`[Wallet] User ${userId} decrypted with fallback key; schedule re-encryption`);
+  }
+
+  // Lazy re-encryption for wallets on v1
+  if (wallet.keyVersion === 1) {
+    try {
+      const { encrypted, iv, authTag } = encryptSecret(secret);
+      await db.custodialWallet.update({
+        where: { id: wallet.id },
+        data: {
+          encryptedSecret: encrypted,
+          iv,
+          authTag,
+          keyVersion: 2,
+        },
+      });
+      logger.info(`[Wallet] Upgraded user ${userId} to keyVersion 2 via lazy re-encryption`);
+    } catch (err) {
+      logger.error(`[Wallet] Failed to lazy re-encrypt user ${userId}: ${err instanceof Error ? err.message : 'unknown error'}`);
+      // Non-fatal, we still return the keypair
+    }
   }
 
   return Keypair.fromSecret(secret);


### PR DESCRIPTION
## Description

This PR implements a zero-downtime dual-key rotation strategy for Custodial Wallets, allowing us to seamlessly rotate encryption keys without locking users out of the platform or taking the system down.

Closes #232

## Changes Implemented

- **Phase 1 (Mark):** Added a `keyVersion` column to the `CustodialWallet` schema (defaulting to `1`) and created the Prisma migration.
- **Phase 2 (Write New Key):** `createCustodialWallet` now explicitly marks newly provisioned wallets with `keyVersion: 2` (indicating they are encrypted with the active `v2` key).
- **Phase 3 (Lazy Re-encrypt):** Updated the read path in `getKeypairForUser`. On every wallet read, if a wallet is on `v1`, it transparently decrypts the secret (falling back to the old key), re-encrypts it with the new active key, and updates the database row to `keyVersion: 2`.
- **Phase 4 (Reporting/Verify):** Added a new admin endpoint (`GET /api/admin/wallets/rotation-status`) that reports the percentage of wallets still on the old key version, and updated `scripts/rotate-wallet-key.ts` to only query `v1` wallets via cursor-based pagination. Dry-run mode correctly logs the remaining `v1` wallets without touching the database.

## Architecture & Atomic Commits

The PR adheres strictly to atomic commit principles:
1. `feat(wallet): Add keyVersion column to CustodialWallet`
2. `feat(wallet): Implement transparent re-encryption in wallet read path`
3. `feat(admin): Add admin endpoint for wallet rotation status`
4. `chore(scripts): Update rotation script to process only v1 wallets`

## Testing Instructions

1. Spin up the backend with an old key configured for dual reads (`WALLET_ENCRYPTION_KEY_OLD` representing `v1` and `WALLET_ENCRYPTION_KEY` representing `v2`).
2. Run `npm run db:setup` or `npx prisma migrate dev` to migrate the database and insert seeded data.
3. Call the `GET /api/admin/wallets/rotation-status` endpoint to see all wallets currently on `v1` (100%).
4. Authenticate as a seeded user and trigger a wallet read operation.
5. Re-check the admin endpoint and confirm the read wallet was transparently migrated to `v2`.
6. Run `npx ts-node scripts/rotate-wallet-key.ts --dry-run` to see the exact count of remaining `v1` wallets.
