### PR TITLE
feat: goal-based investing (savings goals)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -54,6 +54,8 @@ tags:
     description: Fiat on-ramp / off-ramp (buy and sell crypto with fiat via a payment provider)
   - name: referrals
     description: Referral rewards program (share a code, earn when referred users deposit)
+  - name: goals
+    description: Goal-based investing — a target amount + date driving the agent's strategy selection
   - name: admin
     description: Admin-only management endpoints
   - name: metrics
@@ -473,6 +475,217 @@ paths:
                 totalEarnings: 523.40
                 periodEarnings: 85.20
                 averageApy: 4.23
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ── Goal-based investing (#281) ─────────────────────────────────────────────
+  /api/v1/portfolio/goals:
+    post:
+      tags: [goals]
+      operationId: createGoal
+      summary: Create the caller's savings goal
+      description: |
+        Creates a savings goal for the authenticated user. Only one ACTIVE goal
+        per user is allowed at a time — returns 409 if one already exists.
+        `startingAmount` defaults to the current value of `positionId` (or the
+        sum of the user's active positions if omitted). If the target is
+        already met by the starting amount, the goal is created directly with
+        status ACHIEVED.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [targetAmount, targetDate]
+              properties:
+                targetAmount:
+                  type: number
+                  description: Must be greater than startingAmount
+                targetDate:
+                  type: string
+                  format: date-time
+                  description: Must be in the future
+                startingAmount:
+                  type: number
+                positionId:
+                  type: string
+                  format: uuid
+                riskCeiling:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+              example:
+                targetAmount: 10000
+                targetDate: '2027-07-21T00:00:00.000Z'
+      responses:
+        '201':
+          description: Goal created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  goal:
+                    $ref: '#/components/schemas/SavingsGoal'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/portfolio/goals/{id}:
+    get:
+      tags: [goals]
+      operationId: getGoal
+      summary: Get the user's current savings goal
+      description: |
+        Returns the user's ACTIVE goal if one exists, otherwise their most
+        recently created goal. The authenticated user can only access their
+        own goal (enforceUserAccess). NOTE: for this operation only, `id` is
+        the **user's** ID, not a goal ID — documented under the same path
+        item as PATCH/DELETE below (which take a goal ID) since they share the
+        same route shape, differentiated by HTTP method.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User ID (UUID v4) — see note above
+      responses:
+        '200':
+          description: Savings goal
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  goal:
+                    $ref: '#/components/schemas/SavingsGoal'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [goals]
+      operationId: updateGoal
+      summary: Update a savings goal
+      description: |
+        Updates target amount/date/riskCeiling on an ACTIVE goal. This route is
+        keyed by goal id rather than :userId, so ownership is checked
+        explicitly (goal.userId must match the authenticated caller) instead of
+        via enforceUserAccess.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Goal ID (UUID v4)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetAmount:
+                  type: number
+                targetDate:
+                  type: string
+                  format: date-time
+                riskCeiling:
+                  type: integer
+                  minimum: 0
+                  maximum: 100
+      responses:
+        '200':
+          description: Updated goal
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  goal:
+                    $ref: '#/components/schemas/SavingsGoal'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [goals]
+      operationId: cancelGoal
+      summary: Cancel a savings goal
+      description: |
+        Soft-cancels a goal (sets status = CANCELLED) — never hard-deletes.
+        Ownership is checked explicitly, as with PATCH.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Goal ID (UUID v4)
+      responses:
+        '200':
+          description: Cancelled goal
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  goal:
+                    $ref: '#/components/schemas/SavingsGoal'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/portfolio/goals/{id}/progress:
+    get:
+      tags: [goals]
+      operationId: getGoalProgress
+      summary: Get a savings goal's trajectory
+      description: |
+        Returns current progress, the simple annualized rate required to reach
+        the target by its date, the user's recent actual APY, a projected
+        completion date, and whether the target is reachable within the user's
+        configured risk ceiling. Ownership is checked explicitly, as with
+        PATCH/DELETE.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Goal ID (UUID v4)
+      responses:
+        '200':
+          description: Goal progress
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoalProgress'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -2423,6 +2636,77 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Position'
+
+    SavingsGoal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        positionId:
+          type: string
+          format: uuid
+          nullable: true
+        targetAmount:
+          type: number
+        startingAmount:
+          type: number
+        targetDate:
+          type: string
+          format: date-time
+        riskCeiling:
+          type: integer
+          nullable: true
+        status:
+          type: string
+          enum: [ACTIVE, ACHIEVED, MISSED, CANCELLED]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    GoalProgress:
+      type: object
+      properties:
+        goalId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [ACTIVE, ACHIEVED, MISSED, CANCELLED]
+        targetAmount:
+          type: number
+        startingAmount:
+          type: number
+        currentAmount:
+          type: number
+        targetDate:
+          type: string
+          format: date-time
+        requiredApy:
+          type: number
+          description: Simple annualized rate needed to reach the target by targetDate
+        actualApy:
+          type: number
+          description: Recent (30d) simple average APY the user is actually getting
+        onTrack:
+          type: boolean
+        reachable:
+          type: boolean
+          description: False when requiredApy exceeds the best APY available within the goal's risk ceiling
+        projectedCompletionDate:
+          type: string
+          format: date-time
+          nullable: true
+        note:
+          type: string
+        whatsappReply:
+          type: string
 
     Position:
       type: object

--- a/prisma/migrations/20260721000000_add_savings_goals/migration.sql
+++ b/prisma/migrations/20260721000000_add_savings_goals/migration.sql
@@ -1,0 +1,40 @@
+-- Goal-based investing (#281). Adds a SavingsGoal table so a user can state a
+-- target amount + date and have the agent's strategy selection driven by the
+-- gap between where they are and where they need to be.
+
+-- AlterEnum
+ALTER TYPE "AgentAction" ADD VALUE 'GOAL_PROGRESS';
+
+-- CreateEnum
+CREATE TYPE "GoalStatus" AS ENUM ('ACTIVE', 'ACHIEVED', 'MISSED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "savings_goals" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "positionId" TEXT,
+    "targetAmount" DECIMAL(36,18) NOT NULL,
+    "startingAmount" DECIMAL(36,18) NOT NULL,
+    "targetDate" TIMESTAMP(3) NOT NULL,
+    "riskCeiling" INTEGER,
+    "status" "GoalStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "savings_goals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "savings_goals_userId_idx" ON "savings_goals"("userId");
+
+-- CreateIndex
+CREATE INDEX "savings_goals_status_idx" ON "savings_goals"("status");
+
+-- CreateIndex
+CREATE INDEX "savings_goals_userId_status_idx" ON "savings_goals"("userId", "status");
+
+-- AddForeignKey
+ALTER TABLE "savings_goals" ADD CONSTRAINT "savings_goals_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "savings_goals" ADD CONSTRAINT "savings_goals_positionId_fkey" FOREIGN KEY ("positionId") REFERENCES "positions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,11 @@ enum AgentAction {
   ANALYZE
   ALERT
   CLAIM_YIELD
+  // Progress snapshot for an ACTIVE SavingsGoal (#281) — logged whenever the
+  // goal progress endpoint or strategy engine recomputes trajectory, so a
+  // goal's trend is inspectable via AgentLog the same way rebalance decisions
+  // already are.
+  GOAL_PROGRESS
 }
 
 enum AgentStatus {
@@ -82,6 +87,13 @@ enum ReferralStatus {
   EXPIRED
 }
 
+enum GoalStatus {
+  ACTIVE
+  ACHIEVED
+  MISSED
+  CANCELLED
+}
+
 model User {
   id            String   @id @default(uuid())
   walletAddress String   @unique
@@ -104,6 +116,7 @@ model User {
   fiatOrders            FiatOrder[]
   referralCode          ReferralCode?
   referralConversion    ReferralConversion?
+  savingsGoals          SavingsGoal[]
 
   @@map("users")
 }
@@ -190,6 +203,7 @@ model Position {
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   transactions   Transaction[]
   yieldSnapshots YieldSnapshot[]
+  savingsGoals   SavingsGoal[]
 
   @@index([userId])
   @@index([status])
@@ -518,4 +532,32 @@ model ReferralConversion {
   @@index([status])
   @@index([createdAt])
   @@map("referral_conversions")
+}
+
+/// Goal-based investing (#281). A user-stated target amount + date the agent's
+/// strategy selection is driven by. Required-rate projection reuses the same
+/// simple (non-compounding) APY convention as YieldSnapshot/calculateApy for
+/// consistency with live APY reporting — compounding-aware modeling is tracked
+/// separately (#225). One ACTIVE goal per user is enforced at the API layer,
+/// not via a DB constraint, since past goals (ACHIEVED/MISSED/CANCELLED) are
+/// kept for history.
+model SavingsGoal {
+  id             String     @id @default(uuid())
+  userId         String
+  positionId     String?
+  targetAmount   Decimal    @db.Decimal(36, 18)
+  startingAmount Decimal    @db.Decimal(36, 18)
+  targetDate     DateTime
+  riskCeiling    Int?       // optional min protocol risk score (0-100), matches UserStrategyPreferences.riskCeiling
+  status         GoalStatus @default(ACTIVE)
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+
+  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  position Position? @relation(fields: [positionId], references: [id])
+
+  @@index([userId])
+  @@index([status])
+  @@index([userId, status])
+  @@map("savings_goals")
 }

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -7,7 +7,7 @@ import { getCorrelationId } from '../utils/correlation';
 import { ProtocolComparison, RebalanceDetails, RebalanceThresholds, RebalanceStrategy, UserStrategyPreferences } from './types';
 import { scanAllProtocols, getCurrentOnChainApy } from './scanner';
 import { triggerRebalance as submitRebalance } from '../stellar/contract';
-import { MaxYieldStrategy, TargetAllocationStrategy } from './strategies';
+import { MaxYieldStrategy, TargetAllocationStrategy, GoalTrackingStrategy } from './strategies';
 import db from '../db';
 
 const DEFAULT_THRESHOLDS: RebalanceThresholds = {
@@ -32,6 +32,24 @@ async function loadProtocolRiskScores(): Promise<Record<string, number>> {
     map[row.protocolName] = row.score;
   }
   return map;
+}
+
+/**
+ * Load a user's ACTIVE savings goal (#281), if any. Only called when
+ * userStrategyPreferences are present, so users who never create a goal issue
+ * no extra query beyond this single lookup.
+ */
+async function loadActiveGoal(
+  userId: string,
+): Promise<{ targetAmount: number; startingAmount: number; targetDate: Date; riskCeiling: number | null } | null> {
+  const goal = await db.savingsGoal.findFirst({ where: { userId, status: 'ACTIVE' } });
+  if (!goal) return null;
+  return {
+    targetAmount: Number(goal.targetAmount),
+    startingAmount: Number(goal.startingAmount),
+    targetDate: goal.targetDate,
+    riskCeiling: goal.riskCeiling,
+  };
 }
 
 function toApyBasisPoints(apyPercent: number): number {
@@ -314,16 +332,26 @@ export async function executeRebalanceIfNeeded(
         return null;
       }
 
+      // An ACTIVE savings goal (#281) takes priority over the stored strategy
+      // preference — a user working toward a stated target/date should have
+      // the agent chase whatever rate that goal actually needs, not a static
+      // preference that predates the goal. Users with no goal fall through to
+      // the existing preference logic completely unchanged.
+      const goalUserId = userStrategyPreferences[0]?.userId;
+      const activeGoal = goalUserId ? await loadActiveGoal(goalUserId) : null;
+
       const preferredStrategy = userStrategyPreferences[0]?.strategyName;
-      const strategy: RebalanceStrategy =
-        preferredStrategy === 'TARGET_ALLOCATION'
+      const strategy: RebalanceStrategy = activeGoal
+        ? new GoalTrackingStrategy()
+        : preferredStrategy === 'TARGET_ALLOCATION'
           ? new TargetAllocationStrategy()
           : new MaxYieldStrategy();
 
-      // Risk ceiling is opt-in per user. Only when a ceiling is set do we load
-      // the current ProtocolRiskScore rows and pass them to the strategy — the
-      // no-ceiling path issues no extra query and behaves exactly as before.
-      const riskCeiling = userStrategyPreferences[0]?.riskCeiling;
+      // Risk ceiling is opt-in per user (or per goal). Only when a ceiling is
+      // set do we load the current ProtocolRiskScore rows and pass them to the
+      // strategy — the no-ceiling path issues no extra query and behaves
+      // exactly as before.
+      const riskCeiling = activeGoal?.riskCeiling ?? userStrategyPreferences[0]?.riskCeiling ?? undefined;
       const protocolRiskScores =
         riskCeiling !== undefined ? await loadProtocolRiskScores() : undefined;
 
@@ -336,6 +364,13 @@ export async function executeRebalanceIfNeeded(
         userStrategyPreferences,
         riskCeiling,
         protocolRiskScores,
+        goal: activeGoal
+          ? {
+              targetAmount: activeGoal.targetAmount,
+              startingAmount: activeGoal.startingAmount,
+              targetDate: activeGoal.targetDate,
+            }
+          : undefined,
       });
 
       if (!decision.shouldRebalance) {

--- a/src/agent/strategies.ts
+++ b/src/agent/strategies.ts
@@ -27,7 +27,7 @@ export const NO_ELIGIBLE_PROTOCOLS_REASON =
  * as ineligible rather than given the benefit of the doubt — a risk control must
  * not admit unknowns.
  */
-function applyRiskCeiling(
+export function applyRiskCeiling(
   protocols: YieldProtocol[],
   riskCeiling: number | undefined,
   scores: Record<string, number> | undefined,
@@ -262,6 +262,133 @@ export class TargetAllocationStrategy implements RebalanceStrategy {
         highestTarget,
         ratio,
       },
+    };
+  }
+}
+
+/**
+ * Years remaining between now and a future target date. Mirrors the
+ * non-compounding convention of calculateYearsActive in snapshotter.ts, but
+ * for a future date rather than a past one. Zero or negative means the target
+ * date has already passed.
+ */
+export function calculateYearsRemaining(targetDate: Date, from: Date = new Date()): number {
+  const msPerYear = 365.25 * 24 * 60 * 60 * 1000;
+  return (targetDate.getTime() - from.getTime()) / msPerYear;
+}
+
+/**
+ * Required simple annualized rate (as a percentage, e.g. 8.0 = 8%) to grow
+ * startingAmount into targetAmount over yearsRemaining. Intentionally the same
+ * simple-rate math as calculateApy in snapshotter.ts — this issue reuses that
+ * convention for consistency with live APY reporting rather than introducing a
+ * second, compounding-aware model (that work is tracked separately in #225).
+ *
+ * Returns Infinity when the target date has already passed and the goal is
+ * not yet met (no finite rate can close the gap in zero or negative time).
+ */
+export function calculateRequiredApy(
+  startingAmount: number,
+  targetAmount: number,
+  yearsRemaining: number,
+): number {
+  if (targetAmount <= startingAmount) return 0;
+  if (yearsRemaining <= 0) return Infinity;
+  return ((targetAmount - startingAmount) / startingAmount / yearsRemaining) * 100;
+}
+
+/**
+ * Goal-tracking strategy (#281). Computes the simple annualized rate required
+ * to hit a user's SavingsGoal by its target date, then delegates to
+ * MaxYieldStrategy (bounded by riskCeiling) when behind schedule, or holds
+ * position when already on track. It NEVER silently exceeds the configured
+ * risk ceiling to chase an unrealistic goal — when the required rate exceeds
+ * the best APY available among risk-eligible protocols, it surfaces that as an
+ * explicit "unreachable" decision instead of overriding the ceiling.
+ */
+export class GoalTrackingStrategy implements RebalanceStrategy {
+  readonly name: StrategyName = 'GOAL_TRACKING';
+
+  async analyze(params: StrategyParams): Promise<StrategyDecision> {
+    const { currentProtocol, currentApy, availableProtocols, goal, riskCeiling, protocolRiskScores } = params;
+
+    if (!goal) {
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: 'No active savings goal configured',
+      };
+    }
+
+    if (goal.targetAmount <= goal.startingAmount) {
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: 'Savings goal is already achieved',
+        details: { goal },
+      };
+    }
+
+    const yearsRemaining = calculateYearsRemaining(goal.targetDate);
+
+    if (yearsRemaining <= 0) {
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: 'Savings goal target date has passed without being met',
+        details: { goal },
+      };
+    }
+
+    const requiredApy = calculateRequiredApy(goal.startingAmount, goal.targetAmount, yearsRemaining);
+
+    const eligibleProtocols = applyRiskCeiling(availableProtocols, riskCeiling, protocolRiskScores);
+
+    if (riskCeiling !== undefined && eligibleProtocols.length === 0) {
+      logger.info('GoalTrackingStrategy: no protocols meet risk ceiling', {
+        riskCeiling,
+        requiredApy: requiredApy.toFixed(2),
+      });
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: NO_ELIGIBLE_PROTOCOLS_REASON,
+        details: { requiredApy, riskCeiling, eligibleCount: 0 },
+      };
+    }
+
+    const candidateApys = eligibleProtocols.map((p) => p.apy);
+    const maxEligibleApy = candidateApys.length > 0 ? Math.max(...candidateApys) : currentApy;
+
+    if (requiredApy > maxEligibleApy) {
+      // Required rate is unreachable within the user's risk tolerance. Surface
+      // this explicitly rather than quietly overriding the risk ceiling.
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: `Target requires ${requiredApy.toFixed(2)}% APY, which exceeds the best available within your risk tolerance (${maxEligibleApy.toFixed(2)}%) — target not reachable within your risk tolerance`,
+        details: { requiredApy, maxEligibleApy, riskCeiling, unreachable: true },
+      };
+    }
+
+    if (currentApy >= requiredApy) {
+      return {
+        shouldRebalance: false,
+        targetProtocol: currentProtocol,
+        reasoning: `On track — current ${currentApy.toFixed(2)}% APY meets the ${requiredApy.toFixed(2)}% required to reach your goal by ${goal.targetDate.toISOString().slice(0, 10)}`,
+        details: { requiredApy, currentApy, onTrack: true },
+      };
+    }
+
+    // Behind schedule and reachable: delegate to MaxYieldStrategy (already
+    // bounded by the same riskCeiling) to chase the best eligible yield.
+    const maxYield = new MaxYieldStrategy();
+    const decision = await maxYield.analyze(params);
+
+    return {
+      ...decision,
+      reasoning: `Behind schedule (need ${requiredApy.toFixed(2)}% APY to reach your goal) — ${decision.reasoning}`,
+      details: { ...decision.details, requiredApy, goalDriven: true },
     };
   }
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -74,7 +74,7 @@ export interface RebalanceThresholds {
   maxGasPercent: number; // 0.1% default
 }
 
-export type StrategyName = 'MAX_YIELD' | 'TARGET_ALLOCATION';
+export type StrategyName = 'MAX_YIELD' | 'TARGET_ALLOCATION' | 'GOAL_TRACKING';
 
 export interface StrategyDecision {
   shouldRebalance: boolean;
@@ -107,6 +107,16 @@ export interface StrategyParams {
    * ignored to keep the agent allocating.
    */
   riskCeiling?: number;
+  /**
+   * Optional active SavingsGoal (#281) driving GoalTrackingStrategy. Only
+   * consulted by that strategy — absent for MaxYieldStrategy/TargetAllocationStrategy
+   * callers, which are unaffected by this field's presence.
+   */
+  goal?: {
+    targetAmount: number;
+    startingAmount: number;
+    targetDate: Date;
+  };
 }
 
 export interface RebalanceStrategy {

--- a/src/controllers/goal-controller.ts
+++ b/src/controllers/goal-controller.ts
@@ -1,0 +1,193 @@
+// src/controllers/goal-controller.ts
+// Goal-based investing (#281): create/read/update/cancel a savings goal and
+// report its progress.
+import { Request, Response } from 'express'
+import { logger } from '../utils/logger'
+import { sendError, sendNotFound, sendUnauthorized, sendConflict } from '../utils/errors'
+import { mapGoalToResponse } from '../utils/api-formatters'
+import { formatGoalProgressReply } from '../whatsapp/formatters'
+import {
+  createGoal,
+  getGoalForUser,
+  getGoalById,
+  updateGoal,
+  cancelGoal,
+  computeGoalProgress,
+  GoalConflictError,
+  GoalNotFoundError,
+  GoalValidationError,
+} from '../goals/service'
+
+/**
+ * POST /api/portfolio/goals
+ *
+ * Create the caller's savings goal. Rejects if the caller already has an
+ * ACTIVE goal (single active goal per user, for now).
+ */
+export async function createGoalHandler(req: Request, res: Response): Promise<void> {
+  const userId = req.userId
+  if (!userId) {
+    sendUnauthorized(res)
+    return
+  }
+
+  try {
+    const goal = await createGoal(userId, req.body)
+    res.status(201).json({ goal: mapGoalToResponse(goal) })
+  } catch (error) {
+    if (error instanceof GoalConflictError) {
+      sendConflict(res, error.message)
+      return
+    }
+    if (error instanceof GoalValidationError) {
+      sendError(res, 400, error.message)
+      return
+    }
+    logger.error('[Goals] Failed to create goal:', error)
+    sendError(res, 500, 'Failed to create savings goal')
+  }
+}
+
+/**
+ * GET /api/portfolio/goals/:userId
+ *
+ * The user's current goal: their ACTIVE goal if one exists, otherwise their
+ * most recent goal. enforceUserAccess guarantees req.auth.userId === :userId.
+ */
+export async function getGoalHandler(req: Request, res: Response): Promise<void> {
+  const userId = String(req.params.userId)
+
+  try {
+    const goal = await getGoalForUser(userId)
+    if (!goal) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    res.status(200).json({ goal: mapGoalToResponse(goal) })
+  } catch (error) {
+    logger.error('[Goals] Failed to get goal:', error)
+    sendError(res, 500, 'Failed to retrieve savings goal')
+  }
+}
+
+/**
+ * PATCH /api/portfolio/goals/:id
+ *
+ * Update target amount/date/riskCeiling. Keyed by goal id (not :userId), so
+ * enforceUserAccess doesn't apply — ownership is checked explicitly here.
+ */
+export async function updateGoalHandler(req: Request, res: Response): Promise<void> {
+  const authUserId = req.auth?.userId
+  if (!authUserId) {
+    sendUnauthorized(res)
+    return
+  }
+
+  const id = String(req.params.id)
+
+  try {
+    const existing = await getGoalById(id)
+    if (!existing) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    if (existing.userId !== authUserId) {
+      sendUnauthorized(res)
+      return
+    }
+
+    const goal = await updateGoal(id, req.body)
+    res.status(200).json({ goal: mapGoalToResponse(goal) })
+  } catch (error) {
+    if (error instanceof GoalNotFoundError) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    if (error instanceof GoalValidationError) {
+      sendError(res, 400, error.message)
+      return
+    }
+    logger.error('[Goals] Failed to update goal:', error)
+    sendError(res, 500, 'Failed to update savings goal')
+  }
+}
+
+/**
+ * DELETE /api/portfolio/goals/:id
+ *
+ * Soft-cancel: sets status = CANCELLED, never hard-deletes. Ownership is
+ * checked explicitly since this route is keyed by goal id.
+ */
+export async function cancelGoalHandler(req: Request, res: Response): Promise<void> {
+  const authUserId = req.auth?.userId
+  if (!authUserId) {
+    sendUnauthorized(res)
+    return
+  }
+
+  const id = String(req.params.id)
+
+  try {
+    const existing = await getGoalById(id)
+    if (!existing) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    if (existing.userId !== authUserId) {
+      sendUnauthorized(res)
+      return
+    }
+
+    const goal = await cancelGoal(id)
+    res.status(200).json({ goal: mapGoalToResponse(goal) })
+  } catch (error) {
+    if (error instanceof GoalNotFoundError) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    logger.error('[Goals] Failed to cancel goal:', error)
+    sendError(res, 500, 'Failed to cancel savings goal')
+  }
+}
+
+/**
+ * GET /api/portfolio/goals/:id/progress
+ *
+ * Current trajectory: projected completion date, required vs. actual APY, and
+ * whether the target is reachable within the user's risk tolerance. Ownership
+ * is checked explicitly since this route is keyed by goal id.
+ */
+export async function getGoalProgressHandler(req: Request, res: Response): Promise<void> {
+  const authUserId = req.auth?.userId
+  if (!authUserId) {
+    sendUnauthorized(res)
+    return
+  }
+
+  const id = String(req.params.id)
+
+  try {
+    const existing = await getGoalById(id)
+    if (!existing) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    if (existing.userId !== authUserId) {
+      sendUnauthorized(res)
+      return
+    }
+
+    const progress = await computeGoalProgress(id)
+    res.status(200).json({
+      ...progress,
+      whatsappReply: formatGoalProgressReply(progress),
+    })
+  } catch (error) {
+    if (error instanceof GoalNotFoundError) {
+      sendNotFound(res, 'Savings goal')
+      return
+    }
+    logger.error('[Goals] Failed to compute goal progress:', error)
+    sendError(res, 500, 'Failed to compute savings goal progress')
+  }
+}

--- a/src/goals/service.ts
+++ b/src/goals/service.ts
@@ -1,0 +1,383 @@
+/**
+ * Goal-based investing (#281) — business logic for SavingsGoal CRUD and
+ * progress projection.
+ *
+ * Required-rate math intentionally reuses the same simple (non-compounding)
+ * convention as calculateApy/calculateYearsActive in ../agent/snapshotter.ts
+ * and ../agent/strategies.ts (GoalTrackingStrategy), so the agent's rebalance
+ * decisions and this endpoint's "on track" reporting never disagree.
+ * Compounding-aware modeling is tracked separately in #225.
+ */
+import { Prisma } from '@prisma/client';
+import db from '../db';
+import { logger } from '../utils/logger';
+import { logAgentAction } from '../agent/router';
+import { scanAllProtocols } from '../agent/scanner';
+import { applyRiskCeiling, calculateRequiredApy, calculateYearsRemaining } from '../agent/strategies';
+
+type Db = typeof db | Prisma.TransactionClient;
+
+export class GoalConflictError extends Error {}
+export class GoalNotFoundError extends Error {}
+export class GoalValidationError extends Error {}
+
+export interface CreateGoalInput {
+  targetAmount: number;
+  targetDate: Date;
+  startingAmount?: number;
+  positionId?: string;
+  riskCeiling?: number;
+}
+
+export interface UpdateGoalInput {
+  targetAmount?: number;
+  targetDate?: Date;
+  riskCeiling?: number;
+}
+
+export interface GoalProgress {
+  goalId: string;
+  status: string;
+  targetAmount: number;
+  startingAmount: number;
+  currentAmount: number;
+  targetDate: string;
+  requiredApy: number;
+  actualApy: number;
+  onTrack: boolean;
+  reachable: boolean;
+  projectedCompletionDate: string | null;
+  note?: string;
+}
+
+/**
+ * Sum of currentValue across the user's active positions, or a single
+ * position's value when the goal is scoped to one. Used both to default
+ * startingAmount at creation and to report currentAmount for progress.
+ */
+async function resolveCurrentAmount(
+  userId: string,
+  positionId: string | null | undefined,
+  database: Db,
+): Promise<number> {
+  if (positionId) {
+    const position = await (database as any).position.findUnique({ where: { id: positionId } });
+    if (!position || position.userId !== userId) return 0;
+    return Number(position.currentValue);
+  }
+
+  const positions = await (database as any).position.findMany({
+    where: { userId, status: 'ACTIVE' },
+  });
+  return positions.reduce((sum: number, p: any) => sum + Number(p.currentValue), 0);
+}
+
+/**
+ * Create a savings goal. Only one ACTIVE goal per user is allowed at a time
+ * (enforced here at the API/service layer, not via a DB constraint, since past
+ * goals are kept for history).
+ *
+ * When targetAmount is already met by the (possibly defaulted) starting
+ * amount, the goal is created directly as ACHIEVED rather than a misleading
+ * "in progress" ACTIVE record. Zod validation on the route already rejects an
+ * explicitly-supplied startingAmount >= targetAmount before this runs.
+ */
+export async function createGoal(
+  userId: string,
+  input: CreateGoalInput,
+  database: Db = db,
+): Promise<any> {
+  const existingActive = await (database as any).savingsGoal.findFirst({
+    where: { userId, status: 'ACTIVE' },
+  });
+  if (existingActive) {
+    throw new GoalConflictError('An active savings goal already exists for this user');
+  }
+
+  const startingAmount =
+    input.startingAmount ?? (await resolveCurrentAmount(userId, input.positionId, database));
+
+  const status = input.targetAmount <= startingAmount ? 'ACHIEVED' : 'ACTIVE';
+
+  const goal = await (database as any).savingsGoal.create({
+    data: {
+      userId,
+      positionId: input.positionId ?? null,
+      targetAmount: input.targetAmount,
+      startingAmount,
+      targetDate: input.targetDate,
+      riskCeiling: input.riskCeiling ?? null,
+      status,
+    },
+  });
+
+  logger.info('Savings goal created', { userId, goalId: goal.id, status });
+
+  return goal;
+}
+
+/**
+ * The user's current goal: their ACTIVE goal if one exists, otherwise their
+ * most recently created goal (so a just-cancelled/achieved goal is still
+ * visible), otherwise null.
+ */
+export async function getGoalForUser(userId: string, database: Db = db): Promise<any | null> {
+  const active = await (database as any).savingsGoal.findFirst({
+    where: { userId, status: 'ACTIVE' },
+  });
+  if (active) return active;
+
+  return (database as any).savingsGoal.findFirst({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function getGoalById(id: string, database: Db = db): Promise<any | null> {
+  return (database as any).savingsGoal.findUnique({ where: { id } });
+}
+
+/**
+ * Update target amount/date/riskCeiling on an ACTIVE goal. Callers must check
+ * ownership (goal.userId === req.auth.userId) before calling this — enforced
+ * in the controller since this route is keyed by goal id, not :userId, so
+ * enforceUserAccess doesn't apply.
+ *
+ * No recompute is stored here: yearsRemaining is always derived live from
+ * targetDate at read time (see calculateYearsRemaining), so an edit to
+ * targetDate/targetAmount is automatically reflected in the next progress
+ * calculation without a separate "recompute" step.
+ */
+export async function updateGoal(id: string, updates: UpdateGoalInput, database: Db = db): Promise<any> {
+  const goal = await getGoalById(id, database);
+  if (!goal) {
+    throw new GoalNotFoundError('Savings goal not found');
+  }
+  if (goal.status !== 'ACTIVE') {
+    throw new GoalValidationError('Only an ACTIVE goal can be updated');
+  }
+
+  return (database as any).savingsGoal.update({
+    where: { id },
+    data: {
+      ...(updates.targetAmount !== undefined ? { targetAmount: updates.targetAmount } : {}),
+      ...(updates.targetDate !== undefined ? { targetDate: updates.targetDate } : {}),
+      ...(updates.riskCeiling !== undefined ? { riskCeiling: updates.riskCeiling } : {}),
+    },
+  });
+}
+
+/** Soft-cancel: sets status = CANCELLED, never hard-deletes. */
+export async function cancelGoal(id: string, database: Db = db): Promise<any> {
+  const goal = await getGoalById(id, database);
+  if (!goal) {
+    throw new GoalNotFoundError('Savings goal not found');
+  }
+  if (goal.status !== 'ACTIVE') {
+    return goal;
+  }
+
+  return (database as any).savingsGoal.update({
+    where: { id },
+    data: { status: 'CANCELLED' },
+  });
+}
+
+/**
+ * Recent (30d) simple average APY across the user's active positions, mirroring
+ * the averageApy calculation in routes/portfolio.ts's /earnings endpoint —
+ * reused here rather than a second convention for "what rate am I actually
+ * getting".
+ */
+async function resolveActualApy(userId: string, database: Db): Promise<number> {
+  const fromDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const snapshots = await (database as any).yieldSnapshot.findMany({
+    where: { position: { is: { userId } }, snapshotAt: { gte: fromDate } },
+  });
+  if (snapshots.length === 0) return 0;
+  return (
+    snapshots.reduce((sum: number, s: any) => sum + Number(s.apy), 0) / snapshots.length
+  );
+}
+
+/**
+ * Whether the goal's required rate is achievable given currently scanned
+ * protocols and the goal's riskCeiling. Mirrors the same fail-closed
+ * applyRiskCeiling filter GoalTrackingStrategy uses, so the agent and this
+ * endpoint never disagree about what's reachable.
+ */
+async function resolveReachability(
+  requiredApy: number,
+  riskCeiling: number | null,
+): Promise<{ reachable: boolean; maxEligibleApy: number }> {
+  if (requiredApy <= 0) return { reachable: true, maxEligibleApy: requiredApy };
+
+  const allProtocols = await scanAllProtocols();
+  if (allProtocols.length === 0) {
+    return { reachable: false, maxEligibleApy: 0 };
+  }
+
+  let eligible = allProtocols;
+  if (riskCeiling !== null && riskCeiling !== undefined) {
+    const scores: Record<string, number> = {};
+    const riskRows = await db.protocolRiskScore.findMany({ select: { protocolName: true, score: true } });
+    for (const row of riskRows as Array<{ protocolName: string; score: number }>) {
+      scores[row.protocolName] = row.score;
+    }
+    eligible = applyRiskCeiling(allProtocols, riskCeiling, scores);
+  }
+
+  const maxEligibleApy = eligible.length > 0 ? Math.max(...eligible.map((p) => p.apy)) : 0;
+  return { reachable: requiredApy <= maxEligibleApy, maxEligibleApy };
+}
+
+/**
+ * Compute trajectory for a goal: current amount, required vs. actual APY,
+ * projected completion date, and whether the target is reachable within the
+ * user's risk tolerance. Also lazily transitions the goal to ACHIEVED/MISSED
+ * when appropriate, and logs an AgentLog GOAL_PROGRESS row so the trend is
+ * inspectable the same way rebalance decisions already are.
+ *
+ * Note on linked positions: the codebase does not currently have a code path
+ * that closes/liquidates a Position, so there is no event to hook a
+ * goal-cancellation into. This is checked lazily here instead — if a goal's
+ * linked position has disappeared or is no longer ACTIVE, the goal is
+ * cancelled on next read rather than left dangling as ACTIVE.
+ */
+export async function computeGoalProgress(goalId: string, database: Db = db): Promise<GoalProgress> {
+  const goal = await getGoalById(goalId, database);
+  if (!goal) {
+    throw new GoalNotFoundError('Savings goal not found');
+  }
+
+  const targetAmount = Number(goal.targetAmount);
+  const startingAmount = Number(goal.startingAmount);
+  const requiredApy = calculateRequiredApy(
+    startingAmount,
+    targetAmount,
+    calculateYearsRemaining(goal.targetDate),
+  );
+
+  if (goal.status !== 'ACTIVE') {
+    const currentAmount = await resolveCurrentAmount(goal.userId, goal.positionId, database);
+    return {
+      goalId: goal.id,
+      status: goal.status,
+      targetAmount,
+      startingAmount,
+      currentAmount,
+      targetDate: goal.targetDate.toISOString(),
+      requiredApy: Number.isFinite(requiredApy) ? requiredApy : 0,
+      actualApy: 0,
+      onTrack: goal.status === 'ACHIEVED',
+      reachable: goal.status === 'ACHIEVED',
+      projectedCompletionDate: null,
+    };
+  }
+
+  if (goal.positionId) {
+    const position = await (database as any).position.findUnique({ where: { id: goal.positionId } });
+    if (!position || position.status !== 'ACTIVE') {
+      await (database as any).savingsGoal.update({ where: { id: goal.id }, data: { status: 'CANCELLED' } });
+      await logAgentAction(
+        'GOAL_PROGRESS',
+        'SKIPPED',
+        { reasoning: 'Linked position is no longer active — goal cancelled' },
+        goal.userId,
+        goal.positionId,
+      );
+      return computeGoalProgress(goalId, database);
+    }
+  }
+
+  const currentAmount = await resolveCurrentAmount(goal.userId, goal.positionId, database);
+  const actualApy = await resolveActualApy(goal.userId, database);
+  const yearsRemaining = calculateYearsRemaining(goal.targetDate);
+
+  if (currentAmount >= targetAmount) {
+    await (database as any).savingsGoal.update({ where: { id: goal.id }, data: { status: 'ACHIEVED' } });
+    await logAgentAction(
+      'GOAL_PROGRESS',
+      'SUCCESS',
+      { reasoning: 'Savings goal achieved', outputData: { currentAmount, targetAmount } },
+      goal.userId,
+      goal.positionId ?? undefined,
+    );
+    return {
+      goalId: goal.id,
+      status: 'ACHIEVED',
+      targetAmount,
+      startingAmount,
+      currentAmount,
+      targetDate: goal.targetDate.toISOString(),
+      requiredApy: 0,
+      actualApy,
+      onTrack: true,
+      reachable: true,
+      projectedCompletionDate: new Date().toISOString(),
+    };
+  }
+
+  if (yearsRemaining <= 0) {
+    await (database as any).savingsGoal.update({ where: { id: goal.id }, data: { status: 'MISSED' } });
+    await logAgentAction(
+      'GOAL_PROGRESS',
+      'FAILED',
+      { reasoning: 'Savings goal target date passed without being met', outputData: { currentAmount, targetAmount } },
+      goal.userId,
+      goal.positionId ?? undefined,
+    );
+    return {
+      goalId: goal.id,
+      status: 'MISSED',
+      targetAmount,
+      startingAmount,
+      currentAmount,
+      targetDate: goal.targetDate.toISOString(),
+      requiredApy,
+      actualApy,
+      onTrack: false,
+      reachable: false,
+      projectedCompletionDate: null,
+    };
+  }
+
+  const { reachable } = await resolveReachability(requiredApy, goal.riskCeiling);
+  const onTrack = actualApy >= requiredApy;
+
+  let projectedCompletionDate: string | null = null;
+  if (actualApy > 0 && currentAmount > 0 && currentAmount < targetAmount) {
+    const yearsToComplete = (targetAmount - currentAmount) / currentAmount / (actualApy / 100);
+    const projected = new Date();
+    projected.setDate(projected.getDate() + Math.round(yearsToComplete * 365.25));
+    projectedCompletionDate = projected.toISOString();
+  }
+
+  await logAgentAction(
+    'GOAL_PROGRESS',
+    'SUCCESS',
+    {
+      reasoning: reachable
+        ? (onTrack ? 'On track toward savings goal' : 'Behind schedule but still reachable within risk tolerance')
+        : 'Target not reachable within your risk tolerance',
+      outputData: { currentAmount, targetAmount, requiredApy, actualApy, reachable, onTrack },
+    },
+    goal.userId,
+    goal.positionId ?? undefined,
+  );
+
+  return {
+    goalId: goal.id,
+    status: goal.status,
+    targetAmount,
+    startingAmount,
+    currentAmount,
+    targetDate: goal.targetDate.toISOString(),
+    requiredApy,
+    actualApy,
+    onTrack,
+    reachable,
+    projectedCompletionDate,
+    note: reachable ? undefined : 'Target not reachable within your risk tolerance',
+  };
+}

--- a/src/nlp/parser.ts
+++ b/src/nlp/parser.ts
@@ -3,7 +3,7 @@ import { HttpClientAdapter } from '../utils/http-client'
 import { config } from '../config'
 
 export interface Intent {
-  action: 'deposit' | 'withdraw' | 'balance' | 'earnings' | 'help' | 'unknown'
+  action: 'deposit' | 'withdraw' | 'balance' | 'earnings' | 'goal' | 'help' | 'unknown'
   amount?: number
   currency?: string
   all?: boolean
@@ -57,6 +57,11 @@ export function parseWithRegex(message: string): Intent | null {
     return { action: 'earnings' }
   }
 
+  // Savings goal (progress/status query — creation happens via the REST API)
+  if (/goal/i.test(lowerMsg)) {
+    return { action: 'goal' }
+  }
+
   // Help
   if (/help|what can you do|commands/i.test(lowerMsg)) {
     return { action: 'help' }
@@ -72,10 +77,10 @@ export async function parseWithClaude(message: string): Promise<Intent> {
       return anthropic.messages.create({
         model: 'claude-3-haiku-20240307',
         max_tokens: 150,
-        system: `You are an intent parser for a financial bot. Determine if the user wants to deposit, withdraw, check balance, view earnings/performance, or needs help.
+        system: `You are an intent parser for a financial bot. Determine if the user wants to deposit, withdraw, check balance, view earnings/performance, check their savings goal progress, or needs help.
 Return ONLY a JSON object representing the intent, matching this TypeScript interface exactly without any wrapper text or markdown:
 {
-  "action": "deposit" | "withdraw" | "balance" | "earnings" | "help" | "unknown",
+  "action": "deposit" | "withdraw" | "balance" | "earnings" | "goal" | "help" | "unknown",
   "amount": number, // optional
   "currency": string, // optional
   "all": boolean // for "withdraw everything"
@@ -94,7 +99,7 @@ Return ONLY a JSON object representing the intent, matching this TypeScript inte
       if (jsonStr) {
         const parsed = JSON.parse(jsonStr)
         if (
-          ['deposit', 'withdraw', 'balance', 'earnings', 'help'].includes(
+          ['deposit', 'withdraw', 'balance', 'earnings', 'goal', 'help'].includes(
             parsed.action
           )
         ) {

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -1,0 +1,54 @@
+/**
+ * Goal-based investing routes (#281), mounted under /api/portfolio/goals.
+ *
+ *   POST   /api/portfolio/goals            — create the caller's savings goal
+ *   GET    /api/portfolio/goals/:userId     — the user's current goal (owner-scoped)
+ *   PATCH  /api/portfolio/goals/:id         — update target amount/date/riskCeiling
+ *   DELETE /api/portfolio/goals/:id         — cancel (soft) a goal
+ *   GET    /api/portfolio/goals/:id/progress — trajectory + reachability
+ *
+ * PATCH/DELETE/progress are keyed by goal id, not :userId, so enforceUserAccess
+ * doesn't apply to them — ownership is checked explicitly in the controller.
+ */
+import { Router } from 'express'
+import { requireAuth, enforceUserAccess } from '../middleware/authenticate'
+import { validate } from '../middleware/validate'
+import { userIdParamSchema } from '../validators/common-validators'
+import { createGoalSchema, updateGoalSchema, goalIdParamSchema } from '../validators/goal-validators'
+import {
+  createGoalHandler,
+  getGoalHandler,
+  updateGoalHandler,
+  cancelGoalHandler,
+  getGoalProgressHandler,
+} from '../controllers/goal-controller'
+
+const router = Router()
+
+router.post('/', requireAuth, validate({ body: createGoalSchema }), createGoalHandler)
+
+router.get(
+  '/:userId',
+  requireAuth,
+  enforceUserAccess,
+  validate({ params: userIdParamSchema }),
+  getGoalHandler,
+)
+
+router.patch(
+  '/:id',
+  requireAuth,
+  validate({ params: goalIdParamSchema, body: updateGoalSchema }),
+  updateGoalHandler,
+)
+
+router.delete('/:id', requireAuth, validate({ params: goalIdParamSchema }), cancelGoalHandler)
+
+router.get(
+  '/:id/progress',
+  requireAuth,
+  validate({ params: goalIdParamSchema }),
+  getGoalProgressHandler,
+)
+
+export default router

--- a/src/routes/portfolio.ts
+++ b/src/routes/portfolio.ts
@@ -11,8 +11,13 @@ import {
   formatPortfolioReply,
 } from '../whatsapp/formatters'
 import { userIdParamSchema } from '../validators/common-validators'
+import goalsRouter from './goals'
 
 const router = Router()
+
+// Mounted before the /:userId route below so a literal "goals" first segment
+// is never captured as a userId.
+router.use('/goals', goalsRouter)
 
 const portfolioSchema = z.object({
   params: z.object({

--- a/src/utils/api-formatters.ts
+++ b/src/utils/api-formatters.ts
@@ -17,3 +17,16 @@ export const mapPositionToResponse = (position: any) => ({
   yieldEarned: Number(position.yieldEarned),
   status: position.status,
 })
+
+export const mapGoalToResponse = (goal: any) => ({
+  id: goal.id,
+  userId: goal.userId,
+  positionId: goal.positionId,
+  targetAmount: Number(goal.targetAmount),
+  startingAmount: Number(goal.startingAmount),
+  targetDate: goal.targetDate.toISOString(),
+  riskCeiling: goal.riskCeiling,
+  status: goal.status,
+  createdAt: goal.createdAt.toISOString(),
+  updatedAt: goal.updatedAt.toISOString(),
+})

--- a/src/validators/goal-validators.ts
+++ b/src/validators/goal-validators.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export const goalIdParamSchema = z.object({
+  id: z.string().uuid('Invalid goal ID format'),
+})
+
+export const createGoalSchema = z
+  .object({
+    targetAmount: z.number().positive('targetAmount must be greater than 0'),
+    targetDate: z.coerce.date().refine((date) => date.getTime() > Date.now(), {
+      message: 'targetDate must be in the future',
+    }),
+    startingAmount: z.number().nonnegative().optional(),
+    positionId: z.string().uuid().optional(),
+    riskCeiling: z.number().min(0).max(100).optional(),
+  })
+  .refine(
+    (data) => data.startingAmount === undefined || data.targetAmount > data.startingAmount,
+    { message: 'targetAmount must be greater than startingAmount', path: ['targetAmount'] },
+  )
+
+export const updateGoalSchema = z
+  .object({
+    targetAmount: z.number().positive('targetAmount must be greater than 0').optional(),
+    targetDate: z.coerce.date().optional(),
+    riskCeiling: z.number().min(0).max(100).optional(),
+  })
+  .refine(
+    (data) => data.targetAmount !== undefined || data.targetDate !== undefined || data.riskCeiling !== undefined,
+    { message: 'At least one of targetAmount, targetDate, riskCeiling must be provided' },
+  )
+  .refine((data) => data.targetDate === undefined || data.targetDate.getTime() > Date.now(), {
+    message: 'targetDate must be in the future',
+    path: ['targetDate'],
+  })

--- a/src/whatsapp/formatters.ts
+++ b/src/whatsapp/formatters.ts
@@ -126,6 +126,54 @@ export function formatDepositReply(input: {
   ].join('\n')
 }
 
+export function formatGoalProgressReply(input: {
+  status: string
+  targetAmount: number
+  currentAmount: number
+  targetDate: string
+  requiredApy: number
+  actualApy: number
+  onTrack: boolean
+  reachable: boolean
+  projectedCompletionDate: string | null
+}): string {
+  if (input.status === 'ACHIEVED') {
+    return ['🎯 *Savings Goal*', `You've reached your goal of $${input.targetAmount.toFixed(2)}! 🎉`].join('\n')
+  }
+
+  if (input.status === 'MISSED') {
+    return [
+      '🎯 *Savings Goal*',
+      `Target date passed at $${input.currentAmount.toFixed(2)} of $${input.targetAmount.toFixed(2)}.`,
+    ].join('\n')
+  }
+
+  if (input.status === 'CANCELLED') {
+    return ['🎯 *Savings Goal*', 'This goal has been cancelled.'].join('\n')
+  }
+
+  const lines = [
+    '🎯 *Savings Goal Progress*',
+    `Progress: *$${input.currentAmount.toFixed(2)}* of *$${input.targetAmount.toFixed(2)}*`,
+    `Target date: _${input.targetDate.slice(0, 10)}_`,
+    `Required APY: *${input.requiredApy.toFixed(2)}%* | Actual APY: *${input.actualApy.toFixed(2)}%*`,
+  ]
+
+  if (!input.reachable) {
+    lines.push('⚠️ Target not reachable within your risk tolerance.')
+  } else if (input.onTrack) {
+    lines.push('✅ On track to reach your goal.')
+  } else {
+    lines.push('⏳ Behind schedule, but still reachable.')
+  }
+
+  if (input.projectedCompletionDate) {
+    lines.push(`Projected completion: _${input.projectedCompletionDate.slice(0, 10)}_`)
+  }
+
+  return lines.join('\n')
+}
+
 export function formatWithdrawReply(input: {
   amount: number
   assetSymbol: string

--- a/src/whatsapp/handler.ts
+++ b/src/whatsapp/handler.ts
@@ -1,4 +1,5 @@
 import { parseIntent } from '../nlp/parser'
+import { formatGoalProgressReply } from './formatters'
 import {
   normalizePhone,
   createOrGetUser,
@@ -7,6 +8,7 @@ import {
   getBalance,
   getUserWalletAddress,
   getPortfolioYieldSummary,
+  getGoalStatus,
   decrementBalance,
 } from './userManager'
 
@@ -21,6 +23,7 @@ function formatHelpMessage(): string {
     '- "deposit <amount>" → get deposit instructions',
     '- "withdraw <amount>" → withdraw funds (if available)',
     '- "earnings" → see your performance',
+    '- "goal" → check your savings goal progress',
     '- "help" → show this message again',
   ].join('\n')
 }
@@ -131,6 +134,16 @@ export async function handleWhatsAppMessage(
       }
       const newBalance = decrementBalance(normalizedPhone, amount)
       return { body: formatWithdrawConfirmation(amount, newBalance) }
+    }
+
+    case 'goal': {
+      const progress = await getGoalStatus(normalizedPhone)
+      if (!progress) {
+        return {
+          body: "You don't have a savings goal set up yet. Set one up in the app to start tracking progress.",
+        }
+      }
+      return { body: formatGoalProgressReply(progress) }
     }
 
     case 'help':

--- a/src/whatsapp/userManager.ts
+++ b/src/whatsapp/userManager.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import db from '../db'
 import { createCustodialWallet, getWalletByUserId } from '../stellar/wallet'
+import { getGoalForUser, computeGoalProgress, GoalProgress } from '../goals/service'
 
 export type WhatsAppUser = {
   id: string
@@ -224,6 +225,33 @@ export async function getPortfolioYieldSummary(
     periodEarnings,
     averageApy,
   }
+}
+
+/**
+ * Savings goal progress (#281) for a WhatsApp user, resolved from their
+ * custodial wallet address the same way getPortfolioYieldSummary is.
+ * Returns null when the user has no DB record yet or no goal at all.
+ */
+export async function getGoalStatus(phone: string): Promise<GoalProgress | null> {
+  const user = getUserByPhone(phone)
+  if (!user) {
+    return null
+  }
+
+  const dbUser = await db.user.findUnique({
+    where: { walletAddress: user.walletAddress },
+    select: { id: true },
+  })
+  if (!dbUser) {
+    return null
+  }
+
+  const goal = await getGoalForUser(dbUser.id)
+  if (!goal) {
+    return null
+  }
+
+  return computeGoalProgress(goal.id)
 }
 
 export function incrementBalance(phone: string, amount: number): number {

--- a/tests/integration/agent/goal-strategy-selection.integration.test.ts
+++ b/tests/integration/agent/goal-strategy-selection.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test: goal-driven strategy selection (#281)
+ *
+ * Validates that:
+ * - Users with NO active SavingsGoal see byte-for-byte identical strategy
+ *   selection to before this feature existed (existing preference logic, e.g.
+ *   MAX_YIELD, is untouched).
+ * - Users WITH an active SavingsGoal have GoalTrackingStrategy selected
+ *   instead of their stored preference, and the agent rebalances to chase the
+ *   rate the goal actually needs even when the stored preference (e.g.
+ *   TARGET_ALLOCATION with no better configured target) would not have.
+ */
+
+import { executeRebalanceIfNeeded } from '../../../src/agent/router';
+
+const mockSubmitRebalance = jest.fn();
+jest.mock('../../../src/stellar/contract', () => ({
+  triggerRebalance: (...args: unknown[]) => mockSubmitRebalance(...args),
+}));
+
+const mockScanAllProtocols = jest.fn();
+const mockGetCurrentOnChainApy = jest.fn();
+jest.mock('../../../src/agent/scanner', () => ({
+  scanAllProtocols: (...args: unknown[]) => mockScanAllProtocols(...args),
+  getCurrentOnChainApy: (...args: unknown[]) => mockGetCurrentOnChainApy(...args),
+}));
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockSavingsGoalFindFirst = jest.fn();
+const mockProtocolRiskScoreFindMany = jest.fn().mockResolvedValue([]);
+const mockPositionFindFirst = jest.fn().mockResolvedValue(null);
+const mockPositionFindMany = jest.fn().mockResolvedValue([]);
+const mockTransactionCreate = jest.fn().mockResolvedValue({});
+const mockAgentLogCreate = jest.fn().mockResolvedValue({ id: 'log-1' });
+
+jest.mock('../../../src/db', () => ({
+  __esModule: true,
+  default: {
+    savingsGoal: {
+      findFirst: (...args: unknown[]) => mockSavingsGoalFindFirst(...args),
+    },
+    protocolRiskScore: {
+      findMany: (...args: unknown[]) => mockProtocolRiskScoreFindMany(...args),
+    },
+    position: {
+      findFirst: (...args: unknown[]) => mockPositionFindFirst(...args),
+      findMany: (...args: unknown[]) => mockPositionFindMany(...args),
+    },
+    transaction: {
+      create: (...args: unknown[]) => mockTransactionCreate(...args),
+    },
+    agentLog: {
+      create: (...args: unknown[]) => mockAgentLogCreate(...args),
+    },
+  },
+}));
+
+describe('Goal-driven strategy selection integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPositionFindFirst.mockResolvedValue(null);
+    mockPositionFindMany.mockResolvedValue([]);
+    mockTransactionCreate.mockResolvedValue({});
+    mockAgentLogCreate.mockResolvedValue({ id: 'log-1' });
+    mockSubmitRebalance.mockResolvedValue({ hash: 'tx-hash-goal' });
+  });
+
+  it('non-goal user: MAX_YIELD preference behaves exactly as before (no active goal query short-circuits it)', async () => {
+    mockSavingsGoalFindFirst.mockResolvedValue(null);
+    mockGetCurrentOnChainApy.mockResolvedValue(3.0);
+    mockScanAllProtocols.mockResolvedValue([
+      { name: 'Luma', apy: 8.0, assetSymbol: 'USDC', lastUpdated: new Date(), isAvailable: true },
+      { name: 'Blend', apy: 3.0, assetSymbol: 'USDC', lastUpdated: new Date(), isAvailable: true },
+    ]);
+
+    const result = await executeRebalanceIfNeeded(
+      'Blend',
+      [{ id: 'pos-1', amount: '10000000000000000000000', userId: 'user-no-goal' }],
+      undefined,
+      [{ userId: 'user-no-goal', strategyName: 'MAX_YIELD' }],
+    );
+
+    expect(mockSavingsGoalFindFirst).toHaveBeenCalledWith({
+      where: { userId: 'user-no-goal', status: 'ACTIVE' },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.toProtocol).toBe('Luma');
+  });
+
+  it('goal user: GoalTrackingStrategy overrides a TARGET_ALLOCATION preference that would not otherwise rebalance', async () => {
+    mockSavingsGoalFindFirst.mockResolvedValue({
+      id: 'goal-1',
+      userId: 'user-with-goal',
+      targetAmount: '13000',
+      startingAmount: '10000',
+      targetDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      riskCeiling: null,
+    });
+    mockGetCurrentOnChainApy.mockResolvedValue(3.0);
+    mockScanAllProtocols.mockResolvedValue([
+      { name: 'Luma', apy: 35.0, assetSymbol: 'USDC', lastUpdated: new Date(), isAvailable: true },
+      { name: 'Blend', apy: 3.0, assetSymbol: 'USDC', lastUpdated: new Date(), isAvailable: true },
+    ]);
+
+    const result = await executeRebalanceIfNeeded(
+      'Blend',
+      [{ id: 'pos-2', amount: '10000000000000000000000', userId: 'user-with-goal' }],
+      undefined,
+      // TARGET_ALLOCATION with no targetAllocations configured would normally
+      // decline to rebalance (see TargetAllocationStrategy's "no target
+      // allocations configured" branch) — the active goal must override this.
+      [{ userId: 'user-with-goal', strategyName: 'TARGET_ALLOCATION' }],
+    );
+
+    expect(mockSavingsGoalFindFirst).toHaveBeenCalledWith({
+      where: { userId: 'user-with-goal', status: 'ACTIVE' },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.toProtocol).toBe('Luma');
+  });
+});

--- a/tests/unit/agent/goalTrackingStrategy.test.ts
+++ b/tests/unit/agent/goalTrackingStrategy.test.ts
@@ -1,0 +1,178 @@
+import {
+  GoalTrackingStrategy,
+  calculateRequiredApy,
+  calculateYearsRemaining,
+  NO_ELIGIBLE_PROTOCOLS_REASON,
+} from '../../../src/agent/strategies';
+import { StrategyParams, YieldProtocol } from '../../../src/agent/types';
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+function makeProtocol(overrides: Partial<YieldProtocol> = {}): YieldProtocol {
+  return {
+    name: 'TestProtocol',
+    apy: 5.0,
+    assetSymbol: 'USDC',
+    lastUpdated: new Date(),
+    isAvailable: true,
+    ...overrides,
+  };
+}
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
+
+const defaultThresholds = {
+  minimumImprovement: 0.5,
+  maxGasPercent: 0.1,
+};
+
+function baseParams(overrides: Partial<StrategyParams> = {}): StrategyParams {
+  return {
+    currentProtocol: 'Blend',
+    totalAmount: '10000000000000000000000',
+    currentApy: 3.0,
+    availableProtocols: [makeProtocol({ name: 'Blend', apy: 3.0 })],
+    thresholds: defaultThresholds,
+    userStrategyPreferences: [],
+    ...overrides,
+  };
+}
+
+describe('calculateRequiredApy', () => {
+  it('computes the simple annualized rate needed to close the gap', () => {
+    // (1500 - 1000) / 1000 / 1 year = 50%
+    expect(calculateRequiredApy(1000, 1500, 1)).toBeCloseTo(50, 5);
+  });
+
+  it('returns 0 when the target is already met or exceeded', () => {
+    expect(calculateRequiredApy(1000, 1000, 1)).toBe(0);
+    expect(calculateRequiredApy(1500, 1000, 1)).toBe(0);
+  });
+
+  it('returns Infinity when there is no time left and the target is unmet', () => {
+    expect(calculateRequiredApy(1000, 1500, 0)).toBe(Infinity);
+    expect(calculateRequiredApy(1000, 1500, -0.1)).toBe(Infinity);
+  });
+});
+
+describe('calculateYearsRemaining', () => {
+  it('is positive for a future date and negative for a past date', () => {
+    const from = new Date('2026-01-01T00:00:00Z');
+    expect(calculateYearsRemaining(new Date('2027-01-01T00:00:00Z'), from)).toBeGreaterThan(0.9);
+    expect(calculateYearsRemaining(new Date('2025-01-01T00:00:00Z'), from)).toBeLessThan(0);
+  });
+});
+
+describe('GoalTrackingStrategy', () => {
+  const strategy = new GoalTrackingStrategy();
+
+  it('returns strategy name as GOAL_TRACKING', () => {
+    expect(strategy.name).toBe('GOAL_TRACKING');
+  });
+
+  it('does nothing when no goal is configured', async () => {
+    const decision = await strategy.analyze(baseParams({ goal: undefined }));
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('No active savings goal');
+  });
+
+  it('reports already achieved when targetAmount <= startingAmount', async () => {
+    const params = baseParams({
+      goal: { targetAmount: 1000, startingAmount: 1500, targetDate: daysFromNow(180) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('already achieved');
+  });
+
+  it('reports a missed goal when the target date has passed without being met', async () => {
+    const params = baseParams({
+      goal: { targetAmount: 2000, startingAmount: 1000, targetDate: daysFromNow(-10) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('target date has passed');
+  });
+
+  it('on-track: does not rebalance when current APY already meets the required rate', async () => {
+    // Required: (11000-10000)/10000/1 = 10%. Current APY of 12% already covers it.
+    const params = baseParams({
+      currentApy: 12,
+      availableProtocols: [makeProtocol({ name: 'Blend', apy: 12 })],
+      goal: { targetAmount: 11000, startingAmount: 10000, targetDate: daysFromNow(365) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('On track');
+    expect(decision.details?.requiredApy).toBeCloseTo(10, 1);
+  });
+
+  it('ahead-of-schedule: does not rebalance when current APY comfortably exceeds the required rate', async () => {
+    // Required: (10500-10000)/10000/2 = 2.5%. Current APY of 15% is well ahead.
+    const params = baseParams({
+      currentApy: 15,
+      availableProtocols: [makeProtocol({ name: 'Blend', apy: 15 })],
+      goal: { targetAmount: 10500, startingAmount: 10000, targetDate: daysFromNow(730) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('On track');
+    expect(decision.details?.requiredApy).toBeCloseTo(2.5, 1);
+  });
+
+  it('behind schedule: delegates to MaxYieldStrategy when required rate is reachable', async () => {
+    // Required: (13000-10000)/10000/1 = 30%. Current APY 3%, but Luma offers 35%.
+    const params = baseParams({
+      currentProtocol: 'Blend',
+      currentApy: 3,
+      availableProtocols: [
+        makeProtocol({ name: 'Luma', apy: 35 }),
+        makeProtocol({ name: 'Blend', apy: 3 }),
+      ],
+      goal: { targetAmount: 13000, startingAmount: 10000, targetDate: daysFromNow(365) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(true);
+    expect(decision.targetProtocol).toBe('Luma');
+    expect(decision.reasoning).toContain('Behind schedule');
+    expect(decision.details?.requiredApy).toBeCloseTo(30, 1);
+  });
+
+  it('unreachable-within-risk-ceiling: surfaces target-not-reachable instead of exceeding the ceiling', async () => {
+    // Required: (20000-10000)/10000/1 = 100%. No protocol comes close.
+    const params = baseParams({
+      currentProtocol: 'Blend',
+      currentApy: 3,
+      availableProtocols: [
+        makeProtocol({ name: 'Blend', apy: 3 }),
+        makeProtocol({ name: 'Luma', apy: 8 }),
+      ],
+      goal: { targetAmount: 20000, startingAmount: 10000, targetDate: daysFromNow(365) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toContain('not reachable within your risk tolerance');
+    expect(decision.details?.unreachable).toBe(true);
+  });
+
+  it('unreachable-within-risk-ceiling: never overrides an explicit riskCeiling that excludes every protocol', async () => {
+    const params = baseParams({
+      currentProtocol: 'Blend',
+      currentApy: 3,
+      availableProtocols: [
+        makeProtocol({ name: 'Blend', apy: 3 }),
+        makeProtocol({ name: 'Luma', apy: 35 }),
+      ],
+      riskCeiling: 80,
+      protocolRiskScores: { Blend: 40, Luma: 20 },
+      goal: { targetAmount: 13000, startingAmount: 10000, targetDate: daysFromNow(365) },
+    });
+    const decision = await strategy.analyze(params);
+    expect(decision.shouldRebalance).toBe(false);
+    expect(decision.reasoning).toBe(NO_ELIGIBLE_PROTOCOLS_REASON);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `SavingsGoal` model + migration (one ACTIVE goal per user, enforced at the service layer) and a REST API under `/api/portfolio/goals` (create, get by user, update, cancel, progress), with explicit ownership checks on the `:id`-keyed routes since `enforceUserAccess` only covers `:userId`-shaped routes.
- Adds `GoalTrackingStrategy` implementing the existing `RebalanceStrategy` interface (from #227). It computes the simple annualized rate required to hit the goal — reusing the same non-compounding convention as `calculateApy`/`calculateYearsActive` in `snapshotter.ts` rather than a second math model (full compounding-aware analytics are tracked separately in #225) — then delegates to `MaxYieldStrategy` when behind schedule, bounded by the user's risk ceiling. It never silently exceeds that ceiling; when the target isn't reachable within it, that's surfaced explicitly rather than pretending it's on track.
- `router.ts`'s strategy selection now checks for an ACTIVE goal first; users with no goal fall through to the existing stored-preference logic completely unchanged (covered by an integration test).
- Adds a `'goal'` WhatsApp/NLP intent (regex + Claude prompt) for progress queries, and a `formatGoalProgressReply` formatter.
- `docs/openapi.yaml` updated with the new `goals` endpoints and schemas.

## Test plan
- [x] `tests/unit/agent/goalTrackingStrategy.test.ts` — required-rate math plus on-track, ahead-of-schedule, behind-schedule, and unreachable-within-risk-ceiling strategy decisions
- [x] `tests/integration/agent/goal-strategy-selection.integration.test.ts` — confirms non-goal users see identical strategy selection, and that an active goal overrides a stored preference that would not otherwise rebalance
- [x] `npx tsc --noEmit` — no new type errors introduced (verified against baseline)
- [x] `npx redocly lint docs/openapi.yaml` — valid, no new errors
- [x] Full existing unit/integration suites re-run — no regressions (pre-existing failures in this environment are unrelated to this change and reproduce identically on `main`, e.g. missing local env secrets for a few integration tests)

Closes #281