### PR TITLE
feat: protocol risk scoring & transparency dashboard (#291)

### DIFF
--- a/docs/PROTOCOL_RISK_SCORING.md
+++ b/docs/PROTOCOL_RISK_SCORING.md
@@ -1,0 +1,172 @@
+# Protocol Risk Scoring & Transparency
+
+This document is the human-readable companion to the `GET /api/protocols/risk`
+endpoint. It defines exactly how each protocol's risk score is computed so that a
+user reading the endpoint's factor breakdown can understand *why* a protocol
+scored the way it did. An opaque single number would defeat the purpose of a
+transparency dashboard, so every input below is surfaced in the API response.
+
+- Scoring math: [`src/agent/riskScoring.ts`](../src/agent/riskScoring.ts) (pure, unit-tested)
+- Scheduled job: [`src/jobs/protocolRiskScoring.ts`](../src/jobs/protocolRiskScoring.ts)
+- Curated metadata: [`src/config/protocolRiskMetadata.ts`](../src/config/protocolRiskMetadata.ts)
+- Data model: `ProtocolRiskScore` in [`prisma/schema.prisma`](../prisma/schema.prisma)
+
+## What the score means
+
+`score` is a normalized integer in **0–100 where higher = lower risk**. It is a
+platform-wide methodology: every user is scored against the same formula. A user
+cannot redefine the weights (out of scope for v1); they can only set a *risk
+ceiling* — a minimum acceptable score — against this shared scale.
+
+The score is recomputed on a schedule (default every 6 hours,
+`PROTOCOL_RISK_INTERVAL_MS`) from two sources:
+
+1. **On-chain rate history** already accumulated in `ProtocolRate` — used to
+   derive the APY-volatility and TVL-trend factors.
+2. **Curated audit/age metadata** — audit status and launch date, which cannot
+   be derived from rate history alone. This lives in a single reviewable file
+   (see [Curated metadata & review process](#curated-metadata--review-process)).
+
+## The four factors and their weights
+
+The score is a weighted sum of four normalized sub-factors, each in `[0,1]`,
+then scaled to 0–100:
+
+| Factor | Weight | Source | Higher value means |
+|---|---|---|---|
+| Audit status | **0.35** | Curated metadata | Stronger external verification |
+| APY volatility | **0.25** | `ProtocolRate` history | More stable yields |
+| TVL trend | **0.20** | `ProtocolRate` history | Growing / stable liquidity |
+| Protocol age | **0.20** | Curated inception date | Longer track record |
+
+Weights are defined in `WEIGHTS` in `src/agent/riskScoring.ts` and sum to 1.0.
+`score = round( clamp01( 0.35·audit + 0.25·volatility + 0.20·tvlTrend + 0.20·age ) · 100 )`.
+
+### Audit status factor
+
+Maps the curated `auditStatus` enum to a factor:
+
+| `auditStatus` | Factor | Operational meaning |
+|---|---|---|
+| `THIRD_PARTY_AUDITED` | 1.0 | A completed audit by a reputable **external** firm, with a publicly linkable report recorded in the metadata's `auditReference`. |
+| `SELF_REPORTED` | 0.5 | The team claims security review/audit but no third-party report is confirmed. |
+| `UNAUDITED` | 0.0 | No audit, or status unknown. This is the default for any protocol not present in the curated table. |
+
+### APY volatility factor
+
+Computed from the **standard deviation of `supplyApy`** across the trailing
+window (`TRAILING_WINDOW_DAYS`, default 30 days). The factor falls off linearly
+from 1.0 at zero stdev to 0.0 at `APY_STDEV_FLOOR` (default 5 percentage points)
+and above:
+
+`apyVolatilityFactor = clamp01( 1 − stdev(apy) / APY_STDEV_FLOOR )`
+
+Requires at least 2 usable samples; otherwise it contributes 0 (and the
+insufficient-history rule below almost certainly applies anyway).
+
+### TVL trend factor
+
+Computed from the **relative change in TVL** between the first and last
+observation in the trailing window. Growth pushes the factor toward 1, decline
+toward 0, and flat toward the neutral midpoint 0.5:
+
+`tvlTrendFactor = clamp01( 0.5 + (lastTvl − firstTvl) / firstTvl )`
+
+so a +50% TVL change or more saturates to 1.0 and a −50% change or worse to 0.0.
+Samples with null TVL are ignored. If there is no usable TVL data at all, the
+factor is the neutral **0.5** — absence of TVL data is not itself a directional
+risk signal, and we do not let it masquerade as growth or decline.
+
+### Protocol age factor
+
+Linear credit for track record, from 0 at launch to full credit at
+`AGE_SATURATION_DAYS` (default 730 days ≈ 2 years):
+
+`ageFactor = clamp01( protocolAgeDays / AGE_SATURATION_DAYS )`
+
+`protocolAgeDays` is derived at compute time from the curated `inceptionDate`, so
+it stays current automatically without manual edits.
+
+## Policy: new protocols (insufficient history)
+
+A protocol needs at least `MIN_SAMPLES_FOR_HISTORY` (default **3**) samples in
+the trailing window to have its volatility/trend characterized. Below that
+threshold the protocol is **flagged `insufficientHistory: true` and assigned a
+conservative fixed score of `INSUFFICIENT_HISTORY_SCORE` (default 20)** rather
+than being scored on audit + age alone.
+
+This is deliberate: a brand-new but audited protocol could otherwise post a
+misleadingly high score purely from its audit/age credit despite having no
+observed track record of stable yields. Scoring it low-and-flagged, instead of
+neutral, keeps the number honest. The `insufficientHistory` flag and
+`sampleCount` are both exposed in the API so the state is visible, not hidden.
+
+## Policy: data gaps
+
+The rate collector can have downtime, leaving gaps in a protocol's history. Our
+policy — matching the concern raised for the backtesting engine in issue #283 —
+is:
+
+- **Missing data is treated as absence, never as zero and never as a favorable
+  (stable/growing) signal.** We do not fabricate, interpolate, or forward-fill
+  values for missing intervals.
+- Volatility and trend are computed **only from samples that actually exist** in
+  the trailing window.
+- The practical consequence: a gap reduces the effective `sampleCount`. If that
+  drops the count below `MIN_SAMPLES_FOR_HISTORY`, the protocol falls back to the
+  insufficient-history policy above rather than being scored on thin data.
+
+This guarantees a gap can never *inflate* a score (e.g. by making a volatile
+protocol look artificially stable) — at worst it makes the score conservative.
+
+## Policy: risk ceiling enforcement (a real safety control)
+
+A user may set an opt-in `riskCeiling` (stored in `User.strategyConfig.riskCeiling`)
+— the minimum score a protocol must have to be eligible. This is enforced in
+`MaxYieldStrategy` and `TargetAllocationStrategy` **before** any yield/allocation
+optimization.
+
+Two guarantees hold, and both are covered by tests:
+
+1. **Backward compatible / opt-in.** When `riskCeiling` is `undefined`, the
+   candidate set and every downstream decision are byte-for-byte identical to
+   the pre-existing behavior. No score lookup even runs.
+2. **Never silently bypassed.** If the ceiling excludes *every* candidate
+   protocol, the strategy returns an explicit "no protocols currently meet your
+   risk tolerance" decision (`NO_ELIGIBLE_PROTOCOLS_REASON`) and does **not**
+   rebalance. The agent never falls back to ignoring the ceiling to have
+   somewhere to allocate. Enforcement is also **fail-closed**: a protocol with no
+   known score is treated as ineligible under a ceiling, not given the benefit of
+   the doubt.
+
+## Curated metadata & review process
+
+`auditStatus` and `inceptionDate` are curated by hand in
+[`src/config/protocolRiskMetadata.ts`](../src/config/protocolRiskMetadata.ts)
+because on-chain data cannot tell you whether a protocol was third-party audited
+or when it launched. Keeping this explicit and diffable — rather than buried in
+code or a database — is intentional: **the code review of a change to that file
+IS the update process.**
+
+Because this metadata goes stale (a protocol gets audited after being marked
+`UNAUDITED`, for example), it must be reviewed:
+
+1. **On protocol onboarding** — add an entry when a protocol is added to the
+   scanner (`src/agent/scanner.ts`). A protocol absent from the table is scored
+   with the most conservative assumption (`UNAUDITED`, unknown/0-day age).
+2. **At least quarterly** — confirm each `auditStatus` against the protocol's
+   latest published audits. `THIRD_PARTY_AUDITED` requires a completed external
+   audit whose report is publicly linkable; record the link in `auditReference`.
+
+`inceptionDate` is fixed at launch and should not change once set; age is derived
+from it automatically.
+
+> The audit statuses currently committed are conservative placeholders pending
+> verification against each protocol's published audits. Confirm them on the
+> first review pass before treating the scores as authoritative.
+
+## Out of scope (v1)
+
+- Automated on-chain audit-status verification — `auditStatus` is curated.
+- Per-user custom scoring weights — the formula is platform-wide; users set only
+  a threshold against it.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -645,6 +645,57 @@ paths:
                     network: stellar
                     fetchedAt: '2026-06-29T12:00:00.000Z'
 
+  /api/v1/protocols/risk:
+    get:
+      tags: [protocols]
+      operationId: getProtocolRiskScores
+      summary: Get protocol risk scores and contributing factors
+      description: >
+        Returns the current risk score (0-100, higher = lower risk) for each
+        protocol together with the contributing factors behind it — audit status,
+        protocol age, APY volatility, TVL trend, sample count and an
+        insufficient-history flag — so the score is transparent rather than
+        opaque. Public: aggregate, non-user-specific data. See the scoring
+        methodology in docs/PROTOCOL_RISK_SCORING.md.
+      responses:
+        '200':
+          description: Protocol risk scores
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  protocols:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProtocolRiskScore'
+                  methodology:
+                    type: string
+                    description: Path to the methodology document backing the factors.
+              example:
+                protocols:
+                  - protocolName: Blend
+                    score: 82
+                    factors:
+                      auditStatus: THIRD_PARTY_AUDITED
+                      protocolAgeDays: 896
+                      apyVolatilityFactor: 0.91
+                      tvlTrendFactor: 0.63
+                      sampleCount: 42
+                      insufficientHistory: false
+                    computedAt: '2026-07-16T00:00:00.000Z'
+                  - protocolName: Luma
+                    score: 20
+                    factors:
+                      auditStatus: SELF_REPORTED
+                      protocolAgeDays: 411
+                      apyVolatilityFactor: 0
+                      tvlTrendFactor: 0.5
+                      sampleCount: 1
+                      insufficientHistory: true
+                    computedAt: '2026-07-16T00:00:00.000Z'
+                methodology: docs/PROTOCOL_RISK_SCORING.md
+
   /api/v1/protocols/agent/status:
     get:
       tags: [protocols]
@@ -2232,6 +2283,45 @@ components:
         network:
           type: string
         fetchedAt:
+          type: string
+          format: date-time
+
+    ProtocolRiskScore:
+      type: object
+      description: >-
+        A protocol's transparent risk score plus the contributing factors
+        behind it. See docs/PROTOCOL_RISK_SCORING.md for the methodology.
+      properties:
+        protocolName:
+          type: string
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Normalized 0-100, higher = lower risk.
+        factors:
+          type: object
+          properties:
+            auditStatus:
+              type: string
+              enum: [UNAUDITED, SELF_REPORTED, THIRD_PARTY_AUDITED]
+            protocolAgeDays:
+              type: integer
+            apyVolatilityFactor:
+              type: number
+              description: APY stability in [0,1]; 1 = very stable.
+            tvlTrendFactor:
+              type: number
+              description: TVL trend in [0,1]; >0.5 = growing, <0.5 = declining.
+            sampleCount:
+              type: integer
+              description: Number of rate samples the factors were computed from.
+            insufficientHistory:
+              type: boolean
+              description: >-
+                True when history is too sparse to characterize the protocol;
+                such protocols are scored conservatively low and flagged.
+        computedAt:
           type: string
           format: date-time
 

--- a/prisma/migrations/20260716000000_add_protocol_risk_scores/migration.sql
+++ b/prisma/migrations/20260716000000_add_protocol_risk_scores/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "AuditStatus" AS ENUM ('UNAUDITED', 'SELF_REPORTED', 'THIRD_PARTY_AUDITED');
+
+-- CreateTable
+CREATE TABLE "protocol_risk_scores" (
+    "id" TEXT NOT NULL,
+    "protocolName" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "tvlTrendFactor" DOUBLE PRECISION NOT NULL,
+    "apyVolatilityFactor" DOUBLE PRECISION NOT NULL,
+    "auditStatus" "AuditStatus" NOT NULL,
+    "protocolAgeDays" INTEGER NOT NULL,
+    "insufficientHistory" BOOLEAN NOT NULL DEFAULT false,
+    "sampleCount" INTEGER NOT NULL DEFAULT 0,
+    "computedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "protocol_risk_scores_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "protocol_risk_scores_protocolName_key" ON "protocol_risk_scores"("protocolName");
+
+-- CreateIndex
+CREATE INDEX "protocol_risk_scores_score_idx" ON "protocol_risk_scores"("score");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,12 @@ enum DeadLetterEventStatus {
   RESOLVED
 }
 
+enum AuditStatus {
+  UNAUDITED
+  SELF_REPORTED
+  THIRD_PARTY_AUDITED
+}
+
 model User {
   id            String   @id @default(uuid())
   walletAddress String   @unique
@@ -231,6 +237,31 @@ model ProtocolRate {
   @@index([fetchedAt])
   @@index([protocolName, assetSymbol, fetchedAt])
   @@map("protocol_rates")
+}
+
+// ProtocolRiskScore — quantitative, transparent risk score per protocol.
+// Recomputed on a schedule from ProtocolRate history plus curated audit/age
+// metadata (see src/config/protocolRiskMetadata.ts). See
+// docs/PROTOCOL_RISK_SCORING.md for the scoring methodology.
+model ProtocolRiskScore {
+  id                  String      @id @default(uuid())
+  protocolName        String      @unique
+  score               Int // normalized 0-100, higher = lower risk
+  tvlTrendFactor      Float
+  apyVolatilityFactor Float
+  auditStatus         AuditStatus
+  protocolAgeDays     Int
+  // True when there is not enough rate history to compute volatility/trend
+  // meaningfully. Such protocols score conservatively low and are flagged
+  // rather than presented with a misleadingly neutral score.
+  insufficientHistory Boolean     @default(false)
+  // Number of ProtocolRate samples the factors were computed from — surfaced
+  // in the transparency endpoint so users can judge confidence in the score.
+  sampleCount         Int         @default(0)
+  computedAt          DateTime    @default(now())
+
+  @@index([score])
+  @@map("protocol_risk_scores")
 }
 
 model AgentLog {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -130,6 +130,9 @@ async function rebalanceCheckJob(): Promise<void> {
               strategyName: p.user.rebalanceStrategy || null,
               targetAllocations: p.user.strategyConfig?.targetAllocations || undefined,
               riskTolerance: p.user.riskTolerance,
+              // Opt-in risk ceiling (0-100 min protocol risk score). Absent for
+              // users who never configured one, keeping agent behavior unchanged.
+              riskCeiling: p.user.strategyConfig?.riskCeiling,
             }))
           : undefined;
 

--- a/src/agent/riskScoring.ts
+++ b/src/agent/riskScoring.ts
@@ -1,0 +1,206 @@
+/**
+ * Protocol risk scoring — pure computation.
+ *
+ * Turns a protocol's ProtocolRate history plus curated audit/age metadata into a
+ * normalized 0-100 risk score (higher = lower risk) and the contributing
+ * factors behind it. This module is deliberately free of I/O so it can be unit
+ * tested against fixture rate histories; the scheduled job in
+ * src/jobs/protocolRiskScoring.ts is the only thing that reads the DB and calls
+ * into here.
+ *
+ * The full methodology (weights, thresholds, gap/new-protocol policy, what
+ * "third-party audited" means) is documented in docs/PROTOCOL_RISK_SCORING.md.
+ * Keep that doc and this file in sync — the transparency endpoint exposes these
+ * factors precisely so a user can reconcile them against the docs.
+ */
+
+import { AuditStatusValue, computeProtocolAgeDays, getProtocolMetadata } from '../config/protocolRiskMetadata';
+
+/** A single historical rate sample for one protocol (asset-agnostic here). */
+export interface RateSample {
+  supplyApy: number;
+  tvl: number | null;
+  fetchedAt: Date;
+}
+
+export interface RiskScoreFactors {
+  /**
+   * Rolling TVL growth/decline signal in [0,1]. 1 = strongly growing (lower
+   * risk), 0.5 = flat/unknown, 0 = strongly declining (higher risk).
+   */
+  tvlTrendFactor: number;
+  /**
+   * APY stability signal in [0,1]. 1 = very stable APY (lower risk), 0 = highly
+   * volatile APY (higher risk). Derived from the standard deviation of APY over
+   * the trailing window.
+   */
+  apyVolatilityFactor: number;
+  auditStatus: AuditStatusValue;
+  protocolAgeDays: number;
+  /** Number of samples the factors were computed from. */
+  sampleCount: number;
+  /** True when history is too sparse to compute volatility/trend meaningfully. */
+  insufficientHistory: boolean;
+}
+
+export interface RiskScoreResult extends RiskScoreFactors {
+  protocolName: string;
+  /** Normalized 0-100, higher = lower risk. */
+  score: number;
+}
+
+// ── Tunables (mirror docs/PROTOCOL_RISK_SCORING.md) ──────────────────────────
+
+/**
+ * Minimum number of samples required to compute volatility/trend. Below this we
+ * cannot meaningfully characterize the distribution, so the protocol is flagged
+ * `insufficientHistory` and scored conservatively low rather than neutral.
+ */
+export const MIN_SAMPLES_FOR_HISTORY = 3;
+
+/** Trailing window over which volatility/trend are measured. */
+export const TRAILING_WINDOW_DAYS = 30;
+
+/**
+ * APY standard deviation (in percentage points) mapped to the volatility floor.
+ * At/above this stdev the apyVolatilityFactor is 0; at 0 stdev it is 1.
+ */
+export const APY_STDEV_FLOOR = 5;
+
+/** Protocol age (days) at which the age contribution saturates to full credit. */
+export const AGE_SATURATION_DAYS = 730; // ~2 years
+
+/** Score (0-100) assigned to protocols flagged insufficientHistory. */
+export const INSUFFICIENT_HISTORY_SCORE = 20;
+
+/** Component weights. Must sum to 1. */
+export const WEIGHTS = {
+  audit: 0.35,
+  volatility: 0.25,
+  tvlTrend: 0.2,
+  age: 0.2,
+} as const;
+
+const AUDIT_FACTOR: Record<AuditStatusValue, number> = {
+  THIRD_PARTY_AUDITED: 1,
+  SELF_REPORTED: 0.5,
+  UNAUDITED: 0,
+};
+
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+function stdev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const m = mean(values);
+  const variance = mean(values.map((v) => (v - m) ** 2));
+  return Math.sqrt(variance);
+}
+
+/**
+ * Gap-handling policy (documented in docs/PROTOCOL_RISK_SCORING.md):
+ *
+ * We do NOT fabricate values for missing sample intervals. Volatility and trend
+ * are computed only from samples that actually exist in the trailing window —
+ * missing data is treated as absence, never as zero and never as a favorable
+ * (stable/growing) signal. The practical effect is that a data gap reduces the
+ * effective sampleCount; if that drops the count below MIN_SAMPLES_FOR_HISTORY
+ * the protocol is flagged `insufficientHistory` rather than scored on thin data.
+ */
+export function filterToWindow(samples: RateSample[], now: Date, windowDays = TRAILING_WINDOW_DAYS): RateSample[] {
+  const cutoff = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  return samples
+    .filter((s) => s.fetchedAt.getTime() >= cutoff)
+    .sort((a, b) => a.fetchedAt.getTime() - b.fetchedAt.getTime());
+}
+
+/**
+ * APY stability in [0,1] from the standard deviation of APY across the window.
+ * Higher stdev → lower factor. Linear falloff to 0 at APY_STDEV_FLOOR.
+ */
+export function computeApyVolatilityFactor(samples: RateSample[]): number {
+  const apys = samples.map((s) => s.supplyApy).filter((v) => Number.isFinite(v));
+  if (apys.length < 2) return 0;
+  const sd = stdev(apys);
+  return clamp01(1 - sd / APY_STDEV_FLOOR);
+}
+
+/**
+ * TVL trend in [0,1] from the relative change between the first and last TVL
+ * observation in the window. Growth → toward 1, decline → toward 0, flat → 0.5.
+ * Samples with null TVL are ignored. Unknown (no usable TVL data) → 0.5 neutral,
+ * since absence of TVL data is not itself a risk signal about direction.
+ */
+export function computeTvlTrendFactor(samples: RateSample[]): number {
+  const tvls = samples
+    .map((s) => s.tvl)
+    .filter((v): v is number => v !== null && Number.isFinite(v) && v > 0);
+  if (tvls.length < 2) return 0.5;
+  const first = tvls[0];
+  const last = tvls[tvls.length - 1];
+  const relChange = (last - first) / first; // e.g. +0.2 = +20% growth
+  // Map [-0.5, +0.5] relative change onto [0,1], centered at 0.5 (flat).
+  return clamp01(0.5 + relChange);
+}
+
+/** Age credit in [0,1], linear from 0 days to AGE_SATURATION_DAYS. */
+export function computeAgeFactor(protocolAgeDays: number): number {
+  return clamp01(protocolAgeDays / AGE_SATURATION_DAYS);
+}
+
+/**
+ * Compute a full risk score + factor breakdown for one protocol.
+ *
+ * @param protocolName  Must match the curated metadata / scanner protocol name.
+ * @param samples       All available rate history for the protocol (any age).
+ * @param now           The reference "now" (injected for deterministic tests).
+ */
+export function computeRiskScore(protocolName: string, samples: RateSample[], now: Date): RiskScoreResult {
+  const meta = getProtocolMetadata(protocolName);
+  const protocolAgeDays = computeProtocolAgeDays(meta.inceptionDate, now);
+
+  const windowed = filterToWindow(samples, now);
+  const sampleCount = windowed.length;
+  const insufficientHistory = sampleCount < MIN_SAMPLES_FOR_HISTORY;
+
+  const apyVolatilityFactor = computeApyVolatilityFactor(windowed);
+  const tvlTrendFactor = computeTvlTrendFactor(windowed);
+
+  const factors: RiskScoreFactors = {
+    tvlTrendFactor,
+    apyVolatilityFactor,
+    auditStatus: meta.auditStatus,
+    protocolAgeDays,
+    sampleCount,
+    insufficientHistory,
+  };
+
+  // A protocol without enough history cannot be characterized on
+  // volatility/trend. Rather than let audit + age alone produce a
+  // misleadingly high score, cap it at a conservative floor.
+  if (insufficientHistory) {
+    return { protocolName, score: INSUFFICIENT_HISTORY_SCORE, ...factors };
+  }
+
+  const auditFactor = AUDIT_FACTOR[meta.auditStatus];
+  const ageFactor = computeAgeFactor(protocolAgeDays);
+
+  const weighted =
+    WEIGHTS.audit * auditFactor +
+    WEIGHTS.volatility * apyVolatilityFactor +
+    WEIGHTS.tvlTrend * tvlTrendFactor +
+    WEIGHTS.age * ageFactor;
+
+  const score = Math.round(clamp01(weighted) * 100);
+
+  return { protocolName, score, ...factors };
+}

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -15,6 +15,25 @@ const DEFAULT_THRESHOLDS: RebalanceThresholds = {
   maxGasPercent: 0.1,
 };
 
+/**
+ * Load current protocol risk scores keyed by protocol name.
+ *
+ * Only called when a user has actually configured a riskCeiling, so the default
+ * (no-ceiling) rebalancing path issues no extra query and is unaffected. A
+ * protocol absent from this map is treated as ineligible under a ceiling
+ * (fail-closed) by the strategy engine.
+ */
+async function loadProtocolRiskScores(): Promise<Record<string, number>> {
+  const rows = await db.protocolRiskScore.findMany({
+    select: { protocolName: true, score: true },
+  });
+  const map: Record<string, number> = {};
+  for (const row of rows as Array<{ protocolName: string; score: number }>) {
+    map[row.protocolName] = row.score;
+  }
+  return map;
+}
+
 function toApyBasisPoints(apyPercent: number): number {
   if (!Number.isFinite(apyPercent) || apyPercent < 0) {
     throw new Error('APY must be a non-negative number');
@@ -301,6 +320,13 @@ export async function executeRebalanceIfNeeded(
           ? new TargetAllocationStrategy()
           : new MaxYieldStrategy();
 
+      // Risk ceiling is opt-in per user. Only when a ceiling is set do we load
+      // the current ProtocolRiskScore rows and pass them to the strategy — the
+      // no-ceiling path issues no extra query and behaves exactly as before.
+      const riskCeiling = userStrategyPreferences[0]?.riskCeiling;
+      const protocolRiskScores =
+        riskCeiling !== undefined ? await loadProtocolRiskScores() : undefined;
+
       const decision = await strategy.analyze({
         currentProtocol,
         totalAmount,
@@ -308,6 +334,8 @@ export async function executeRebalanceIfNeeded(
         availableProtocols: allProtocols,
         thresholds: effectiveThresholds,
         userStrategyPreferences,
+        riskCeiling,
+        protocolRiskScores,
       });
 
       if (!decision.shouldRebalance) {

--- a/src/agent/strategies.ts
+++ b/src/agent/strategies.ts
@@ -3,8 +3,42 @@ import {
   StrategyName,
   StrategyDecision,
   StrategyParams,
+  YieldProtocol,
 } from './types';
 import { logger } from '../utils/logger';
+
+/**
+ * Reasoning emitted when a configured risk ceiling excludes every candidate
+ * protocol. This is an explicit, surfaced state — the ceiling is NEVER silently
+ * dropped to keep the agent allocating (see issue #291 acceptance criteria and
+ * the test that guards this in tests/unit/agent/strategies.test.ts).
+ */
+export const NO_ELIGIBLE_PROTOCOLS_REASON =
+  'No protocols currently meet your risk tolerance';
+
+/**
+ * Apply an optional risk ceiling to a candidate protocol set.
+ *
+ * Backward-compatibility contract: when `riskCeiling` is undefined this returns
+ * the SAME array reference unchanged, so a user who never sets a ceiling sees
+ * byte-for-byte identical behavior to before this parameter existed.
+ *
+ * Fail-closed: when a ceiling IS set, a protocol with no known score is treated
+ * as ineligible rather than given the benefit of the doubt — a risk control must
+ * not admit unknowns.
+ */
+function applyRiskCeiling(
+  protocols: YieldProtocol[],
+  riskCeiling: number | undefined,
+  scores: Record<string, number> | undefined,
+): YieldProtocol[] {
+  if (riskCeiling === undefined) return protocols;
+  const scoreMap = scores ?? {};
+  return protocols.filter((p) => {
+    const score = scoreMap[p.name];
+    return score !== undefined && score >= riskCeiling;
+  });
+}
 
 function estimateRebalanceCosts(
   amount: string,
@@ -26,7 +60,7 @@ export class MaxYieldStrategy implements RebalanceStrategy {
   readonly name: StrategyName = 'MAX_YIELD';
 
   async analyze(params: StrategyParams): Promise<StrategyDecision> {
-    const { currentProtocol, totalAmount, currentApy, availableProtocols, thresholds } = params;
+    const { currentProtocol, totalAmount, currentApy, availableProtocols, thresholds, riskCeiling, protocolRiskScores } = params;
 
     if (availableProtocols.length === 0) {
       return {
@@ -36,7 +70,24 @@ export class MaxYieldStrategy implements RebalanceStrategy {
       };
     }
 
-    const bestProtocol = availableProtocols[0];
+    // Enforce the risk ceiling BEFORE optimizing for yield. When no ceiling is
+    // set this is a no-op that preserves the original candidate set exactly.
+    const eligibleProtocols = applyRiskCeiling(availableProtocols, riskCeiling, protocolRiskScores);
+
+    if (riskCeiling !== undefined && eligibleProtocols.length === 0) {
+      logger.info('MaxYieldStrategy: no protocols meet risk ceiling', {
+        riskCeiling,
+        candidates: availableProtocols.map((p) => p.name),
+      });
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: NO_ELIGIBLE_PROTOCOLS_REASON,
+        details: { riskCeiling, eligibleCount: 0 },
+      };
+    }
+
+    const bestProtocol = eligibleProtocols[0];
 
     if (bestProtocol.name === currentProtocol) {
       return {
@@ -94,7 +145,7 @@ export class TargetAllocationStrategy implements RebalanceStrategy {
   private readonly targetDeviationThreshold = 0.2;
 
   async analyze(params: StrategyParams): Promise<StrategyDecision> {
-    const { currentProtocol, totalAmount, currentApy, availableProtocols, thresholds, userStrategyPreferences } = params;
+    const { currentProtocol, totalAmount, currentApy, availableProtocols, thresholds, userStrategyPreferences, riskCeiling, protocolRiskScores } = params;
 
     const relevantPrefs = userStrategyPreferences.filter(p => p.targetAllocations && Object.keys(p.targetAllocations!).length > 0);
     if (relevantPrefs.length === 0) {
@@ -120,11 +171,38 @@ export class TargetAllocationStrategy implements RebalanceStrategy {
     const totalTarget = Object.values(targets).reduce((sum, v) => sum + v, 0);
     const targetShare = totalTarget > 0 ? currentTarget / totalTarget : 0;
 
+    // Candidate rebalance targets are the configured protocols other than the
+    // current one. When a risk ceiling is set, exclude any candidate that does
+    // not clear it (fail-closed on unknown scores) BEFORE choosing a target.
+    // When no ceiling is set this filter is a no-op, preserving prior behavior.
+    const scoreMap = protocolRiskScores ?? {};
+    const passesCeiling = (name: string): boolean =>
+      riskCeiling === undefined ||
+      (scoreMap[name] !== undefined && scoreMap[name] >= riskCeiling);
+
     const bestTargetProtocol = Object.entries(targets)
       .filter(([name]) => name !== currentProtocol)
+      .filter(([name]) => passesCeiling(name))
       .sort(([, a], [, b]) => b - a);
 
     if (bestTargetProtocol.length === 0) {
+      // Distinguish "ceiling excluded everything" from "nothing else configured"
+      // so the user's stated risk tolerance is surfaced, never silently dropped.
+      if (riskCeiling !== undefined) {
+        const otherConfigured = Object.keys(targets).filter((name) => name !== currentProtocol);
+        if (otherConfigured.length > 0) {
+          logger.info('TargetAllocationStrategy: no target protocols meet risk ceiling', {
+            riskCeiling,
+            candidates: otherConfigured,
+          });
+          return {
+            shouldRebalance: false,
+            targetProtocol: currentProtocol,
+            reasoning: NO_ELIGIBLE_PROTOCOLS_REASON,
+            details: { riskCeiling, eligibleCount: 0 },
+          };
+        }
+      }
       return {
         shouldRebalance: false,
         targetProtocol: currentProtocol,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -91,6 +91,22 @@ export interface StrategyParams {
   availableProtocols: YieldProtocol[];
   thresholds: RebalanceThresholds;
   userStrategyPreferences: UserStrategyPreferences[];
+  /**
+   * Optional per-protocol risk scores (0-100, higher = lower risk), keyed by
+   * protocol name. Supplied by the caller from ProtocolRiskScore. Only consulted
+   * when a strategy is given a riskCeiling; absent scores are treated as
+   * ineligible under a ceiling (fail-closed — see StrategyParams.riskCeiling).
+   */
+  protocolRiskScores?: Record<string, number>;
+  /**
+   * Optional minimum acceptable risk score. When set, candidate protocols are
+   * filtered to those with score >= riskCeiling BEFORE any yield/allocation
+   * optimization. Opt-in: when undefined, behavior is byte-for-byte identical to
+   * before this parameter existed. A ceiling that excludes every protocol
+   * surfaces an explicit "no eligible protocols" decision — it is never silently
+   * ignored to keep the agent allocating.
+   */
+  riskCeiling?: number;
 }
 
 export interface RebalanceStrategy {
@@ -103,4 +119,11 @@ export interface UserStrategyPreferences {
   strategyName?: StrategyName | null;
   targetAllocations?: Record<string, number>;
   riskTolerance?: number;
+  /**
+   * Optional minimum acceptable protocol risk score (0-100, higher = lower
+   * risk). When set, the strategy engine only considers protocols scoring at or
+   * above this value. Opt-in and backward compatible: unset means no risk
+   * filtering, identical to prior behavior.
+   */
+  riskCeiling?: number;
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -424,4 +424,8 @@ export const config = {
     /** Interval between retention job runs in ms (default: 24 hours) */
     intervalMs: parseInt(process.env.RETENTION_INTERVAL_MS || '86400000'),
   },
+  protocolRisk: {
+    /** Interval between protocol risk-score recomputations in ms (default: 6 hours) */
+    intervalMs: parseInt(process.env.PROTOCOL_RISK_INTERVAL_MS || '21600000'),
+  },
 }

--- a/src/config/protocolRiskMetadata.ts
+++ b/src/config/protocolRiskMetadata.ts
@@ -1,0 +1,108 @@
+/**
+ * Curated protocol risk metadata.
+ *
+ * This file is the single, reviewable source of truth for the two risk inputs
+ * that cannot be derived from on-chain rate history: a protocol's audit status
+ * and its age. On-chain data alone can't tell you whether a protocol has been
+ * third-party audited or when it launched, so these are curated by hand.
+ *
+ * ── Review process (see docs/PROTOCOL_RISK_SCORING.md) ──────────────────────
+ * This metadata goes stale (a protocol gets audited after being marked
+ * UNAUDITED, or simply ages). It MUST be reviewed on protocol onboarding and
+ * at least quarterly:
+ *   1. Confirm `auditStatus` against the protocol's latest published audits.
+ *      THIRD_PARTY_AUDITED requires a completed audit by a reputable external
+ *      firm whose report is publicly linkable (record it in `auditReference`).
+ *   2. `inceptionDate` is fixed at launch and should not change once set.
+ *      protocolAgeDays is derived from it at compute time, so age stays current
+ *      automatically without edits here.
+ * Changes to this file are code-reviewed like any other change — that review IS
+ * the update process. Do not move this data into a database or bury it in the
+ * scoring code; keeping it explicit and diffable is the point.
+ *
+ * A protocol that appears in rate history but is absent here is treated as
+ * UNAUDITED with unknown (0-day) age — the most conservative assumption.
+ */
+
+export type AuditStatusValue = 'UNAUDITED' | 'SELF_REPORTED' | 'THIRD_PARTY_AUDITED';
+
+export interface ProtocolRiskMetadata {
+  /** Must match ProtocolRate.protocolName / YieldProtocol.name exactly. */
+  protocolName: string;
+  auditStatus: AuditStatusValue;
+  /**
+   * Protocol launch date (ISO-8601, UTC). protocolAgeDays is computed from this
+   * relative to the scoring run, so it never needs manual bumping.
+   */
+  inceptionDate: string;
+  /** Optional public link/citation backing the auditStatus. For review only. */
+  auditReference?: string;
+}
+
+/**
+ * Curated metadata for the protocols the scanner tracks today (Blend, Stellar
+ * DEX, Luma — see src/agent/scanner.ts). Add an entry when a new protocol is
+ * onboarded to the scanner.
+ *
+ * NOTE: audit statuses below are placeholders pending verification against each
+ * protocol's published audits (see the review process above). They intentionally
+ * default toward the conservative end until confirmed.
+ */
+export const PROTOCOL_RISK_METADATA: readonly ProtocolRiskMetadata[] = [
+  {
+    protocolName: 'Blend',
+    auditStatus: 'THIRD_PARTY_AUDITED',
+    inceptionDate: '2024-02-01',
+    auditReference: 'https://docs.blend.capital/ — verify latest audit report on review',
+  },
+  {
+    protocolName: 'Stellar DEX',
+    auditStatus: 'THIRD_PARTY_AUDITED',
+    inceptionDate: '2015-09-30',
+    auditReference: 'Stellar Core protocol; native DEX. Verify scope on review.',
+  },
+  {
+    protocolName: 'Luma',
+    auditStatus: 'SELF_REPORTED',
+    inceptionDate: '2023-06-01',
+    auditReference: 'Self-reported; no third-party audit confirmed at time of curation.',
+  },
+];
+
+const METADATA_BY_NAME: ReadonlyMap<string, ProtocolRiskMetadata> = new Map(
+  PROTOCOL_RISK_METADATA.map((m) => [m.protocolName, m]),
+);
+
+/**
+ * The conservative default applied to any protocol seen in rate history but not
+ * present in the curated table: unaudited, unknown age.
+ */
+export const DEFAULT_PROTOCOL_METADATA: Omit<ProtocolRiskMetadata, 'protocolName'> = {
+  auditStatus: 'UNAUDITED',
+  inceptionDate: '', // empty => age unknown => treated as 0 days (newest/riskiest)
+};
+
+/**
+ * Look up curated metadata for a protocol, falling back to the conservative
+ * default when the protocol is not curated.
+ */
+export function getProtocolMetadata(protocolName: string): ProtocolRiskMetadata {
+  const found = METADATA_BY_NAME.get(protocolName);
+  if (found) return found;
+  return { protocolName, ...DEFAULT_PROTOCOL_METADATA };
+}
+
+/**
+ * Compute protocol age in whole days from its curated inception date relative to
+ * `now`. Returns 0 when the inception date is missing or unparseable (unknown
+ * age is treated as brand-new, i.e. maximally risky).
+ */
+export function computeProtocolAgeDays(inceptionDate: string, now: Date): number {
+  if (!inceptionDate) return 0;
+  const inception = new Date(inceptionDate);
+  const ms = inception.getTime();
+  if (Number.isNaN(ms)) return 0;
+  const diffMs = now.getTime() - ms;
+  if (diffMs <= 0) return 0;
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { connectDb } from './db'
 import { scheduleSessionCleanup } from './jobs/sessionCleanup'
 import { scheduleDataRetention } from './jobs/dataRetention'
 import { schedulePoolMetrics } from './jobs/poolMetrics'
+import { scheduleProtocolRiskScoring } from './jobs/protocolRiskScoring'
 import { startEventListener, stopEventListener } from './stellar/events'
 import { validateStellarNetworkReady } from './config/readiness'
 import healthRouter from './routes/health'
@@ -73,6 +74,7 @@ let httpServer: Server | null = null
 let sessionCleanupHandle: NodeJS.Timeout | null = null
 let dataRetentionHandle: NodeJS.Timeout | null = null
 let poolMetricsHandle: NodeJS.Timeout | null = null
+let protocolRiskHandle: NodeJS.Timeout | null = null
 
 function allServicesReady(): boolean {
   return Object.values(serviceStatus).every(s => s.ready)
@@ -284,6 +286,12 @@ async function gracefulShutdown(signal: string): Promise<void> {
     logger.info('[Shutdown] Pool metrics timer cleared')
   }
 
+  if (protocolRiskHandle) {
+    clearInterval(protocolRiskHandle)
+    protocolRiskHandle = null
+    logger.info('[Shutdown] Protocol risk scoring timer cleared')
+  }
+
   if (!httpServer) {
     logger.warn('[Shutdown] No HTTP server to close')
     process.exit(0)
@@ -417,6 +425,7 @@ async function main(): Promise<void> {
   sessionCleanupHandle = scheduleSessionCleanup()
   dataRetentionHandle = scheduleDataRetention()
   poolMetricsHandle = schedulePoolMetrics()
+  protocolRiskHandle = scheduleProtocolRiskScoring()
 }
 
 // ── Process-level error guards ────────────────────────────────────────────────

--- a/src/jobs/protocolRiskScoring.ts
+++ b/src/jobs/protocolRiskScoring.ts
@@ -1,0 +1,122 @@
+import db from '../db';
+import { logger, logBackgroundJob } from '../utils/logger';
+import { generateCorrelationId, runWithCorrelationIdAsync } from '../utils/correlation';
+import { config } from '../config/env';
+import { recordJobSuccess, recordJobFailure } from '../utils/job-metrics';
+import { computeRiskScore, RateSample } from '../agent/riskScoring';
+import { PROTOCOL_RISK_METADATA } from '../config/protocolRiskMetadata';
+
+/**
+ * Protocol risk scoring job.
+ *
+ * Recomputes each protocol's risk score from its ProtocolRate history plus the
+ * curated audit/age metadata, and upserts the result into ProtocolRiskScore.
+ * Scoring math lives in src/agent/riskScoring.ts (pure + unit-tested); this job
+ * is only the DB glue and scheduling, mirroring the other jobs in src/jobs/.
+ *
+ * The set of protocols to score is the union of everything seen in rate history
+ * and everything in the curated metadata table, so a curated-but-not-yet-scanned
+ * protocol still gets a (conservative) score, and a scanned-but-uncurated one is
+ * scored with the conservative UNAUDITED/unknown-age default.
+ */
+export async function computeProtocolRiskScores(now: Date = new Date()): Promise<void> {
+  const correlationId = generateCorrelationId();
+  return runWithCorrelationIdAsync(correlationId, async () => {
+    const start = Date.now();
+    const jobName = 'protocol_risk_scoring';
+
+    try {
+      // Distinct protocol names from rate history…
+      const rateProtocols = await db.protocolRate.findMany({
+        distinct: ['protocolName'],
+        select: { protocolName: true },
+      });
+
+      const protocolNames = new Set<string>([
+        ...rateProtocols.map((r: { protocolName: string }) => r.protocolName),
+        ...PROTOCOL_RISK_METADATA.map((m) => m.protocolName),
+      ]);
+
+      let scored = 0;
+      for (const protocolName of protocolNames) {
+        const rates = await db.protocolRate.findMany({
+          where: { protocolName },
+          orderBy: { fetchedAt: 'asc' },
+          select: { supplyApy: true, tvl: true, fetchedAt: true },
+        });
+
+        const samples: RateSample[] = rates.map(
+          (r: { supplyApy: unknown; tvl: unknown; fetchedAt: Date }) => ({
+            supplyApy: Number(r.supplyApy),
+            tvl: r.tvl === null || r.tvl === undefined ? null : Number(r.tvl),
+            fetchedAt: r.fetchedAt,
+          }),
+        );
+
+        const result = computeRiskScore(protocolName, samples, now);
+
+        await db.protocolRiskScore.upsert({
+          where: { protocolName },
+          create: {
+            protocolName,
+            score: result.score,
+            tvlTrendFactor: result.tvlTrendFactor,
+            apyVolatilityFactor: result.apyVolatilityFactor,
+            auditStatus: result.auditStatus,
+            protocolAgeDays: result.protocolAgeDays,
+            insufficientHistory: result.insufficientHistory,
+            sampleCount: result.sampleCount,
+            computedAt: now,
+          },
+          update: {
+            score: result.score,
+            tvlTrendFactor: result.tvlTrendFactor,
+            apyVolatilityFactor: result.apyVolatilityFactor,
+            auditStatus: result.auditStatus,
+            protocolAgeDays: result.protocolAgeDays,
+            insufficientHistory: result.insufficientHistory,
+            sampleCount: result.sampleCount,
+            computedAt: now,
+          },
+        });
+        scored++;
+      }
+
+      const durationMs = Date.now() - start;
+      logBackgroundJob(jobName, 'success', durationMs / 1000, correlationId, {
+        protocolsScored: scored,
+      });
+      recordJobSuccess(jobName, durationMs);
+    } catch (error) {
+      const durationMs = Date.now() - start;
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      logBackgroundJob(jobName, 'failed', durationMs / 1000, correlationId, {
+        error: errorMessage,
+      });
+      recordJobFailure(jobName, durationMs);
+    }
+  });
+}
+
+/**
+ * Schedule the risk-scoring job. Runs once on startup then on the configured
+ * interval (default 6 h), following the same pattern as the other jobs.
+ *
+ * @returns NodeJS.Timeout handle — pass to clearInterval() on shutdown.
+ */
+export function scheduleProtocolRiskScoring(): NodeJS.Timeout {
+  void computeProtocolRiskScores();
+
+  const intervalMs = config.protocolRisk.intervalMs;
+  const handle = setInterval(() => {
+    void computeProtocolRiskScores();
+  }, intervalMs);
+
+  handle.unref?.();
+
+  logger.info(
+    `[ProtocolRiskScoring] Risk scoring scheduled every ${intervalMs / 3600000}h`,
+  );
+  return handle;
+}

--- a/src/routes/protocols.ts
+++ b/src/routes/protocols.ts
@@ -36,6 +36,50 @@ router.get('/rates', async (req: Request, res: Response) => {
 })
 
 /**
+ * GET /api/protocols/risk
+ * Returns the current risk score for each protocol together with the
+ * contributing factors behind it (not an opaque number), plus the scoring
+ * methodology reference so a caller can reconcile the factors against the docs.
+ *
+ * Public (no auth): this is aggregate, non-user-specific data with no PII or
+ * per-user financial exposure — consistent with the public posture the issue
+ * specifies and with the aggregate nature of protocol data.
+ */
+router.get('/risk', async (_req: Request, res: Response) => {
+  try {
+    const scores = await db.protocolRiskScore.findMany({
+      orderBy: { score: 'desc' },
+    })
+
+    const items = scores.map((s: any) => ({
+      protocolName: s.protocolName,
+      score: s.score,
+      // Contributing factors — exposed so the score is transparent, not opaque.
+      factors: {
+        auditStatus: s.auditStatus,
+        protocolAgeDays: s.protocolAgeDays,
+        apyVolatilityFactor: Number(s.apyVolatilityFactor),
+        tvlTrendFactor: Number(s.tvlTrendFactor),
+        sampleCount: s.sampleCount,
+        insufficientHistory: s.insufficientHistory,
+      },
+      computedAt: s.computedAt.toISOString(),
+    }))
+
+    return res.status(200).json({
+      protocols: items,
+      methodology: 'docs/PROTOCOL_RISK_SCORING.md',
+    })
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return res.status(500).json({
+      success: false,
+      error: errorMessage,
+    })
+  }
+})
+
+/**
  * GET /api/protocols/agent/status
  * Returns agent status information
  * Requires authentication to prevent information disclosure

--- a/tests/unit/agent/riskScoring.test.ts
+++ b/tests/unit/agent/riskScoring.test.ts
@@ -1,0 +1,207 @@
+import {
+  computeRiskScore,
+  computeApyVolatilityFactor,
+  computeTvlTrendFactor,
+  computeAgeFactor,
+  filterToWindow,
+  RateSample,
+  MIN_SAMPLES_FOR_HISTORY,
+  TRAILING_WINDOW_DAYS,
+  APY_STDEV_FLOOR,
+  AGE_SATURATION_DAYS,
+  INSUFFICIENT_HISTORY_SCORE,
+  WEIGHTS,
+} from '../../../src/agent/riskScoring';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Fixed reference "now" so every fixture is deterministic.
+const NOW = new Date('2026-07-16T00:00:00.000Z');
+
+/** Build a sample `daysAgo` before NOW. */
+function sample(daysAgo: number, supplyApy: number, tvl: number | null = 1_000_000): RateSample {
+  return {
+    supplyApy,
+    tvl,
+    fetchedAt: new Date(NOW.getTime() - daysAgo * DAY_MS),
+  };
+}
+
+describe('riskScoring — weights invariant', () => {
+  it('component weights sum to 1', () => {
+    const sum = WEIGHTS.audit + WEIGHTS.volatility + WEIGHTS.tvlTrend + WEIGHTS.age;
+    expect(sum).toBeCloseTo(1, 10);
+  });
+});
+
+describe('filterToWindow', () => {
+  it('keeps only samples within the trailing window and sorts ascending by time', () => {
+    const samples = [
+      sample(1, 5),
+      sample(TRAILING_WINDOW_DAYS + 5, 5), // outside window — dropped
+      sample(10, 5),
+    ];
+    const windowed = filterToWindow(samples, NOW);
+    expect(windowed).toHaveLength(2);
+    // Ascending order: the 10-days-ago sample comes before the 1-day-ago one.
+    expect(windowed[0].fetchedAt.getTime()).toBeLessThan(windowed[1].fetchedAt.getTime());
+  });
+});
+
+describe('computeApyVolatilityFactor', () => {
+  it('returns 1 for a perfectly stable APY', () => {
+    const samples = [sample(3, 5), sample(2, 5), sample(1, 5)];
+    expect(computeApyVolatilityFactor(samples)).toBe(1);
+  });
+
+  it('returns a lower factor as APY volatility increases', () => {
+    const stable = [sample(3, 5), sample(2, 5.1), sample(1, 4.9)];
+    const volatile = [sample(3, 1), sample(2, 9), sample(1, 5)];
+    expect(computeApyVolatilityFactor(volatile)).toBeLessThan(
+      computeApyVolatilityFactor(stable),
+    );
+  });
+
+  it('floors at 0 once stdev reaches APY_STDEV_FLOOR', () => {
+    // Two points at +/- APY_STDEV_FLOOR around the mean → stdev == APY_STDEV_FLOOR.
+    const samples = [sample(2, 10 - APY_STDEV_FLOOR), sample(1, 10 + APY_STDEV_FLOOR)];
+    expect(computeApyVolatilityFactor(samples)).toBe(0);
+  });
+
+  it('returns 0 when fewer than two APY points exist', () => {
+    expect(computeApyVolatilityFactor([sample(1, 5)])).toBe(0);
+  });
+});
+
+describe('computeTvlTrendFactor', () => {
+  it('is > 0.5 when TVL is growing across the window', () => {
+    const samples = [sample(3, 5, 1_000_000), sample(2, 5, 1_100_000), sample(1, 5, 1_200_000)];
+    expect(computeTvlTrendFactor(samples)).toBeGreaterThan(0.5);
+  });
+
+  it('is < 0.5 when TVL is declining across the window', () => {
+    const samples = [sample(3, 5, 1_200_000), sample(2, 5, 1_000_000), sample(1, 5, 800_000)];
+    expect(computeTvlTrendFactor(samples)).toBeLessThan(0.5);
+  });
+
+  it('is neutral (0.5) when there is no usable TVL data', () => {
+    const samples = [sample(3, 5, null), sample(2, 5, null), sample(1, 5, null)];
+    expect(computeTvlTrendFactor(samples)).toBe(0.5);
+  });
+});
+
+describe('computeAgeFactor', () => {
+  it('is 0 at age 0 and saturates to 1 at AGE_SATURATION_DAYS', () => {
+    expect(computeAgeFactor(0)).toBe(0);
+    expect(computeAgeFactor(AGE_SATURATION_DAYS)).toBe(1);
+    expect(computeAgeFactor(AGE_SATURATION_DAYS * 2)).toBe(1); // clamped
+  });
+});
+
+describe('computeRiskScore', () => {
+  it('produces a normalized 0-100 score with the full factor breakdown', () => {
+    // Blend is curated THIRD_PARTY_AUDITED with a 2024 inception → mature + audited.
+    const samples = [
+      sample(20, 5.0, 1_000_000),
+      sample(15, 5.1, 1_050_000),
+      sample(10, 4.9, 1_100_000),
+      sample(5, 5.0, 1_150_000),
+      sample(1, 5.05, 1_200_000),
+    ];
+    const result = computeRiskScore('Blend', samples, NOW);
+
+    expect(result.protocolName).toBe('Blend');
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+    expect(result.insufficientHistory).toBe(false);
+    expect(result.sampleCount).toBe(5);
+    expect(result.auditStatus).toBe('THIRD_PARTY_AUDITED');
+    expect(result.protocolAgeDays).toBeGreaterThan(0);
+    // Stable APY + growing TVL + audited + mature → a high (low-risk) score.
+    expect(result.score).toBeGreaterThan(70);
+  });
+
+  it('scores an audited, stable protocol higher than an unaudited, volatile one', () => {
+    const stableAudited = [
+      sample(20, 5.0, 1_000_000),
+      sample(10, 5.0, 1_100_000),
+      sample(1, 5.0, 1_200_000),
+    ];
+    const volatileUnaudited = [
+      sample(20, 1.0, 1_200_000),
+      sample(10, 9.0, 900_000),
+      sample(1, 4.0, 700_000),
+    ];
+    const good = computeRiskScore('Blend', stableAudited, NOW);
+    // 'UnknownProtocol' is not curated → UNAUDITED, age 0.
+    const bad = computeRiskScore('UnknownProtocol', volatileUnaudited, NOW);
+    expect(good.score).toBeGreaterThan(bad.score);
+  });
+
+  describe('insufficient-history policy', () => {
+    it('flags a brand-new protocol with too few samples and scores it conservatively low', () => {
+      const samples = [sample(2, 5.0), sample(1, 5.2)]; // 2 < MIN_SAMPLES_FOR_HISTORY
+      const result = computeRiskScore('Blend', samples, NOW);
+      expect(result.insufficientHistory).toBe(true);
+      expect(result.score).toBe(INSUFFICIENT_HISTORY_SCORE);
+    });
+
+    it('does not give a no-history protocol a misleadingly neutral score', () => {
+      const result = computeRiskScore('Blend', [], NOW);
+      expect(result.sampleCount).toBe(0);
+      expect(result.insufficientHistory).toBe(true);
+      expect(result.score).toBe(INSUFFICIENT_HISTORY_SCORE);
+      // Even though Blend is audited + mature, the score is NOT pulled up by
+      // audit/age alone when history is absent.
+      expect(result.score).toBeLessThan(50);
+    });
+
+    it('requires at least MIN_SAMPLES_FOR_HISTORY in-window samples', () => {
+      const justEnough = Array.from({ length: MIN_SAMPLES_FOR_HISTORY }, (_, i) =>
+        sample(i + 1, 5.0),
+      );
+      const result = computeRiskScore('Blend', justEnough, NOW);
+      expect(result.insufficientHistory).toBe(false);
+    });
+  });
+
+  describe('data-gap policy', () => {
+    it('treats out-of-window samples as absent, not as favorable data', () => {
+      // Plenty of history overall, but a long collector gap means only 2 samples
+      // fall inside the trailing window → treated as insufficient, NOT scored as
+      // if the missing days were stable/neutral.
+      const samples = [
+        sample(200, 5.0), // ancient, outside window
+        sample(180, 5.0), // ancient, outside window
+        sample(150, 5.0), // ancient, outside window
+        sample(2, 5.0), // in window
+        sample(1, 5.0), // in window
+      ];
+      const result = computeRiskScore('Blend', samples, NOW);
+      expect(result.sampleCount).toBe(2);
+      expect(result.insufficientHistory).toBe(true);
+      expect(result.score).toBe(INSUFFICIENT_HISTORY_SCORE);
+    });
+
+    it('ignores null-TVL samples when computing the TVL trend rather than treating them as zero', () => {
+      const withGaps = [
+        sample(20, 5.0, 1_000_000),
+        sample(15, 5.0, null), // gap in TVL data
+        sample(10, 5.0, null), // gap in TVL data
+        sample(5, 5.0, 1_100_000),
+        sample(1, 5.0, 1_200_000),
+      ];
+      const result = computeRiskScore('Blend', withGaps, NOW);
+      // Trend computed from the 3 real TVL points (all growing) → > 0.5, and
+      // never dragged to 0 by treating the nulls as zero TVL.
+      expect(result.tvlTrendFactor).toBeGreaterThan(0.5);
+    });
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const samples = [sample(10, 5.0, 1_000_000), sample(5, 5.1, 1_050_000), sample(1, 4.9, 1_100_000)];
+    const a = computeRiskScore('Blend', samples, NOW);
+    const b = computeRiskScore('Blend', samples, NOW);
+    expect(a).toEqual(b);
+  });
+});

--- a/tests/unit/agent/strategies.test.ts
+++ b/tests/unit/agent/strategies.test.ts
@@ -1,4 +1,8 @@
-import { MaxYieldStrategy, TargetAllocationStrategy } from '../../../src/agent/strategies';
+import {
+  MaxYieldStrategy,
+  TargetAllocationStrategy,
+  NO_ELIGIBLE_PROTOCOLS_REASON,
+} from '../../../src/agent/strategies';
 import { StrategyParams, YieldProtocol } from '../../../src/agent/types';
 
 jest.mock('../../../src/utils/logger', () => ({
@@ -235,5 +239,159 @@ describe('TargetAllocationStrategy', () => {
     const decision = await strategy.analyze(params);
     expect(decision.shouldRebalance).toBe(false);
     expect(decision.reasoning).toContain('No target allocation set');
+  });
+});
+
+// ── Risk ceiling (issue #291) ────────────────────────────────────────────────
+//
+// The ceiling is a genuine safety control on where user funds can go. These
+// tests guard two things the issue calls out explicitly:
+//   1. Backward compatibility — a user who never sets a ceiling must see
+//      byte-for-byte identical decisions to before the parameter existed.
+//   2. The ceiling is NEVER silently bypassed: when it excludes every protocol
+//      the strategy surfaces an explicit "no eligible protocols" state rather
+//      than falling back to allocating somewhere the user disallowed.
+
+describe('MaxYieldStrategy — riskCeiling', () => {
+  const strategy = new MaxYieldStrategy();
+
+  const baseParams = (): StrategyParams => ({
+    currentProtocol: 'Blend',
+    totalAmount: '10000000000000000000000',
+    currentApy: 3.0,
+    availableProtocols: [
+      makeProtocol({ name: 'Luma', apy: 8.0 }),
+      makeProtocol({ name: 'Blend', apy: 3.0 }),
+    ],
+    thresholds: defaultThresholds,
+    userStrategyPreferences: [],
+  });
+
+  it('is a no-op when riskCeiling is undefined (identical decision to before)', async () => {
+    const params = baseParams();
+    // Even if scores are supplied, an unset ceiling must ignore them entirely.
+    params.protocolRiskScores = { Luma: 10, Blend: 10 };
+
+    const withoutCeiling = await strategy.analyze(baseParams());
+    const withScoresButNoCeiling = await strategy.analyze(params);
+
+    expect(withScoresButNoCeiling).toEqual(withoutCeiling);
+    expect(withScoresButNoCeiling.shouldRebalance).toBe(true);
+    expect(withScoresButNoCeiling.targetProtocol).toBe('Luma');
+  });
+
+  it('filters out protocols below the ceiling before optimizing for yield', async () => {
+    const params = baseParams();
+    params.riskCeiling = 50;
+    // Luma is the highest yield but too risky; a lower-yield protocol clears it.
+    params.availableProtocols = [
+      makeProtocol({ name: 'Luma', apy: 8.0 }),
+      makeProtocol({ name: 'Stellar DEX', apy: 6.0 }),
+      makeProtocol({ name: 'Blend', apy: 3.0 }),
+    ];
+    params.protocolRiskScores = { Luma: 20, 'Stellar DEX': 70, Blend: 80 };
+
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(true);
+    // Must NOT pick Luma even though it has the best APY.
+    expect(decision.targetProtocol).toBe('Stellar DEX');
+  });
+
+  it('surfaces an explicit "no eligible protocols" state rather than bypassing the ceiling', async () => {
+    const params = baseParams();
+    params.riskCeiling = 90;
+    params.protocolRiskScores = { Luma: 20, Blend: 30 }; // nothing clears 90
+
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.targetProtocol).toBe('Blend'); // stays put, no silent move
+    expect(decision.reasoning).toBe(NO_ELIGIBLE_PROTOCOLS_REASON);
+  });
+
+  it('fail-closed: a protocol with no known score is excluded under a ceiling', async () => {
+    const params = baseParams();
+    params.riskCeiling = 50;
+    // Luma has a passing score; Blend (current) has no score at all.
+    params.protocolRiskScores = { Luma: 70 };
+
+    const decision = await strategy.analyze(params);
+    // Luma is eligible and higher yield -> rebalance to it.
+    expect(decision.shouldRebalance).toBe(true);
+    expect(decision.targetProtocol).toBe('Luma');
+  });
+
+  it('fail-closed: when scores are entirely absent, a ceiling excludes everything', async () => {
+    const params = baseParams();
+    params.riskCeiling = 50;
+    params.protocolRiskScores = undefined;
+
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toBe(NO_ELIGIBLE_PROTOCOLS_REASON);
+  });
+});
+
+describe('TargetAllocationStrategy — riskCeiling', () => {
+  const strategy = new TargetAllocationStrategy();
+
+  const baseParams = (): StrategyParams => ({
+    currentProtocol: 'Blend',
+    totalAmount: '10000000000000000000000',
+    currentApy: 5.0,
+    availableProtocols: [
+      makeProtocol({ name: 'Luma', apy: 6.0 }),
+      makeProtocol({ name: 'Blend', apy: 5.0 }),
+    ],
+    thresholds: defaultThresholds,
+    userStrategyPreferences: [
+      {
+        userId: 'user-1',
+        strategyName: 'TARGET_ALLOCATION',
+        targetAllocations: { Blend: 30, 'Stellar DEX': 40, Luma: 30 },
+      },
+    ],
+  });
+
+  it('is a no-op when riskCeiling is undefined (identical decision to before)', async () => {
+    const params = baseParams();
+    params.protocolRiskScores = { Blend: 10, 'Stellar DEX': 10, Luma: 10 };
+
+    const withoutCeiling = await strategy.analyze(baseParams());
+    const withScoresButNoCeiling = await strategy.analyze(params);
+
+    expect(withScoresButNoCeiling).toEqual(withoutCeiling);
+    expect(withScoresButNoCeiling.shouldRebalance).toBe(true);
+    expect(withScoresButNoCeiling.targetProtocol).toBe('Stellar DEX');
+  });
+
+  it('excludes target protocols below the ceiling before choosing a rebalance target', async () => {
+    const params = baseParams();
+    params.riskCeiling = 50;
+    // Weight Luma above the current protocol so a rebalance is warranted once
+    // the higher-weighted Stellar DEX is excluded by the ceiling.
+    params.userStrategyPreferences = [
+      {
+        userId: 'user-1',
+        strategyName: 'TARGET_ALLOCATION',
+        targetAllocations: { Blend: 20, 'Stellar DEX': 40, Luma: 40 },
+      },
+    ];
+    // Stellar DEX has the highest target weight but fails the ceiling; Luma clears it.
+    params.protocolRiskScores = { Blend: 80, 'Stellar DEX': 20, Luma: 70 };
+
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(true);
+    expect(decision.targetProtocol).toBe('Luma');
+  });
+
+  it('surfaces "no eligible protocols" when the ceiling excludes every target', async () => {
+    const params = baseParams();
+    params.riskCeiling = 90;
+    params.protocolRiskScores = { Blend: 95, 'Stellar DEX': 20, Luma: 30 };
+
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.targetProtocol).toBe('Blend');
+    expect(decision.reasoning).toBe(NO_ELIGIBLE_PROTOCOLS_REASON);
   });
 });


### PR DESCRIPTION
closes #291 
Add a quantitative, transparent per-protocol risk score that both constrains the strategy engine and is visible to users.

- ProtocolRiskScore model + migration; AuditStatus enum
- Pure scoring module (src/agent/riskScoring.ts) with documented new-protocol and data-gap policies; unit-tested against fixtures
- Curated, reviewable audit/age metadata source
- Scheduled recompute job following the existing src/jobs/* pattern
- Opt-in riskCeiling on MaxYield/TargetAllocation strategies; behavior is unchanged when unset, and a ceiling that excludes all protocols surfaces an explicit "no eligible protocols" state, never bypassed
- Public GET /api/protocols/risk exposing scores and contributing factors, not an opaque number
- Methodology docs (docs/PROTOCOL_RISK_SCORING.md) + openapi.yaml