### PR TITLE
Add global request timeout middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,9 @@ HTTP_CLIENT_MAX_DELAY_MS=10000
 HTTP_CLIENT_CIRCUIT_BREAKER_THRESHOLD=5
 HTTP_CLIENT_CIRCUIT_BREAKER_RESET_MS=30000
 
+# Global request timeout for general API routes (health/metrics and agent routes use tighter overrides)
+REQUEST_TIMEOUT_MS=30000
+
 # Dead Letter Queue
 DLQ_ALERT_THRESHOLD=50
 DLQ_ALERT_COOLDOWN_MS=900000

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -258,6 +258,7 @@ export const config = {
     /** How often (ms) to poll prisma.$metrics.json() for pool gauges. */
     poolMetricsIntervalMs: parseInt(process.env.DB_POOL_METRICS_INTERVAL_MS || '15000'),
   },
+  requestTimeoutMs: parseInt(process.env.REQUEST_TIMEOUT_MS || '30000'),
   jwt: {
     /**
      * JWT_SEED: 64-hex secret used to sign/verify JWTs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { config } from './config/env'
 import { errorHandler } from './middleware/errorHandler'
 import { correlationIdMiddleware } from './middleware/correlationId'
 import { requestLogger } from './middleware/logger'
+import { requestTimeoutMiddleware } from './middleware/requestTimeout'
 import { rateLimiter, authRateLimiter, adminRateLimiter, internalRateLimiter, webhookRateLimiter, trustedIpBypass } from './middleware/rateLimiter'
 import { configureTrustProxy, securityHeaders, permissionsPolicy } from './middleware/security'
 import { logger } from './utils/logger'
@@ -112,6 +113,7 @@ app.use((req: Request & { user?: { id: string } }, _res: Response, next) => {
 app.use(requestLogger)
 app.use(trustedIpBypass)
 app.use(rateLimiter)
+app.use(requestTimeoutMiddleware)
 
 // ── Readiness / liveness probes ───────────────────────────────────────────────
 

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,6 +1,7 @@
 export { logger } from '../utils/logger';
 export { errorHandler } from './errorHandler';
 export { rateLimiter } from './rateLimiter';
+export { requestTimeoutMiddleware, resolveRequestTimeout } from './requestTimeout';
 export { configureTrustProxy, securityHeaders, permissionsPolicy } from './security';
 export { requireAuth, enforceUserAccess, AuthMiddleware } from './authenticate';
 export type { } from './authenticate'; // re-export augmented Request types

--- a/src/middleware/requestTimeout.ts
+++ b/src/middleware/requestTimeout.ts
@@ -1,0 +1,53 @@
+import type { NextFunction, Request, Response } from 'express'
+import { config } from '../config/env'
+import { logger } from '../utils/logger'
+import { recordRequestTimeout } from '../utils/metrics'
+
+const HEALTH_TIMEOUT_MS = 5_000
+const AGENT_TIMEOUT_MS = 60_000
+
+export interface RequestTimeoutConfig {
+  timeoutMs: number
+  routeGroup: 'health' | 'agent' | 'general'
+}
+
+export function resolveRequestTimeout(path: string): RequestTimeoutConfig {
+  if (path === '/metrics' || path.startsWith('/health')) {
+    return { timeoutMs: HEALTH_TIMEOUT_MS, routeGroup: 'health' }
+  }
+
+  if (path.startsWith('/api/v1/agent') || path.startsWith('/api/agent')) {
+    return { timeoutMs: AGENT_TIMEOUT_MS, routeGroup: 'agent' }
+  }
+
+  return { timeoutMs: config.requestTimeoutMs, routeGroup: 'general' }
+}
+
+export function requestTimeoutMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const timeout = resolveRequestTimeout(req.path)
+
+  const timer = setTimeout(() => {
+    if (res.headersSent || res.writableEnded) {
+      return
+    }
+
+    recordRequestTimeout(timeout.routeGroup)
+    logger.warn('[RequestTimeout] Request timed out', {
+      path: req.path,
+      method: req.method,
+      timeoutMs: timeout.timeoutMs,
+      correlationId: req.correlationId,
+      routeGroup: timeout.routeGroup,
+    })
+
+    res.status(504).json({ error: 'Request timed out' })
+  }, timeout.timeoutMs)
+
+  res.on('finish', () => clearTimeout(timer))
+  res.on('close', () => clearTimeout(timer))
+  next()
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -198,6 +198,15 @@ export const httpRequestDuration = new client.Histogram({
   registers: [register],
 })
 
+// ── Request Timeout Metrics ───────────────────────────────────────────────────
+
+export const requestTimeoutsTotal = new client.Counter({
+  name: 'request_timeouts_total',
+  help: 'Total number of HTTP requests that timed out before completing',
+  labelNames: ['route_group'] as const,
+  registers: [register],
+})
+
 // ── Analytics API Metrics ────────────────────────────────────────────────────────
 
 export const analyticsRequestsTotal = new client.Counter({
@@ -384,6 +393,13 @@ export function recordHttpRequest(
     { method, route, status_code: statusCode.toString() },
     durationSeconds
   )
+}
+
+/**
+ * Record a timed-out HTTP request
+ */
+export function recordRequestTimeout(routeGroup: string): void {
+  requestTimeoutsTotal.inc({ route_group: routeGroup })
 }
 
 /**

--- a/tests/unit/middleware/requestTimeout.test.ts
+++ b/tests/unit/middleware/requestTimeout.test.ts
@@ -1,0 +1,58 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { requestTimeoutMiddleware, resolveRequestTimeout } from '../../../src/middleware/requestTimeout'
+import { register } from '../../../src/utils/metrics'
+
+describe('requestTimeout middleware', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    register.resetMetrics()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    register.resetMetrics()
+    jest.restoreAllMocks()
+  })
+
+  it('applies route-specific timeout windows', () => {
+    expect(resolveRequestTimeout('/health/live')).toEqual({
+      timeoutMs: 5_000,
+      routeGroup: 'health',
+    })
+    expect(resolveRequestTimeout('/metrics')).toEqual({
+      timeoutMs: 5_000,
+      routeGroup: 'health',
+    })
+    expect(resolveRequestTimeout('/api/v1/agent/status')).toEqual({
+      timeoutMs: 60_000,
+      routeGroup: 'agent',
+    })
+    expect(resolveRequestTimeout('/api/withdraw')).toEqual({
+      timeoutMs: 30_000,
+      routeGroup: 'general',
+    })
+  })
+
+  it('returns 504 when a route exceeds the configured timeout', async () => {
+    const app = express()
+    app.use(requestTimeoutMiddleware)
+    app.get('/slow', async () => {
+      await new Promise(() => {
+        // Intentionally never resolves so the timeout middleware fires.
+      })
+    })
+
+    const pending = request(app).get('/slow')
+    jest.advanceTimersByTime(30_000)
+    await Promise.resolve()
+    const res = await pending
+
+    expect(res.status).toBe(504)
+    expect(res.body).toEqual({ error: 'Request timed out' })
+
+    const metrics = await register.metrics()
+    expect(metrics).toContain('request_timeouts_total{route_group="general"} 1')
+  })
+})


### PR DESCRIPTION
Closes #269
Closes #268
Closes #267 
Closes #252

Summary
This change adds a global request-timeout middleware to the backend so hung requests do not stay open indefinitely and tie up server resources. The timeout is configurable through `REQUEST_TIMEOUT_MS` for normal API traffic, while the health and metrics paths use a tighter timeout and agent routes get a longer window for their slower upstream calls.

What changed
- Added `src/middleware/requestTimeout.ts` with route-aware timeout resolution and a 504 JSON response when a request exceeds its deadline.
- Wired the middleware into the Express bootstrap in `src/index.ts` before the application routes are mounted.
- Added `REQUEST_TIMEOUT_MS` to `src/config/env.ts` and documented it in `.env.example`.
- Added a Prometheus counter, `request_timeouts_total`, so timed-out requests are visible in `/metrics`.
- Added a focused unit test that verifies the route-specific timeout windows and a simulated slow request that returns 504.

Behavior details
- General API traffic defaults to `30000` ms unless overridden with `REQUEST_TIMEOUT_MS`.
- Health and metrics endpoints use `5000` ms so probe traffic fails fast when the service is unhealthy.
- Agent endpoints use `60000` ms to allow slower Stellar/RPC-style work without tripping the global default too aggressively.
- Timeouts are logged with the request path, method, route group, and correlation ID for debugging.

Testing
- `git diff --check`