### PR TITLE
feat(fiat): add fiat on-ramp/off-ramp integration (#290)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -50,6 +50,8 @@ tags:
     description: Analytics — APY history, user yield, protocol performance
   - name: stellar
     description: Stellar event listener metrics
+  - name: fiat
+    description: Fiat on-ramp / off-ramp (buy and sell crypto with fiat via a payment provider)
   - name: admin
     description: Admin-only management endpoints
   - name: metrics
@@ -2003,6 +2005,156 @@ paths:
         '404':
           description: Not found (info hiding for unauthorized requests)
 
+  # ── Fiat on-ramp / off-ramp ──────────────────────────────────────────────
+  /api/v1/fiat/quote:
+    post:
+      tags: [fiat]
+      operationId: getFiatQuote
+      summary: Get a fiat buy/sell quote
+      description: >
+        Returns an indicative quote from the active fiat provider for buying
+        (ON_RAMP) or selling (OFF_RAMP) a crypto asset with fiat currency.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FiatQuoteRequest'
+      responses:
+        '200':
+          description: Quote
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FiatQuote'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          description: Provider unavailable or returned an error
+
+  /api/v1/fiat/orders:
+    post:
+      tags: [fiat]
+      operationId: createFiatOrder
+      summary: Create a fiat order
+      description: >
+        Creates an on-ramp or off-ramp order with the active provider and
+        returns the order along with a provider checkout URL (and KYC URL if
+        the provider requires identity verification). The order settles only
+        after the on-chain crypto leg is independently confirmed.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFiatOrderRequest'
+      responses:
+        '201':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FiatOrder'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          description: Provider unavailable or returned an error
+    get:
+      tags: [fiat]
+      operationId: listFiatOrders
+      summary: List the caller's fiat orders
+      description: Returns the authenticated user's fiat orders, newest first.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Order history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  orders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FiatOrder'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/v1/fiat/orders/{id}:
+    get:
+      tags: [fiat]
+      operationId: getFiatOrder
+      summary: Get a single fiat order
+      description: Returns one fiat order owned by the authenticated user.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Fiat order ID
+      responses:
+        '200':
+          description: Order
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FiatOrder'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/fiat/webhook/{provider}:
+    post:
+      tags: [fiat]
+      operationId: fiatProviderWebhook
+      summary: Fiat provider webhook callback
+      description: >
+        Signed callback delivered by the fiat provider on order state changes.
+        Authenticity is verified from the provider's HMAC signature over the
+        raw request body — no JWT is required. The endpoint is idempotent and
+        always ACKs a well-formed, verified delivery. A provider "completed"
+        signal advances the order to PROCESSING; settlement to SETTLED requires
+        independent on-chain confirmation.
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+          description: Provider key (e.g. `moonpay`)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Provider-specific payload (opaque; verified by signature)
+      responses:
+        '200':
+          description: Delivery accepted (idempotent)
+        '400':
+          description: Malformed payload
+        '401':
+          description: Invalid or missing signature
+        '404':
+          description: Unknown provider
+        '500':
+          description: Processing error (provider should retry)
+
 components:
   securitySchemes:
     BearerAuth:
@@ -2249,6 +2401,140 @@ components:
             - type: array
               items: {}
             - type: object
+
+    # ── Fiat ──────────────────────────────────────────────────────────────
+    FiatDirection:
+      type: string
+      enum: [ON_RAMP, OFF_RAMP]
+      description: ON_RAMP buys crypto with fiat; OFF_RAMP sells crypto for fiat.
+    FiatOrderStatus:
+      type: string
+      enum: [PENDING, PROCESSING, SETTLED, FAILED, REFUNDED]
+      description: >
+        PENDING (awaiting payment), PROCESSING (provider reported payment;
+        awaiting on-chain confirmation), SETTLED (on-chain confirmed),
+        FAILED, REFUNDED.
+    FiatQuoteRequest:
+      type: object
+      required: [direction, fiatAmount, fiatCurrency, assetSymbol]
+      properties:
+        direction:
+          $ref: '#/components/schemas/FiatDirection'
+        fiatAmount:
+          type: number
+          format: double
+          minimum: 0
+          example: 100
+        fiatCurrency:
+          type: string
+          description: 3-letter ISO 4217 currency code
+          example: USD
+        assetSymbol:
+          type: string
+          example: USDC
+    FiatQuote:
+      type: object
+      properties:
+        direction:
+          $ref: '#/components/schemas/FiatDirection'
+        fiatAmount:
+          type: number
+          example: 100
+        fiatCurrency:
+          type: string
+          example: USD
+        cryptoAmount:
+          type: number
+          example: 98.5
+        assetSymbol:
+          type: string
+          example: USDC
+        feeAmount:
+          type: number
+          example: 1.5
+        exchangeRate:
+          type: number
+          example: 1.0
+        provider:
+          type: string
+          example: moonpay
+        expiresAt:
+          type: string
+          format: date-time
+    CreateFiatOrderRequest:
+      type: object
+      required: [userId, direction, fiatAmount, fiatCurrency, assetSymbol]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        direction:
+          $ref: '#/components/schemas/FiatDirection'
+        fiatAmount:
+          type: number
+          minimum: 0
+          example: 100
+        fiatCurrency:
+          type: string
+          example: USD
+        assetSymbol:
+          type: string
+          example: USDC
+    FiatOrder:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        provider:
+          type: string
+          example: moonpay
+        providerOrderId:
+          type: string
+        direction:
+          $ref: '#/components/schemas/FiatDirection'
+        fiatAmount:
+          type: number
+          example: 100
+        fiatCurrency:
+          type: string
+          example: USD
+        cryptoAmount:
+          type: number
+          nullable: true
+          example: 98.5
+        assetSymbol:
+          type: string
+          example: USDC
+        status:
+          $ref: '#/components/schemas/FiatOrderStatus'
+        checkoutUrl:
+          type: string
+          nullable: true
+        kycUrl:
+          type: string
+          nullable: true
+        transactionId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Linked on-chain transaction once settled
+        failureReason:
+          type: string
+          nullable: true
+        settledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
   responses:
     Unauthorized:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:unit": "jest tests/unit",
     "test:integration": "jest tests/integration",
     "prisma:generate": "npx prisma generate",
-    "prepare": "husky"
+    "prepare": "husky",
     "test:cors": "jest tests/cors.test.ts",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/prisma/migrations/20260717000000_add_fiat_orders/migration.sql
+++ b/prisma/migrations/20260717000000_add_fiat_orders/migration.sql
@@ -1,0 +1,49 @@
+-- CreateEnum
+CREATE TYPE "FiatDirection" AS ENUM ('ON_RAMP', 'OFF_RAMP');
+
+-- CreateEnum
+CREATE TYPE "FiatOrderStatus" AS ENUM ('PENDING', 'PROCESSING', 'SETTLED', 'FAILED', 'REFUNDED');
+
+-- CreateTable
+CREATE TABLE "fiat_orders" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerOrderId" TEXT NOT NULL,
+    "direction" "FiatDirection" NOT NULL,
+    "fiatAmount" DECIMAL(36,18) NOT NULL,
+    "fiatCurrency" TEXT NOT NULL,
+    "cryptoAmount" DECIMAL(36,18),
+    "assetSymbol" TEXT NOT NULL,
+    "status" "FiatOrderStatus" NOT NULL DEFAULT 'PENDING',
+    "transactionId" TEXT,
+    "checkoutUrl" TEXT,
+    "kycUrl" TEXT,
+    "failureReason" TEXT,
+    "settledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "fiat_orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "fiat_orders_userId_idx" ON "fiat_orders"("userId");
+
+-- CreateIndex
+CREATE INDEX "fiat_orders_provider_providerOrderId_idx" ON "fiat_orders"("provider", "providerOrderId");
+
+-- CreateIndex
+CREATE INDEX "fiat_orders_status_idx" ON "fiat_orders"("status");
+
+-- CreateIndex
+CREATE INDEX "fiat_orders_createdAt_idx" ON "fiat_orders"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "fiat_orders_provider_providerOrderId_key" ON "fiat_orders"("provider", "providerOrderId");
+
+-- AddForeignKey
+ALTER TABLE "fiat_orders" ADD CONSTRAINT "fiat_orders_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "fiat_orders" ADD CONSTRAINT "fiat_orders_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "transactions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260717000000_add_fiat_orders/rollback.sql
+++ b/prisma/migrations/20260717000000_add_fiat_orders/rollback.sql
@@ -1,0 +1,13 @@
+-- Rollback for 20260717000000_add_fiat_orders
+-- Drops the fiat_orders table and its enums (#290).
+-- WARNING: Destroys all fiat on-ramp/off-ramp order metadata and status history.
+
+ALTER TABLE "fiat_orders" DROP CONSTRAINT IF EXISTS "fiat_orders_transactionId_fkey";
+
+ALTER TABLE "fiat_orders" DROP CONSTRAINT IF EXISTS "fiat_orders_userId_fkey";
+
+DROP TABLE IF EXISTS "fiat_orders";
+
+DROP TYPE IF EXISTS "FiatOrderStatus";
+
+DROP TYPE IF EXISTS "FiatDirection";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,19 @@ enum DeadLetterEventStatus {
   RESOLVED
 }
 
+enum FiatDirection {
+  ON_RAMP
+  OFF_RAMP
+}
+
+enum FiatOrderStatus {
+  PENDING
+  PROCESSING
+  SETTLED
+  FAILED
+  REFUNDED
+}
+
 model User {
   id            String   @id @default(uuid())
   walletAddress String   @unique
@@ -77,6 +90,7 @@ model User {
   transactions          Transaction[]
   agentLogs             AgentLog[]
   webhookSubscriptions  WebhookSubscription[]
+  fiatOrders            FiatOrder[]
 
   @@map("users")
 }
@@ -190,6 +204,7 @@ model Transaction {
 
   user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   position Position? @relation(fields: [positionId], references: [id])
+  fiatOrders FiatOrder[]
 
   @@index([userId])
   @@index([positionId])
@@ -372,4 +387,40 @@ model WebhookDelivery {
   @@index([status])
   @@index([createdAt])
   @@map("webhook_deliveries")
+}
+
+/// Fiat on-ramp / off-ramp order (#290).
+/// Tracks the off-chain payment leg of a fiat<->crypto conversion handled by a
+/// third-party provider (e.g. MoonPay). The on-chain settlement is reconciled
+/// against the existing Stellar event listener rather than trusting the
+/// provider's webhook alone. No plaintext bank/card details are ever stored
+/// here — the provider's hosted checkout captures all PII/payment details.
+model FiatOrder {
+  id              String          @id @default(uuid())
+  userId          String
+  provider        String          // e.g. "moonpay" — provider key, no provider-specific logic elsewhere
+  providerOrderId String
+  direction       FiatDirection
+  fiatAmount      Decimal         @db.Decimal(36, 18)
+  fiatCurrency    String
+  cryptoAmount    Decimal?        @db.Decimal(36, 18)
+  assetSymbol     String
+  status          FiatOrderStatus @default(PENDING)
+  transactionId   String?         // linked once the resulting on-chain Transaction is matched
+  checkoutUrl     String?         // provider hosted checkout URL (on-ramp)
+  kycUrl          String?         // provider KYC next-step link, surfaced to the user when required
+  failureReason   String?         // populated on FAILED/REFUNDED for operator/user visibility
+  settledAt       DateTime?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  transaction Transaction? @relation(fields: [transactionId], references: [id])
+
+  @@unique([provider, providerOrderId])
+  @@index([userId])
+  @@index([provider, providerOrderId])
+  @@index([status])
+  @@index([createdAt])
+  @@map("fiat_orders")
 }

--- a/src/fiat/providers/moonpay.ts
+++ b/src/fiat/providers/moonpay.ts
@@ -1,0 +1,216 @@
+/**
+ * MoonPay fiat ramp provider (#290) — the one concrete implementation shipped
+ * in v1. Everything MoonPay-specific (endpoints, request/response shapes, and
+ * the webhook signature scheme) is contained here, behind FiatRampProvider.
+ *
+ * Webhook verification follows MoonPay's `Moonpay-Signature-V2` scheme: an
+ * HMAC-SHA256 over `${timestamp}.${rawBody}` keyed by the webhook secret, with
+ * the header formatted as `t=<unix-seconds>,s=<hex-signature>`. We compare with
+ * a timing-safe equality check and never throw from verification.
+ * https://dev.moonpay.com/docs/webhooks-verify-signature
+ */
+import { createHmac, timingSafeEqual } from 'crypto'
+import { logger } from '../../utils/logger'
+import { HttpClientAdapter } from '../../utils/http-client'
+import { config } from '../../config/env'
+import {
+  CreateOrderRequest,
+  CreateOrderResult,
+  FiatRampProvider,
+  NormalizedWebhookStatus,
+  ParsedWebhook,
+  QuoteRequest,
+  QuoteResult,
+} from '../types'
+
+const PROVIDER_NAME = 'moonpay'
+
+/** Map MoonPay's raw transaction statuses onto our normalized set. */
+function normalizeStatus(raw: string | undefined): NormalizedWebhookStatus {
+  switch ((raw || '').toLowerCase()) {
+    case 'completed':
+      return 'SETTLED'
+    case 'pending':
+      return 'PROCESSING'
+    case 'waitingpayment':
+    case 'waitingauthorization':
+      return 'PENDING'
+    case 'failed':
+      return 'FAILED'
+    case 'refunded':
+    case 'chargedback':
+      return 'REFUNDED'
+    default:
+      return 'PENDING'
+  }
+}
+
+/** Parse the `t=...,s=...` signature header into its parts. */
+function parseSignatureHeader(header: string | undefined): { timestamp: string; signature: string } | null {
+  if (!header) return null
+  const parts = header.split(',').map((p) => p.trim())
+  let timestamp = ''
+  let signature = ''
+  for (const part of parts) {
+    const [k, v] = part.split('=')
+    if (k === 't') timestamp = v
+    if (k === 's') signature = v
+  }
+  if (!timestamp || !signature) return null
+  return { timestamp, signature }
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  // Length mismatch => not equal, and avoid Buffer length throw in timingSafeEqual.
+  if (a.length !== b.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'))
+  } catch {
+    return false
+  }
+}
+
+export class MoonPayProvider implements FiatRampProvider {
+  readonly name = PROVIDER_NAME
+
+  private readonly apiKey: string
+  private readonly secretKey: string
+  private readonly webhookKey: string
+  private readonly baseUrl: string
+  private readonly http: HttpClientAdapter
+
+  constructor(opts?: { apiKey?: string; secretKey?: string; webhookKey?: string; baseUrl?: string }) {
+    this.apiKey = opts?.apiKey ?? process.env.MOONPAY_API_KEY ?? ''
+    this.secretKey = opts?.secretKey ?? process.env.MOONPAY_SECRET_KEY ?? ''
+    this.webhookKey = opts?.webhookKey ?? process.env.MOONPAY_WEBHOOK_KEY ?? ''
+    this.baseUrl = opts?.baseUrl ?? process.env.MOONPAY_API_BASE_URL ?? 'https://api.moonpay.com'
+    this.http = new HttpClientAdapter({
+      timeoutMs: config.httpClient.timeoutMs,
+      maxRetries: config.httpClient.maxRetries,
+      baseDelayMs: config.httpClient.baseDelayMs,
+      maxDelayMs: config.httpClient.maxDelayMs,
+      circuitBreakerThreshold: config.httpClient.circuitBreakerThreshold,
+      circuitBreakerResetMs: config.httpClient.circuitBreakerResetMs,
+    })
+  }
+
+  async getQuote(req: QuoteRequest): Promise<QuoteResult> {
+    const isBuy = req.direction === 'ON_RAMP'
+    const currencyCode = req.assetSymbol.toLowerCase()
+    const baseCurrencyCode = req.fiatCurrency.toLowerCase()
+    const amountParam = isBuy ? 'baseCurrencyAmount' : 'quoteCurrencyAmount'
+
+    const url =
+      `${this.baseUrl}/v3/currencies/${encodeURIComponent(currencyCode)}/${isBuy ? 'buy_quote' : 'sell_quote'}` +
+      `?apiKey=${encodeURIComponent(this.apiKey)}` +
+      `&baseCurrencyCode=${encodeURIComponent(baseCurrencyCode)}` +
+      `&${amountParam}=${encodeURIComponent(String(req.fiatAmount))}`
+
+    const data = await this.http.execute(async () => {
+      const res = await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } })
+      if (!res.ok) {
+        throw new Error(`MoonPay quote failed: HTTP ${res.status}`)
+      }
+      return (await res.json()) as Record<string, unknown>
+    }, 'moonpay.getQuote')
+
+    const cryptoAmount = Number(data.quoteCurrencyAmount ?? data.cryptoAmount ?? 0)
+    const feeAmount = Number(data.feeAmount ?? 0) || undefined
+    const rate = Number(data.exchangeRate ?? data.rate ?? 0) || undefined
+
+    return {
+      provider: this.name,
+      direction: req.direction,
+      fiatAmount: req.fiatAmount,
+      fiatCurrency: req.fiatCurrency,
+      assetSymbol: req.assetSymbol,
+      cryptoAmount,
+      feeAmount,
+      rate,
+    }
+  }
+
+  async createOrder(req: CreateOrderRequest): Promise<CreateOrderResult> {
+    // MoonPay's primary integration is a hosted widget; server-side we register
+    // a transaction intent and hand back the hosted checkout URL. We POST the
+    // intent and read the provider order id + status back.
+    const isBuy = req.direction === 'ON_RAMP'
+    const endpoint = `${this.baseUrl}/v3/transactions`
+
+    const body = JSON.stringify({
+      apiKey: this.apiKey,
+      flow: isBuy ? 'buy' : 'sell',
+      baseCurrencyCode: req.fiatCurrency.toLowerCase(),
+      currencyCode: req.assetSymbol.toLowerCase(),
+      baseCurrencyAmount: req.fiatAmount,
+      walletAddress: req.walletAddress,
+      externalCustomerId: req.userId,
+    })
+
+    const data = await this.http.execute(async () => {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Api-Key ${this.secretKey}`,
+        },
+        body,
+      })
+      if (!res.ok) {
+        throw new Error(`MoonPay createOrder failed: HTTP ${res.status}`)
+      }
+      return (await res.json()) as Record<string, unknown>
+    }, 'moonpay.createOrder')
+
+    const providerOrderId = String(data.id ?? '')
+    if (!providerOrderId) {
+      throw new Error('MoonPay createOrder returned no order id')
+    }
+
+    return {
+      providerOrderId,
+      checkoutUrl: (data.redirectUrl as string) ?? (data.widgetRedirectUrl as string) ?? undefined,
+      kycUrl: (data.kycRedirectUrl as string) ?? undefined,
+      status: normalizeStatus(data.status as string | undefined),
+      cryptoAmount: Number(data.quoteCurrencyAmount ?? 0) || undefined,
+    }
+  }
+
+  verifyWebhookSignature(rawBody: string, headers: Record<string, string | undefined>): boolean {
+    if (!this.webhookKey) {
+      // No configured secret means we cannot verify — reject rather than trust.
+      logger.error('[MoonPay] MOONPAY_WEBHOOK_KEY not configured — rejecting webhook')
+      return false
+    }
+
+    const header =
+      headers['moonpay-signature-v2'] ??
+      headers['Moonpay-Signature-V2'] ??
+      headers['x-moonpay-signature-v2']
+    const parsed = parseSignatureHeader(header)
+    if (!parsed) return false
+
+    const signedPayload = `${parsed.timestamp}.${rawBody}`
+    const expected = createHmac('sha256', this.webhookKey).update(signedPayload).digest('hex')
+
+    return timingSafeEqualHex(expected, parsed.signature)
+  }
+
+  parseWebhookPayload(rawBody: string): ParsedWebhook {
+    const parsed = JSON.parse(rawBody) as Record<string, any>
+    // MoonPay wraps the resource under `data` with a top-level `type`.
+    const data = (parsed.data ?? parsed) as Record<string, any>
+
+    const providerOrderId = String(data.id ?? parsed.externalTransactionId ?? '')
+    const status = normalizeStatus(data.status as string | undefined)
+
+    return {
+      providerOrderId,
+      status: data.kycRedirectUrl && status !== 'SETTLED' ? 'KYC_REQUIRED' : status,
+      txHash: (data.cryptoTransactionId as string) ?? (data.txHash as string) ?? undefined,
+      cryptoAmount: Number(data.quoteCurrencyAmount ?? data.cryptoAmount ?? 0) || undefined,
+      kycUrl: (data.kycRedirectUrl as string) ?? undefined,
+      reason: (data.failureReason as string) ?? undefined,
+    }
+  }
+}

--- a/src/fiat/registry.ts
+++ b/src/fiat/registry.ts
@@ -1,0 +1,50 @@
+/**
+ * Fiat provider registry (#290).
+ *
+ * The single lookup point that maps a provider key to a {@link FiatRampProvider}
+ * implementation. Route handlers and the reconciliation service resolve
+ * providers exclusively through here, so adding a second vendor is a one-line
+ * registry change with no edits to call sites.
+ *
+ * `getDefaultProvider()` returns the configured active provider for new orders;
+ * `getProvider(name)` resolves the provider a stored order was created with, so
+ * webhooks/reconciliation always use the same vendor that opened the order.
+ */
+import { FiatRampProvider } from './types'
+import { MoonPayProvider } from './providers/moonpay'
+
+const registry = new Map<string, FiatRampProvider>()
+
+function register(provider: FiatRampProvider): void {
+  registry.set(provider.name, provider)
+}
+
+// v1 ships a single provider. Add further vendors here — nothing else changes.
+register(new MoonPayProvider())
+
+/** The provider key used for newly created orders. */
+export function defaultProviderName(): string {
+  return process.env.FIAT_DEFAULT_PROVIDER || 'moonpay'
+}
+
+/** Resolve a provider by key. Throws if the key is unknown/unconfigured. */
+export function getProvider(name: string): FiatRampProvider {
+  const provider = registry.get(name)
+  if (!provider) {
+    throw new Error(`Unknown fiat provider: "${name}"`)
+  }
+  return provider
+}
+
+/** Resolve the active default provider for new orders. */
+export function getDefaultProvider(): FiatRampProvider {
+  return getProvider(defaultProviderName())
+}
+
+/**
+ * Test/bootstrap seam: replace or add a provider implementation. Used by unit
+ * tests to inject a stub without going through env configuration.
+ */
+export function registerProvider(provider: FiatRampProvider): void {
+  register(provider)
+}

--- a/src/fiat/service.ts
+++ b/src/fiat/service.ts
@@ -1,0 +1,399 @@
+/**
+ * Fiat on-ramp / off-ramp service (#290).
+ *
+ * Design constraints baked in here:
+ *
+ *  1. Provider-agnostic. All vendor specifics live behind FiatRampProvider and
+ *     are resolved through the registry — this file never branches on a vendor.
+ *
+ *  2. The provider webhook is NOT trusted as proof of settlement. A provider
+ *     saying "completed" only advances an order to PROCESSING and records the
+ *     tx hash it claims. An order becomes SETTLED only once the crypto leg is
+ *     independently confirmed on-chain by the existing Stellar event listener
+ *     (which upserts a CONFIRMED Transaction row keyed by txHash). This closes
+ *     the gap where a provider reports success but funds never arrived — and
+ *     the inverse (funds arrive, webhook lost) is caught by reconciliation.
+ *
+ *  3. Webhook processing is idempotent. Providers retry deliveries; we key on
+ *     (provider, providerOrderId) and never double-apply a terminal state or
+ *     re-emit a webhook event for an already-settled order.
+ *
+ *  4. Refund/failed handling. FAILED/REFUNDED are terminal; we persist the
+ *     reason for user + operator visibility and emit an outbound webhook event.
+ */
+import db from '../db'
+import { logger } from '../utils/logger'
+import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { alertingService } from '../services/alerting'
+import { getDefaultProvider, getProvider } from './registry'
+import type {
+  CreateFiatOrderInput,
+  FiatQuoteInput,
+} from '../validators/fiat-validators'
+import type { NormalizedWebhookStatus, ParsedWebhook } from './types'
+
+/** How long a PENDING/PROCESSING order may sit before the age-out job fails it. */
+export const STALE_ORDER_MAX_AGE_MS = Number(
+  process.env.FIAT_STALE_ORDER_MAX_AGE_MS || 24 * 60 * 60 * 1000,
+)
+
+type Db = typeof db
+
+// ── Quotes ────────────────────────────────────────────────────────────────────
+
+export async function getFiatQuote(input: FiatQuoteInput) {
+  const provider = getDefaultProvider()
+  return provider.getQuote({
+    direction: input.direction,
+    fiatAmount: input.fiatAmount,
+    fiatCurrency: input.fiatCurrency,
+    assetSymbol: input.assetSymbol,
+  })
+}
+
+// ── Order creation ──────────────────────────────────────────────────────────
+
+export interface CreateOrderContext {
+  /** Authenticated user's custodial/destination Stellar address. */
+  walletAddress: string
+}
+
+export async function createFiatOrder(
+  input: CreateFiatOrderInput,
+  ctx: CreateOrderContext,
+  database: Db = db,
+) {
+  const provider = getDefaultProvider()
+
+  const created = await provider.createOrder({
+    userId: input.userId,
+    direction: input.direction,
+    fiatAmount: input.fiatAmount,
+    fiatCurrency: input.fiatCurrency,
+    assetSymbol: input.assetSymbol,
+    walletAddress: ctx.walletAddress,
+  })
+
+  const initialStatus = mapToOrderStatus(created.status)
+
+  const order = await (database as any).fiatOrder.create({
+    data: {
+      userId: input.userId,
+      provider: provider.name,
+      providerOrderId: created.providerOrderId,
+      direction: input.direction,
+      fiatAmount: input.fiatAmount,
+      fiatCurrency: input.fiatCurrency,
+      cryptoAmount: created.cryptoAmount ?? null,
+      assetSymbol: input.assetSymbol,
+      status: initialStatus,
+      checkoutUrl: created.checkoutUrl ?? null,
+      kycUrl: created.kycUrl ?? null,
+    },
+  })
+
+  logger.info('[Fiat] Order created', {
+    orderId: order.id,
+    provider: provider.name,
+    providerOrderId: created.providerOrderId,
+    direction: input.direction,
+    status: initialStatus,
+  })
+
+  return order
+}
+
+// ── Webhook processing (idempotent) ─────────────────────────────────────────
+
+export interface ProcessWebhookResult {
+  handled: boolean
+  reason?: string
+  orderId?: string
+  status?: string
+}
+
+/**
+ * Apply a verified, parsed provider webhook to the matching order.
+ *
+ * Idempotent: safe to call repeatedly for the same delivery. Terminal states
+ * (SETTLED/FAILED/REFUNDED) are never overwritten, and a provider "completed"
+ * callback only advances the order to PROCESSING — never SETTLED — because
+ * on-chain confirmation is authoritative (see reconcileFiatOrders).
+ */
+export async function processProviderWebhook(
+  providerName: string,
+  parsed: ParsedWebhook,
+  database: Db = db,
+): Promise<ProcessWebhookResult> {
+  if (!parsed.providerOrderId) {
+    return { handled: false, reason: 'missing providerOrderId' }
+  }
+
+  const order = await (database as any).fiatOrder.findUnique({
+    where: {
+      provider_providerOrderId: {
+        provider: providerName,
+        providerOrderId: parsed.providerOrderId,
+      },
+    },
+  })
+
+  if (!order) {
+    // Unknown order — acknowledge without side effects so the provider stops
+    // retrying, but log for investigation (could be a spoof or a cross-env id).
+    logger.warn('[Fiat] Webhook for unknown order', {
+      provider: providerName,
+      providerOrderId: parsed.providerOrderId,
+    })
+    return { handled: false, reason: 'unknown order' }
+  }
+
+  // Terminal states are immutable — drop duplicate/late deliveries.
+  if (isTerminal(order.status)) {
+    return { handled: true, reason: 'already terminal', orderId: order.id, status: order.status }
+  }
+
+  const data: Record<string, unknown> = { updatedAt: new Date() }
+
+  if (parsed.cryptoAmount != null && order.cryptoAmount == null) {
+    data.cryptoAmount = parsed.cryptoAmount
+  }
+  if (parsed.kycUrl) {
+    data.kycUrl = parsed.kycUrl
+  }
+
+  switch (parsed.status) {
+    case 'KYC_REQUIRED':
+      // Still open; surface the KYC link but keep the order actionable.
+      data.status = 'PENDING'
+      break
+    case 'PENDING':
+      data.status = 'PENDING'
+      break
+    case 'PROCESSING':
+    case 'SETTLED':
+      // Provider claims payment success. Do NOT mark SETTLED here — on-chain
+      // confirmation is authoritative. Advance to PROCESSING and stash the
+      // claimed tx hash so reconciliation can match it.
+      data.status = 'PROCESSING'
+      break
+    case 'FAILED':
+      data.status = 'FAILED'
+      data.failureReason = parsed.reason ?? 'Provider reported failure'
+      break
+    case 'REFUNDED':
+      data.status = 'REFUNDED'
+      data.failureReason = parsed.reason ?? 'Provider refunded the payment'
+      break
+  }
+
+  const updated = await (database as any).fiatOrder.update({
+    where: { id: order.id },
+    data,
+  })
+
+  // Emit outbound webhook for terminal failure/refund so subscribers react.
+  if (updated.status === 'FAILED' || updated.status === 'REFUNDED') {
+    dispatchWebhookEvent('fiat.order.failed', {
+      orderId: updated.id,
+      provider: providerName,
+      direction: updated.direction,
+      status: updated.status,
+      failureReason: updated.failureReason,
+      userId: updated.userId,
+    }).catch(() => {})
+  }
+
+  // If the provider handed us a tx hash, try an immediate reconciliation pass
+  // for this single order so settlement isn't delayed to the next sweep.
+  if (parsed.txHash && updated.status === 'PROCESSING') {
+    await reconcileSingleOrder(updated.id, parsed.txHash, database).catch((err) => {
+      logger.error('[Fiat] Inline reconciliation failed', {
+        orderId: updated.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    })
+  }
+
+  return { handled: true, orderId: updated.id, status: updated.status }
+}
+
+// ── Reconciliation against on-chain settlement ──────────────────────────────
+
+/**
+ * Try to settle one order against a specific claimed on-chain tx hash.
+ * Settles only when a CONFIRMED Transaction row exists for that hash — i.e.
+ * the Stellar event listener has independently observed the crypto leg.
+ */
+export async function reconcileSingleOrder(
+  orderId: string,
+  txHash: string,
+  database: Db = db,
+): Promise<boolean> {
+  const order = await (database as any).fiatOrder.findUnique({ where: { id: orderId } })
+  if (!order || isTerminal(order.status)) return false
+
+  const tx = await (database as any).transaction.findUnique({ where: { txHash } })
+  if (!tx || tx.status !== 'CONFIRMED') return false
+  if (tx.userId !== order.userId) {
+    // Hash belongs to a different user — never cross-link funds.
+    logger.error('[Fiat] Claimed txHash user mismatch — refusing to link', {
+      orderId,
+      txHash,
+      orderUser: order.userId,
+      txUser: tx.userId,
+    })
+    return false
+  }
+
+  const settled = await (database as any).fiatOrder.update({
+    where: { id: order.id },
+    data: {
+      status: 'SETTLED',
+      transactionId: tx.id,
+      settledAt: new Date(),
+      cryptoAmount: order.cryptoAmount ?? tx.amount,
+    },
+  })
+
+  logger.info('[Fiat] Order settled via on-chain confirmation', {
+    orderId: settled.id,
+    txHash,
+  })
+
+  dispatchWebhookEvent('fiat.order.settled', {
+    orderId: settled.id,
+    provider: settled.provider,
+    direction: settled.direction,
+    status: 'SETTLED',
+    txHash,
+    userId: settled.userId,
+  }).catch(() => {})
+
+  return true
+}
+
+/**
+ * Sweep PROCESSING orders and settle any whose crypto leg is now confirmed
+ * on-chain. Also emits an operational alert for orders the provider reported as
+ * paid but which have no matching confirmed on-chain transaction after the
+ * stale threshold — the "provider says settled, chain disagrees" case.
+ */
+export async function reconcileFiatOrders(database: Db = db): Promise<{
+  scanned: number
+  settled: number
+}> {
+  const processing = await (database as any).fiatOrder.findMany({
+    where: { status: 'PROCESSING' },
+    orderBy: { createdAt: 'asc' },
+    take: 500,
+  })
+
+  let settled = 0
+  for (const order of processing) {
+    // Match on any CONFIRMED transaction for this user + asset that isn't
+    // already linked to another fiat order. Provider-claimed hashes are handled
+    // inline at webhook time; here we catch lost-webhook / async-settlement.
+    const candidate = await (database as any).transaction.findFirst({
+      where: {
+        userId: order.userId,
+        assetSymbol: order.assetSymbol,
+        status: 'CONFIRMED',
+        fiatOrders: { none: {} },
+      },
+      orderBy: { confirmedAt: 'desc' },
+    })
+
+    if (candidate) {
+      const ok = await reconcileSingleOrder(order.id, candidate.txHash, database).catch(() => false)
+      if (ok) settled++
+      continue
+    }
+
+    // No on-chain match yet. If it's been stuck too long, alert operators —
+    // this is the provider-settled-but-chain-empty discrepancy.
+    const ageMs = Date.now() - new Date(order.createdAt).getTime()
+    if (ageMs > STALE_ORDER_MAX_AGE_MS) {
+      await alertingService
+        .emit(
+          {
+            title: 'Fiat order stuck in PROCESSING without on-chain settlement',
+            description:
+              `Order ${order.id} (${order.provider}/${order.providerOrderId}) has been ` +
+              `PROCESSING for ${Math.round(ageMs / 3_600_000)}h with no confirmed on-chain transaction.`,
+            severity: 'critical',
+            component: 'fiat-reconciliation',
+            metadata: {
+              orderId: order.id,
+              provider: order.provider,
+              providerOrderId: order.providerOrderId,
+              userId: order.userId,
+            },
+          },
+          `fiat:stuck:${order.id}`,
+        )
+        .catch(() => {})
+    }
+  }
+
+  return { scanned: processing.length, settled }
+}
+
+/**
+ * Age-out job: fail orders left PENDING (never paid) past the stale threshold
+ * so they don't linger forever. PROCESSING orders are left to reconciliation +
+ * alerting, because funds may still be in flight.
+ */
+export async function ageOutStaleFiatOrders(database: Db = db): Promise<{ failed: number }> {
+  const cutoff = new Date(Date.now() - STALE_ORDER_MAX_AGE_MS)
+
+  const stale = await (database as any).fiatOrder.findMany({
+    where: { status: 'PENDING', createdAt: { lt: cutoff } },
+    select: { id: true },
+    take: 500,
+  })
+
+  let failed = 0
+  for (const { id } of stale) {
+    await (database as any).fiatOrder.update({
+      where: { id },
+      data: {
+        status: 'FAILED',
+        failureReason: 'Order expired before payment was completed',
+        updatedAt: new Date(),
+      },
+    })
+    failed++
+  }
+
+  if (failed > 0) {
+    logger.info('[Fiat] Aged out stale PENDING orders', { failed })
+  }
+
+  return { failed }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function mapToOrderStatus(status: NormalizedWebhookStatus): string {
+  switch (status) {
+    case 'SETTLED':
+    case 'PROCESSING':
+      // Never persist SETTLED from a provider signal at creation.
+      return 'PROCESSING'
+    case 'FAILED':
+      return 'FAILED'
+    case 'REFUNDED':
+      return 'REFUNDED'
+    case 'KYC_REQUIRED':
+    case 'PENDING':
+    default:
+      return 'PENDING'
+  }
+}
+
+function isTerminal(status: string): boolean {
+  return status === 'SETTLED' || status === 'FAILED' || status === 'REFUNDED'
+}
+
+export { getProvider }

--- a/src/fiat/types.ts
+++ b/src/fiat/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Fiat on-ramp / off-ramp provider abstraction (#290).
+ *
+ * All provider-specific logic MUST live behind the {@link FiatRampProvider}
+ * interface so a second vendor can be added without touching route handlers or
+ * the reconciliation service. Nothing outside `src/fiat/providers/*` should
+ * branch on the provider name.
+ */
+
+export type FiatDirection = 'ON_RAMP' | 'OFF_RAMP'
+
+export interface QuoteRequest {
+  direction: FiatDirection
+  fiatAmount: number
+  fiatCurrency: string
+  assetSymbol: string
+}
+
+export interface QuoteResult {
+  /** Provider key this quote came from (e.g. "moonpay"). */
+  provider: string
+  direction: FiatDirection
+  fiatAmount: number
+  fiatCurrency: string
+  assetSymbol: string
+  /** Estimated crypto amount the user receives (on-ramp) or must send (off-ramp). */
+  cryptoAmount: number
+  /** Provider fee expressed in fiatCurrency, when the provider reports it. */
+  feeAmount?: number
+  /** Exchange rate used (crypto units per 1 fiat unit), when reported. */
+  rate?: number
+  /** When the quote stops being valid, if the provider pins one. */
+  expiresAt?: string
+}
+
+export interface CreateOrderRequest {
+  userId: string
+  direction: FiatDirection
+  fiatAmount: number
+  fiatCurrency: string
+  assetSymbol: string
+  /**
+   * Destination Stellar address for an on-ramp (funds land here), or the
+   * source custodial wallet for an off-ramp. The provider needs this to build
+   * the hosted checkout / payout.
+   */
+  walletAddress: string
+}
+
+export interface CreateOrderResult {
+  /** The provider's own order identifier — used as the idempotency key. */
+  providerOrderId: string
+  /** Hosted checkout URL the client redirects the user to (on-ramp). */
+  checkoutUrl?: string
+  /** KYC next-step URL when the provider blocks the order pending verification. */
+  kycUrl?: string
+  /** Initial provider-reported status, normalized. */
+  status: NormalizedWebhookStatus
+  /** Crypto amount quoted at creation time, if the provider commits to one. */
+  cryptoAmount?: number
+}
+
+/**
+ * Provider status callbacks are normalized into this closed set so the rest of
+ * the system never depends on a provider's raw status strings.
+ */
+export type NormalizedWebhookStatus =
+  | 'PENDING'
+  | 'PROCESSING'
+  | 'SETTLED'
+  | 'FAILED'
+  | 'REFUNDED'
+  | 'KYC_REQUIRED'
+
+export interface ParsedWebhook {
+  providerOrderId: string
+  status: NormalizedWebhookStatus
+  /** On-chain tx hash the provider claims settled the crypto leg, if provided. */
+  txHash?: string
+  cryptoAmount?: number
+  kycUrl?: string
+  /** Human-readable reason for FAILED/REFUNDED, when the provider supplies one. */
+  reason?: string
+}
+
+/**
+ * A fiat ramp vendor. Implementations are the ONLY place that may contain
+ * provider-specific request/response shapes or signature schemes.
+ */
+export interface FiatRampProvider {
+  /** Stable key persisted on FiatOrder.provider (e.g. "moonpay"). */
+  readonly name: string
+
+  /** Fetch a buy/sell quote. */
+  getQuote(req: QuoteRequest): Promise<QuoteResult>
+
+  /** Initiate the provider flow, returning a hosted checkout URL when relevant. */
+  createOrder(req: CreateOrderRequest): Promise<CreateOrderResult>
+
+  /**
+   * Verify the authenticity of a raw webhook request using the provider's own
+   * signature scheme. MUST return false (never throw) on any verification
+   * failure so callers can reject with no partial processing.
+   *
+   * @param rawBody The exact raw request body bytes as received.
+   * @param headers Incoming request headers (lower-cased keys).
+   */
+  verifyWebhookSignature(rawBody: string, headers: Record<string, string | undefined>): boolean
+
+  /** Parse a verified webhook body into the normalized shape. */
+  parseWebhookPayload(rawBody: string): ParsedWebhook
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { connectDb } from './db'
 import { scheduleSessionCleanup } from './jobs/sessionCleanup'
 import { scheduleDataRetention } from './jobs/dataRetention'
 import { schedulePoolMetrics } from './jobs/poolMetrics'
+import { scheduleFiatReconciliation } from './jobs/fiatReconciliation'
 import { startEventListener, stopEventListener } from './stellar/events'
 import { validateStellarNetworkReady } from './config/readiness'
 import healthRouter from './routes/health'
@@ -52,6 +53,7 @@ import adminRouter from './routes/admin'
 import metricsRouter from './routes/metrics'
 import stellarRouter from './routes/stellar'
 import webhooksRouter from './routes/webhooks'
+import fiatRouter from './routes/fiat'
 import { corsMiddleware, jsonBodyParser, payloadSizeErrorHandler, urlencodedBodyParser, contentTypeRestrictionMiddleware } from './middleware/corsandbody'
 import { setSpanUser } from './telemetry/spans'
 
@@ -73,6 +75,7 @@ let httpServer: Server | null = null
 let sessionCleanupHandle: NodeJS.Timeout | null = null
 let dataRetentionHandle: NodeJS.Timeout | null = null
 let poolMetricsHandle: NodeJS.Timeout | null = null
+let fiatReconciliationHandle: NodeJS.Timeout | null = null
 
 function allServicesReady(): boolean {
   return Object.values(serviceStatus).every(s => s.ready)
@@ -91,6 +94,14 @@ app.use(securityHeaders())
 app.use(permissionsPolicy())
 app.use(corsMiddleware)
 app.use(contentTypeRestrictionMiddleware)
+// Fiat provider webhooks are HMAC-signed over the raw request bytes. Capture the
+// raw body BEFORE the global JSON parser so signature verification sees the exact
+// payload — body-parser marks req._body here, so jsonBodyParser then skips these
+// paths. Must precede jsonBodyParser.
+app.use(
+  ['/api/v1/fiat/webhook', '/api/fiat/webhook'],
+  express.raw({ type: '*/*', limit: '1mb' }),
+)
 app.use(jsonBodyParser)
 app.use(urlencodedBodyParser)
 
@@ -224,6 +235,7 @@ const apiRoutes: ApiRoute[] = [
   { path: 'vault', handlers: [vaultRouter] },
   { path: 'analytics', handlers: [analyticsRouter] },
   { path: 'stellar', handlers: [stellarRouter] },
+  { path: 'fiat', handlers: [fiatRouter] },
   { path: 'admin', handlers: [adminRateLimiter, adminRouter] },
 ]
 
@@ -282,6 +294,12 @@ async function gracefulShutdown(signal: string): Promise<void> {
     clearInterval(poolMetricsHandle)
     poolMetricsHandle = null
     logger.info('[Shutdown] Pool metrics timer cleared')
+  }
+
+  if (fiatReconciliationHandle) {
+    clearInterval(fiatReconciliationHandle)
+    fiatReconciliationHandle = null
+    logger.info('[Shutdown] Fiat reconciliation timer cleared')
   }
 
   if (!httpServer) {
@@ -417,6 +435,7 @@ async function main(): Promise<void> {
   sessionCleanupHandle = scheduleSessionCleanup()
   dataRetentionHandle = scheduleDataRetention()
   poolMetricsHandle = schedulePoolMetrics()
+  fiatReconciliationHandle = scheduleFiatReconciliation()
 }
 
 // ── Process-level error guards ────────────────────────────────────────────────

--- a/src/jobs/fiatReconciliation.ts
+++ b/src/jobs/fiatReconciliation.ts
@@ -1,0 +1,67 @@
+import { logger, logBackgroundJob } from '../utils/logger'
+import { generateCorrelationId, runWithCorrelationIdAsync } from '../utils/correlation'
+import { recordBackgroundJob } from '../utils/metrics'
+import { recordJobSuccess, recordJobFailure } from '../utils/job-metrics'
+import { reconcileFiatOrders, ageOutStaleFiatOrders } from '../fiat/service'
+
+/** Interval between reconciliation sweeps (default: 5 minutes). */
+const FIAT_RECONCILE_INTERVAL_MS = Number(
+  process.env.FIAT_RECONCILE_INTERVAL_MS || 5 * 60 * 1000,
+)
+
+/**
+ * Reconcile PROCESSING fiat orders against confirmed on-chain transactions and
+ * age-out stale PENDING orders. Idempotent — safe to run repeatedly.
+ */
+export async function runFiatReconciliation(): Promise<void> {
+  const correlationId = generateCorrelationId()
+  return runWithCorrelationIdAsync(correlationId, async () => {
+    const startTime = Date.now()
+    const jobName = 'fiat_reconciliation'
+
+    try {
+      const { scanned, settled } = await reconcileFiatOrders()
+      const { failed } = await ageOutStaleFiatOrders()
+
+      const durationMs = Date.now() - startTime
+      const duration = durationMs / 1000
+
+      logBackgroundJob(jobName, 'success', duration, correlationId, {
+        scanned,
+        settled,
+        agedOut: failed,
+      })
+
+      recordBackgroundJob(jobName, 'success', duration)
+      recordJobSuccess(jobName, durationMs)
+    } catch (error) {
+      const durationMs = Date.now() - startTime
+      const duration = durationMs / 1000
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+      logBackgroundJob(jobName, 'failed', duration, correlationId, {
+        error: errorMessage,
+      })
+
+      recordBackgroundJob(jobName, 'failed', duration)
+      recordJobFailure(jobName, durationMs)
+    }
+  })
+}
+
+/**
+ * Schedule the fiat reconciliation job. Runs once at startup to catch anything
+ * that settled while offline, then on a fixed interval.
+ *
+ * @returns A NodeJS.Timeout handle (call clearInterval to stop it).
+ */
+export function scheduleFiatReconciliation(): NodeJS.Timeout {
+  runFiatReconciliation()
+
+  const handle = setInterval(runFiatReconciliation, FIAT_RECONCILE_INTERVAL_MS)
+
+  logger.info('[FiatReconciliation] Reconciliation scheduled', {
+    intervalMs: FIAT_RECONCILE_INTERVAL_MS,
+  })
+  return handle
+}

--- a/src/routes/fiat.ts
+++ b/src/routes/fiat.ts
@@ -1,0 +1,165 @@
+/**
+ * Fiat on-ramp / off-ramp routes (#290).
+ *
+ *   POST /api/fiat/quote            — auth; get a buy/sell quote
+ *   POST /api/fiat/orders           — auth; create an order, returns checkout URL
+ *   GET  /api/fiat/orders           — auth; caller's order history
+ *   GET  /api/fiat/orders/:id       — auth; single order (owner-scoped)
+ *   POST /api/fiat/webhook/:provider — provider callback (signature-verified, no JWT)
+ *
+ * The webhook route parses its own RAW body (express.raw) so the provider HMAC
+ * signature is verified over the exact received bytes — the global JSON parser
+ * would otherwise reshape the payload and break verification.
+ */
+import { Router, Request, Response } from 'express'
+import express from 'express'
+import { requireAuth, enforceUserAccess } from '../middleware/authenticate'
+import { validate } from '../middleware/validate'
+import { logger } from '../utils/logger'
+import { sendError } from '../utils/errors'
+import {
+  fiatQuoteSchema,
+  createFiatOrderSchema,
+} from '../validators/fiat-validators'
+import {
+  getFiatQuote,
+  createFiatOrder,
+  processProviderWebhook,
+} from '../fiat/service'
+import { getProvider } from '../fiat/registry'
+import db from '../db'
+
+const router = Router()
+
+// ── Quote ─────────────────────────────────────────────────────────────────────
+router.post(
+  '/quote',
+  requireAuth,
+  validate({ body: fiatQuoteSchema, errorMessage: 'Validation error' }),
+  async (req: Request, res: Response) => {
+    try {
+      const quote = await getFiatQuote(req.body)
+      return res.json(quote)
+    } catch (err) {
+      logger.error('[Fiat] Quote failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return sendError(res, 502, 'Failed to fetch quote from provider')
+    }
+  },
+)
+
+// ── Create order ────────────────────────────────────────────────────────────
+router.post(
+  '/orders',
+  requireAuth,
+  validate({ body: createFiatOrderSchema, errorMessage: 'Validation error' }),
+  enforceUserAccess,
+  async (req: Request, res: Response) => {
+    const walletAddress = req.auth?.walletAddress
+    if (!walletAddress) {
+      return sendError(res, 401, 'Unauthorized')
+    }
+
+    try {
+      const order = await createFiatOrder(req.body, { walletAddress })
+      return res.status(201).json(order)
+    } catch (err) {
+      logger.error('[Fiat] Order creation failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return sendError(res, 502, 'Failed to create order with provider')
+    }
+  },
+)
+
+// ── Order history (caller-scoped) ─────────────────────────────────────────────
+router.get('/orders', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.userId
+  if (!userId) return sendError(res, 401, 'Unauthorized')
+
+  const orders = await (db as any).fiatOrder.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+  return res.json({ orders })
+})
+
+// ── Single order (owner-scoped) ───────────────────────────────────────────────
+router.get('/orders/:id', requireAuth, async (req: Request, res: Response) => {
+  const userId = req.userId
+  if (!userId) return sendError(res, 401, 'Unauthorized')
+
+  const order = await (db as any).fiatOrder.findUnique({
+    where: { id: req.params.id },
+  })
+  if (!order || order.userId !== userId) {
+    // Don't leak existence of other users' orders — 404 either way.
+    return sendError(res, 404, 'Order not found')
+  }
+  return res.json(order)
+})
+
+// ── Provider webhook ──────────────────────────────────────────────────────────
+// Raw body parser scoped to this route only. No JWT: authenticity is proven by
+// the provider signature. Always ACK 2xx once verified so the provider stops
+// retrying, even when the order is unknown/terminal (handled idempotently).
+router.post(
+  '/webhook/:provider',
+  express.raw({ type: '*/*', limit: '1mb' }),
+  async (req: Request, res: Response) => {
+    const providerName = req.params.provider
+
+    let provider
+    try {
+      provider = getProvider(providerName)
+    } catch {
+      return sendError(res, 404, 'Unknown provider')
+    }
+
+    const rawBody = Buffer.isBuffer(req.body)
+      ? req.body.toString('utf8')
+      : typeof req.body === 'string'
+        ? req.body
+        : JSON.stringify(req.body ?? {})
+
+    // Normalize header keys to lower-case for the provider verifier.
+    const headers: Record<string, string | undefined> = {}
+    for (const [k, v] of Object.entries(req.headers)) {
+      headers[k.toLowerCase()] = Array.isArray(v) ? v[0] : v
+    }
+
+    if (!provider.verifyWebhookSignature(rawBody, headers)) {
+      logger.warn('[Fiat] Webhook signature verification failed', { provider: providerName })
+      return sendError(res, 401, 'Invalid signature')
+    }
+
+    let parsed
+    try {
+      parsed = provider.parseWebhookPayload(rawBody)
+    } catch (err) {
+      logger.error('[Fiat] Webhook payload parse failed', {
+        provider: providerName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return sendError(res, 400, 'Malformed webhook payload')
+    }
+
+    try {
+      const result = await processProviderWebhook(providerName, parsed)
+      // 200 regardless of handled/unknown — signature was valid; we don't want
+      // the provider retrying a well-formed, authenticated delivery.
+      return res.status(200).json({ received: true, ...result })
+    } catch (err) {
+      // Processing error (e.g. DB): 500 so the provider retries later.
+      logger.error('[Fiat] Webhook processing error', {
+        provider: providerName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return sendError(res, 500, 'Webhook processing failed')
+    }
+  },
+)
+
+export default router

--- a/src/validators/fiat-validators.ts
+++ b/src/validators/fiat-validators.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+/** Fiat on-ramp / off-ramp request validators (#290). */
+
+export const fiatDirectionSchema = z.enum(['ON_RAMP', 'OFF_RAMP'])
+
+// ISO 4217-ish: 3-letter currency code. Kept permissive (upper-cased) rather
+// than an exhaustive enum so new fiat currencies don't require a code change.
+const fiatCurrencySchema = z
+  .string()
+  .trim()
+  .length(3, 'fiatCurrency must be a 3-letter ISO code')
+  .transform((s) => s.toUpperCase())
+
+const assetSymbolSchema = z.string().trim().min(1).max(20)
+
+export const fiatQuoteSchema = z.object({
+  direction: fiatDirectionSchema,
+  fiatAmount: z.number().positive(),
+  fiatCurrency: fiatCurrencySchema,
+  assetSymbol: assetSymbolSchema,
+})
+
+export const createFiatOrderSchema = z.object({
+  userId: z.string().uuid(),
+  direction: fiatDirectionSchema,
+  fiatAmount: z.number().positive(),
+  fiatCurrency: fiatCurrencySchema,
+  assetSymbol: assetSymbolSchema,
+})
+
+export const fiatOrderHistoryParamsSchema = z.object({
+  userId: z.string().uuid(),
+})
+
+export type FiatQuoteInput = z.infer<typeof fiatQuoteSchema>
+export type CreateFiatOrderInput = z.infer<typeof createFiatOrderSchema>

--- a/src/validators/webhook-validators.ts
+++ b/src/validators/webhook-validators.ts
@@ -10,6 +10,8 @@ const WEBHOOK_EVENTS = [
   'agent.rebalanced',
   'deposit.received',
   'withdraw.completed',
+  'fiat.order.settled',
+  'fiat.order.failed',
 ] as const;
 
 export const createWebhookSchema = z.object({

--- a/tests/integration/fiat.integration.test.ts
+++ b/tests/integration/fiat.integration.test.ts
@@ -1,0 +1,209 @@
+// #290 — Fiat routes integration test. Mounts the fiat router on a minimal
+// Express app with the auth middleware and service layer mocked, so it verifies
+// the HTTP wiring (validation, status codes, owner-scoping, and the raw-body
+// webhook signature path) without a live database or provider network calls.
+import request from 'supertest'
+import express from 'express'
+
+// --- Auth: stub requireAuth/enforceUserAccess to inject a fixed identity ------
+jest.mock('../../src/middleware/authenticate', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.userId = 'user-1'
+    req.auth = { userId: 'user-1', walletAddress: 'GWALLET_USER_1' }
+    next()
+  },
+  enforceUserAccess: (req: any, res: any, next: any) => {
+    const target = req.params.userId ?? req.body?.userId
+    if (target && target !== req.auth.userId) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    next()
+  },
+}))
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}))
+
+// --- Service layer: mock so no DB / provider network is touched ---------------
+const mockGetFiatQuote = jest.fn()
+const mockCreateFiatOrder = jest.fn()
+const mockProcessProviderWebhook = jest.fn()
+jest.mock('../../src/fiat/service', () => ({
+  getFiatQuote: (...a: unknown[]) => mockGetFiatQuote(...a),
+  createFiatOrder: (...a: unknown[]) => mockCreateFiatOrder(...a),
+  processProviderWebhook: (...a: unknown[]) => mockProcessProviderWebhook(...a),
+}))
+
+// --- Provider registry: a stub provider with controllable verification --------
+const mockVerify = jest.fn()
+const mockParse = jest.fn()
+jest.mock('../../src/fiat/registry', () => ({
+  getProvider: (name: string) => {
+    if (name !== 'moonpay') throw new Error(`Unknown fiat provider: "${name}"`)
+    return {
+      name: 'moonpay',
+      verifyWebhookSignature: (...a: unknown[]) => mockVerify(...a),
+      parseWebhookPayload: (...a: unknown[]) => mockParse(...a),
+    }
+  },
+}))
+
+// --- DB: history/detail routes read fiatOrder directly ------------------------
+jest.mock('../../src/db', () => ({
+  __esModule: true,
+  default: {
+    fiatOrder: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}))
+import db from '../../src/db'
+import fiatRouter from '../../src/routes/fiat'
+
+const mockDb = db as any
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/fiat', fiatRouter)
+  return app
+}
+
+const app = buildApp()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('POST /api/fiat/quote', () => {
+  it('returns a quote for a valid request', async () => {
+    mockGetFiatQuote.mockResolvedValue({ provider: 'moonpay', cryptoAmount: 98.5 })
+    const res = await request(app)
+      .post('/api/fiat/quote')
+      .send({ direction: 'ON_RAMP', fiatAmount: 100, fiatCurrency: 'usd', assetSymbol: 'USDC' })
+    expect(res.status).toBe(200)
+    expect(res.body.cryptoAmount).toBe(98.5)
+  })
+
+  it('rejects an invalid body with 400', async () => {
+    const res = await request(app)
+      .post('/api/fiat/quote')
+      .send({ direction: 'SIDEWAYS', fiatAmount: -5, fiatCurrency: 'usd', assetSymbol: 'USDC' })
+    expect(res.status).toBe(400)
+    expect(mockGetFiatQuote).not.toHaveBeenCalled()
+  })
+
+  it('returns 502 when the provider errors', async () => {
+    mockGetFiatQuote.mockRejectedValue(new Error('provider down'))
+    const res = await request(app)
+      .post('/api/fiat/quote')
+      .send({ direction: 'ON_RAMP', fiatAmount: 100, fiatCurrency: 'USD', assetSymbol: 'USDC' })
+    expect(res.status).toBe(502)
+  })
+})
+
+describe('POST /api/fiat/orders', () => {
+  it('creates an order for the authenticated user', async () => {
+    mockCreateFiatOrder.mockResolvedValue({ id: 'order-1', status: 'PENDING', checkoutUrl: 'https://pay' })
+    const res = await request(app)
+      .post('/api/fiat/orders')
+      .send({ userId: 'user-1', direction: 'ON_RAMP', fiatAmount: 100, fiatCurrency: 'USD', assetSymbol: 'USDC' })
+    expect(res.status).toBe(201)
+    expect(res.body.checkoutUrl).toBe('https://pay')
+    // The wallet address comes from the authenticated session, not the body.
+    expect(mockCreateFiatOrder).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ walletAddress: 'GWALLET_USER_1' }),
+    )
+  })
+
+  it('forbids creating an order on behalf of another user', async () => {
+    const res = await request(app)
+      .post('/api/fiat/orders')
+      .send({ userId: 'someone-else', direction: 'ON_RAMP', fiatAmount: 100, fiatCurrency: 'USD', assetSymbol: 'USDC' })
+    expect(res.status).toBe(403)
+    expect(mockCreateFiatOrder).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/fiat/orders', () => {
+  it('lists only the caller-scoped orders', async () => {
+    mockDb.fiatOrder.findMany.mockResolvedValue([{ id: 'order-1' }])
+    const res = await request(app).get('/api/fiat/orders')
+    expect(res.status).toBe(200)
+    expect(res.body.orders).toHaveLength(1)
+    expect(mockDb.fiatOrder.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'user-1' } }),
+    )
+  })
+})
+
+describe('GET /api/fiat/orders/:id', () => {
+  it('returns the order when owned by the caller', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue({ id: 'order-1', userId: 'user-1' })
+    const res = await request(app).get('/api/fiat/orders/order-1')
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBe('order-1')
+  })
+
+  it("returns 404 for another user's order (no existence leak)", async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue({ id: 'order-1', userId: 'other' })
+    const res = await request(app).get('/api/fiat/orders/order-1')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /api/fiat/webhook/:provider', () => {
+  it('returns 404 for an unknown provider', async () => {
+    const res = await request(app).post('/api/fiat/webhook/unknown').send({})
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects a delivery whose signature fails verification with 401', async () => {
+    mockVerify.mockReturnValue(false)
+    const res = await request(app)
+      .post('/api/fiat/webhook/moonpay')
+      .set('Content-Type', 'application/json')
+      .send({ data: { id: 'mp_1' } })
+    expect(res.status).toBe(401)
+    expect(mockProcessProviderWebhook).not.toHaveBeenCalled()
+  })
+
+  it('processes a verified delivery and ACKs 200', async () => {
+    mockVerify.mockReturnValue(true)
+    mockParse.mockReturnValue({ providerOrderId: 'mp_1', status: 'PROCESSING' })
+    mockProcessProviderWebhook.mockResolvedValue({ handled: true, orderId: 'order-1', status: 'PROCESSING' })
+    const res = await request(app)
+      .post('/api/fiat/webhook/moonpay')
+      .set('Content-Type', 'application/json')
+      .send({ data: { id: 'mp_1', status: 'pending' } })
+    expect(res.status).toBe(200)
+    expect(res.body.received).toBe(true)
+    expect(mockProcessProviderWebhook).toHaveBeenCalledWith('moonpay', { providerOrderId: 'mp_1', status: 'PROCESSING' })
+  })
+
+  it('returns 400 on a malformed (unparseable) payload', async () => {
+    mockVerify.mockReturnValue(true)
+    mockParse.mockImplementation(() => {
+      throw new Error('bad json')
+    })
+    const res = await request(app)
+      .post('/api/fiat/webhook/moonpay')
+      .set('Content-Type', 'application/json')
+      .send({ data: {} })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 when processing throws (provider should retry)', async () => {
+    mockVerify.mockReturnValue(true)
+    mockParse.mockReturnValue({ providerOrderId: 'mp_1', status: 'PROCESSING' })
+    mockProcessProviderWebhook.mockRejectedValue(new Error('db down'))
+    const res = await request(app)
+      .post('/api/fiat/webhook/moonpay')
+      .set('Content-Type', 'application/json')
+      .send({ data: { id: 'mp_1' } })
+    expect(res.status).toBe(500)
+  })
+})

--- a/tests/unit/fiat/moonpay.test.ts
+++ b/tests/unit/fiat/moonpay.test.ts
@@ -1,0 +1,102 @@
+// #290 — MoonPay provider unit tests: webhook signature verification, status
+// normalization, and payload parsing. No network calls are exercised here.
+import { createHmac } from 'crypto'
+import { MoonPayProvider } from '../../../src/fiat/providers/moonpay'
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+
+const WEBHOOK_KEY = 'whsec_test_key'
+
+function sign(rawBody: string, timestamp: string, key = WEBHOOK_KEY): string {
+  const sig = createHmac('sha256', key).update(`${timestamp}.${rawBody}`).digest('hex')
+  return `t=${timestamp},s=${sig}`
+}
+
+describe('MoonPayProvider.verifyWebhookSignature', () => {
+  const provider = new MoonPayProvider({ webhookKey: WEBHOOK_KEY })
+
+  it('accepts a correctly signed payload', () => {
+    const body = JSON.stringify({ type: 'transaction_updated', data: { id: 'mp_1', status: 'completed' } })
+    const ts = '1700000000'
+    const header = sign(body, ts)
+    expect(
+      provider.verifyWebhookSignature(body, { 'moonpay-signature-v2': header }),
+    ).toBe(true)
+  })
+
+  it('rejects a tampered body', () => {
+    const body = JSON.stringify({ data: { id: 'mp_1', status: 'completed' } })
+    const ts = '1700000000'
+    const header = sign(body, ts)
+    const tampered = JSON.stringify({ data: { id: 'mp_1', status: 'refunded' } })
+    expect(
+      provider.verifyWebhookSignature(tampered, { 'moonpay-signature-v2': header }),
+    ).toBe(false)
+  })
+
+  it('rejects a signature made with the wrong key', () => {
+    const body = JSON.stringify({ data: { id: 'mp_1' } })
+    const header = sign(body, '1700000000', 'wrong_key')
+    expect(
+      provider.verifyWebhookSignature(body, { 'moonpay-signature-v2': header }),
+    ).toBe(false)
+  })
+
+  it('rejects when the signature header is missing or malformed', () => {
+    const body = '{}'
+    expect(provider.verifyWebhookSignature(body, {})).toBe(false)
+    expect(provider.verifyWebhookSignature(body, { 'moonpay-signature-v2': 'garbage' })).toBe(false)
+    expect(provider.verifyWebhookSignature(body, { 'moonpay-signature-v2': 't=1' })).toBe(false)
+  })
+
+  it('rejects everything when no webhook key is configured', () => {
+    const noKey = new MoonPayProvider({ webhookKey: '' })
+    const body = '{}'
+    const header = sign(body, '1700000000', '')
+    expect(noKey.verifyWebhookSignature(body, { 'moonpay-signature-v2': header })).toBe(false)
+  })
+})
+
+describe('MoonPayProvider.parseWebhookPayload', () => {
+  const provider = new MoonPayProvider({ webhookKey: WEBHOOK_KEY })
+
+  it('normalizes a completed transaction to SETTLED and extracts the tx hash', () => {
+    const body = JSON.stringify({
+      type: 'transaction_updated',
+      data: { id: 'mp_42', status: 'completed', cryptoTransactionId: '0xabc', quoteCurrencyAmount: 98.5 },
+    })
+    const parsed = provider.parseWebhookPayload(body)
+    expect(parsed).toMatchObject({
+      providerOrderId: 'mp_42',
+      status: 'SETTLED',
+      txHash: '0xabc',
+      cryptoAmount: 98.5,
+    })
+  })
+
+  it('maps waitingPayment to PENDING', () => {
+    const body = JSON.stringify({ data: { id: 'mp_1', status: 'waitingPayment' } })
+    expect(provider.parseWebhookPayload(body).status).toBe('PENDING')
+  })
+
+  it('maps failed to FAILED and carries the reason', () => {
+    const body = JSON.stringify({ data: { id: 'mp_1', status: 'failed', failureReason: 'card_declined' } })
+    const parsed = provider.parseWebhookPayload(body)
+    expect(parsed.status).toBe('FAILED')
+    expect(parsed.reason).toBe('card_declined')
+  })
+
+  it('maps refunded/chargedback to REFUNDED', () => {
+    expect(provider.parseWebhookPayload(JSON.stringify({ data: { id: 'a', status: 'refunded' } })).status).toBe('REFUNDED')
+    expect(provider.parseWebhookPayload(JSON.stringify({ data: { id: 'b', status: 'chargedback' } })).status).toBe('REFUNDED')
+  })
+
+  it('flags KYC_REQUIRED when a kyc redirect url is present and not yet settled', () => {
+    const body = JSON.stringify({ data: { id: 'mp_1', status: 'pending', kycRedirectUrl: 'https://kyc' } })
+    const parsed = provider.parseWebhookPayload(body)
+    expect(parsed.status).toBe('KYC_REQUIRED')
+    expect(parsed.kycUrl).toBe('https://kyc')
+  })
+})

--- a/tests/unit/fiat/service.test.ts
+++ b/tests/unit/fiat/service.test.ts
@@ -1,0 +1,242 @@
+// #290 — Fiat service unit tests. These pin the safety-critical invariants:
+//   * a provider "completed" webhook advances to PROCESSING, never SETTLED
+//   * settlement requires an independently CONFIRMED on-chain transaction
+//   * webhook processing is idempotent (terminal states are immutable)
+//   * a claimed tx hash belonging to another user is never linked
+//   * stale PENDING orders are aged out to FAILED
+import db from '../../../src/db'
+import { dispatchWebhookEvent } from '../../../src/services/webhookDispatcher'
+import { alertingService } from '../../../src/services/alerting'
+import {
+  processProviderWebhook,
+  reconcileSingleOrder,
+  reconcileFiatOrders,
+  ageOutStaleFiatOrders,
+  STALE_ORDER_MAX_AGE_MS,
+} from '../../../src/fiat/service'
+import type { ParsedWebhook } from '../../../src/fiat/types'
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}))
+jest.mock('../../../src/services/webhookDispatcher', () => ({
+  dispatchWebhookEvent: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../../../src/services/alerting', () => ({
+  alertingService: { emit: jest.fn().mockResolvedValue({ sent: true }) },
+}))
+
+const mockDb = db as any
+const mockDispatch = dispatchWebhookEvent as jest.Mock
+const mockEmit = alertingService.emit as jest.Mock
+
+function baseOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'order-1',
+    userId: 'user-1',
+    provider: 'moonpay',
+    providerOrderId: 'mp_1',
+    direction: 'ON_RAMP',
+    assetSymbol: 'USDC',
+    cryptoAmount: null,
+    status: 'PENDING',
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockDb.fiatOrder = {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+    create: jest.fn(),
+  }
+  mockDb.transaction = {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+  }
+})
+
+describe('processProviderWebhook', () => {
+  it('advances a PROCESSING/completed signal to PROCESSING, never SETTLED', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder())
+    mockDb.fiatOrder.update.mockImplementation(({ data }: any) => ({ ...baseOrder(), ...data }))
+
+    const parsed: ParsedWebhook = { providerOrderId: 'mp_1', status: 'SETTLED' }
+    const res = await processProviderWebhook('moonpay', parsed)
+
+    expect(res.handled).toBe(true)
+    const updateArg = mockDb.fiatOrder.update.mock.calls[0][0]
+    expect(updateArg.data.status).toBe('PROCESSING')
+    expect(updateArg.data.status).not.toBe('SETTLED')
+  })
+
+  it('is idempotent — a terminal order is not mutated by a later delivery', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'SETTLED' }))
+
+    const res = await processProviderWebhook('moonpay', { providerOrderId: 'mp_1', status: 'FAILED' })
+
+    expect(res.handled).toBe(true)
+    expect(res.reason).toBe('already terminal')
+    expect(mockDb.fiatOrder.update).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges but does not act on an unknown order', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(null)
+
+    const res = await processProviderWebhook('moonpay', { providerOrderId: 'nope', status: 'FAILED' })
+
+    expect(res.handled).toBe(false)
+    expect(res.reason).toBe('unknown order')
+    expect(mockDb.fiatOrder.update).not.toHaveBeenCalled()
+  })
+
+  it('marks FAILED with a reason and emits an outbound webhook', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder())
+    mockDb.fiatOrder.update.mockImplementation(({ data }: any) => ({ ...baseOrder(), ...data }))
+
+    await processProviderWebhook('moonpay', {
+      providerOrderId: 'mp_1',
+      status: 'FAILED',
+      reason: 'card_declined',
+    })
+
+    const updateArg = mockDb.fiatOrder.update.mock.calls[0][0]
+    expect(updateArg.data.status).toBe('FAILED')
+    expect(updateArg.data.failureReason).toBe('card_declined')
+    expect(mockDispatch).toHaveBeenCalledWith('fiat.order.failed', expect.objectContaining({ status: 'FAILED' }))
+  })
+
+  it('rejects a webhook with no providerOrderId', async () => {
+    const res = await processProviderWebhook('moonpay', { providerOrderId: '', status: 'PENDING' })
+    expect(res.handled).toBe(false)
+    expect(mockDb.fiatOrder.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('runs inline reconciliation when a tx hash is supplied and the order goes PROCESSING', async () => {
+    mockDb.fiatOrder.findUnique
+      .mockResolvedValueOnce(baseOrder()) // webhook lookup
+      .mockResolvedValueOnce(baseOrder({ status: 'PROCESSING' })) // reconcileSingleOrder lookup
+    mockDb.fiatOrder.update.mockImplementation(({ data }: any) => ({ ...baseOrder(), ...data }))
+    mockDb.transaction.findUnique.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'CONFIRMED', userId: 'user-1', amount: 98.5,
+    })
+
+    await processProviderWebhook('moonpay', { providerOrderId: 'mp_1', status: 'SETTLED', txHash: '0xabc' })
+
+    // Second update is the settlement.
+    const settleCall = mockDb.fiatOrder.update.mock.calls.find((c: any) => c[0].data.status === 'SETTLED')
+    expect(settleCall).toBeDefined()
+    expect(settleCall[0].data.transactionId).toBe('tx-1')
+  })
+})
+
+describe('reconcileSingleOrder', () => {
+  it('settles only when a CONFIRMED transaction exists for the same user', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'PROCESSING' }))
+    mockDb.transaction.findUnique.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'CONFIRMED', userId: 'user-1', amount: 100,
+    })
+    mockDb.fiatOrder.update.mockImplementation(({ data }: any) => ({ ...baseOrder(), ...data }))
+
+    const ok = await reconcileSingleOrder('order-1', '0xabc')
+
+    expect(ok).toBe(true)
+    expect(mockDb.fiatOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'SETTLED', transactionId: 'tx-1' }) }),
+    )
+    expect(mockDispatch).toHaveBeenCalledWith('fiat.order.settled', expect.objectContaining({ txHash: '0xabc' }))
+  })
+
+  it('does not settle when the transaction is not yet CONFIRMED', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'PROCESSING' }))
+    mockDb.transaction.findUnique.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'PENDING', userId: 'user-1', amount: 100,
+    })
+
+    const ok = await reconcileSingleOrder('order-1', '0xabc')
+
+    expect(ok).toBe(false)
+    expect(mockDb.fiatOrder.update).not.toHaveBeenCalled()
+  })
+
+  it('refuses to link a tx hash that belongs to a different user', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'PROCESSING' }))
+    mockDb.transaction.findUnique.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'CONFIRMED', userId: 'attacker', amount: 100,
+    })
+
+    const ok = await reconcileSingleOrder('order-1', '0xabc')
+
+    expect(ok).toBe(false)
+    expect(mockDb.fiatOrder.update).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for an already-terminal order', async () => {
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'SETTLED' }))
+    const ok = await reconcileSingleOrder('order-1', '0xabc')
+    expect(ok).toBe(false)
+    expect(mockDb.transaction.findUnique).not.toHaveBeenCalled()
+  })
+})
+
+describe('reconcileFiatOrders', () => {
+  it('settles PROCESSING orders that now have a confirmed on-chain match', async () => {
+    mockDb.fiatOrder.findMany.mockResolvedValue([baseOrder({ status: 'PROCESSING' })])
+    mockDb.transaction.findFirst.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'CONFIRMED', userId: 'user-1', amount: 100,
+    })
+    // reconcileSingleOrder re-reads the order + tx.
+    mockDb.fiatOrder.findUnique.mockResolvedValue(baseOrder({ status: 'PROCESSING' }))
+    mockDb.transaction.findUnique.mockResolvedValue({
+      id: 'tx-1', txHash: '0xabc', status: 'CONFIRMED', userId: 'user-1', amount: 100,
+    })
+    mockDb.fiatOrder.update.mockImplementation(({ data }: any) => ({ ...baseOrder(), ...data }))
+
+    const res = await reconcileFiatOrders()
+
+    expect(res.scanned).toBe(1)
+    expect(res.settled).toBe(1)
+  })
+
+  it('alerts when a PROCESSING order is stuck past the stale threshold with no on-chain match', async () => {
+    const stale = baseOrder({
+      status: 'PROCESSING',
+      createdAt: new Date(Date.now() - STALE_ORDER_MAX_AGE_MS - 1000),
+    })
+    mockDb.fiatOrder.findMany.mockResolvedValue([stale])
+    mockDb.transaction.findFirst.mockResolvedValue(null)
+
+    const res = await reconcileFiatOrders()
+
+    expect(res.settled).toBe(0)
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'critical', component: 'fiat-reconciliation' }),
+      expect.stringContaining('fiat:stuck:'),
+    )
+  })
+})
+
+describe('ageOutStaleFiatOrders', () => {
+  it('fails PENDING orders older than the stale threshold', async () => {
+    mockDb.fiatOrder.findMany.mockResolvedValue([{ id: 'order-1' }, { id: 'order-2' }])
+    mockDb.fiatOrder.update.mockResolvedValue({})
+
+    const res = await ageOutStaleFiatOrders()
+
+    expect(res.failed).toBe(2)
+    expect(mockDb.fiatOrder.update).toHaveBeenCalledTimes(2)
+    const firstData = mockDb.fiatOrder.update.mock.calls[0][0].data
+    expect(firstData.status).toBe('FAILED')
+  })
+
+  it('does nothing when there are no stale orders', async () => {
+    mockDb.fiatOrder.findMany.mockResolvedValue([])
+    const res = await ageOutStaleFiatOrders()
+    expect(res.failed).toBe(0)
+    expect(mockDb.fiatOrder.update).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
closes #290 
Add a provider-agnostic fiat on-ramp/off-ramp feature:

- FiatOrder model + FiatDirection/FiatOrderStatus enums, migration + rollback
- FiatRampProvider interface; all vendor specifics live behind it, resolved via a registry (MoonPay shipped as the one v1 implementation)
- Routes: POST /api/fiat/quote, POST/GET /api/fiat/orders, GET /api/fiat/orders/:id, POST /api/fiat/webhook/:provider
- Webhook signature verified per MoonPay's HMAC scheme over the raw body (raw parser mounted before the global JSON parser); idempotent processing
- Settlement is authoritative on-chain: a provider "completed" callback only advances an order to PROCESSING; SETTLED requires an independently CONFIRMED Transaction, reconciled against the existing event listener's output
- Reconciliation + stale-order age-out background job; operational alert when a PROCESSING order has no on-chain match past the stale threshold
- Refund/failed terminal handling; outbound fiat.order.settled/failed webhooks
- OpenAPI spec updated (fiat tag, paths, schemas)
- Unit tests (MoonPay signature/parse, service invariants) + route integration tests covering validation, owner-scoping, and the webhook signature path

Note: fixes a pre-existing JSON syntax error in package.json (missing comma) that otherwise prevents any tooling from parsing the manifest.