### PR TITLE
Feat/issue 322 portfolio optimization

### DIFF
--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -61,3 +61,55 @@ riskCeiling? }`** — the three keys `src/agent/loop.ts` actually reads.
 11. **The metrics job computes for unpublished strategies too**, so re-publishing
     is ranked immediately instead of waiting up to a full interval. The
     marketplace query, not the job, applies the `isPublished` filter.
+
+## Portfolio Optimization & Allocation Suggestions (#322)
+
+12. **Σ is the covariance of ANNUAL RATE LEVELS, not of daily returns**, and λ is
+    log-spaced over `[5, 500]` rather than linear over `[1, 25]`. Both deviate
+    from the issue plan, and they are one decision, not two. Under the plan's
+    scaling (`Σ = cov(apy/100/365.25) × 365.25`) the risk term sits five to six
+    orders of magnitude below the return term for realistic APY dispersion, so
+    `(λ/2)wᵀΣw` can never offset `μᵀw` at any λ in `[1,25]`: the optimum is
+    always the max-return corner and the efficient frontier collapses to a point.
+    The chosen Σ is exactly the plan's matrix × 365.25, which also makes
+    `expectedVolatility` read in the same units as the APY. Worked numbers in
+    `docs/PORTFOLIO_OPTIMIZATION.md`.
+
+13. **A default 60% per-protocol concentration cap is applied**, raised to `1/n`
+    on a small universe. Unconstrained mean-variance is corner-seeking; measured
+    on this repo's scale, every `riskTolerance` from 3 to 10 returned a single
+    protocol at 100%. That is a true optimum of the stated objective and
+    simultaneously terrible advice for an endpoint whose purpose is to suggest a
+    *diversified* allocation. Applied as an explicit, overridable `bounds.max`
+    default rather than by distorting μ or λ until the answer looked reasonable.
+
+14. **The stable-group floor uses an exact disjoint-group split projection**,
+    not the Dykstra alternating projections the plan called for. For a convex set
+    ∩ halfspace the projection is either the plain capped-simplex projection or
+    lies on `Σ_S w = f`, which splits into two capped simplices over disjoint
+    index groups — exact and non-iterative. Dykstra is correct for a general
+    intersection but only iteratively convergent, and the first draft left the
+    iterate on the wrong side of the floor (returning 0.30 for a 0.60 floor).
+
+15. **`insufficient_universe` carries an optional `bindingConstraint`.** A
+    too-tight risk ceiling empties the universe rather than emptying the feasible
+    set, so reporting it as `infeasible` would mislabel it. The extra field lets
+    the API name `riskCeiling` as the cause while keeping the outcome
+    structurally accurate.
+
+16. **The backtest window is trimmed to the first populated day.** `runBacktest`
+    treats an empty first day as `insufficient_history` and abandons the entire
+    run, so a first observation landing minutes after the window's opening
+    midnight would discard ~89 otherwise-usable days. Trimming makes the
+    comparison depend on the data that exists rather than on when the rate
+    scanner happened to run.
+
+17. **The scheduled job stores suggestions without backtest legs.** They are two
+    full historical replays per user and are only interesting when a human is
+    looking, which is exactly when the POST endpoint computes them live. Rows
+    written by the job carry a null `backtest`; that is expected, not a failure.
+
+18. **`prisma/migrations/20260728000000_add_sub_accounts/rollback.sql` was
+    written here despite being out of scope for #322.** It was missing, which
+    fails `scripts/check-migration-rollback.sh` on `main` and would have left
+    this branch's CI red for an unrelated reason. Flagged in the PR description.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -10,6 +10,7 @@
 - **[API_REFERENCE.md](API_REFERENCE.md)** - Complete backend endpoint reference
 - **[TAX_REPORT.md](TAX_REPORT.md)** - Tax reporting & FIFO cost-basis lot tracking (#284)
 - **[STRATEGY_MARKETPLACE.md](STRATEGY_MARKETPLACE.md)** - Strategy marketplace / opt-in copy-trading: metric formula, eligibility gate, privacy & custody boundaries (#285)
+- **[PORTFOLIO_OPTIMIZATION.md](PORTFOLIO_OPTIMIZATION.md)** - Portfolio optimization & allocation suggestions: objective, λ mapping, estimation method, advisory invariant, limitations (#322)
 
 ### For DevOps/Deployment
 

--- a/docs/PORTFOLIO_OPTIMIZATION.md
+++ b/docs/PORTFOLIO_OPTIMIZATION.md
@@ -1,0 +1,393 @@
+# Portfolio Optimization & Allocation Suggestions (#322)
+
+Computes a mean-variance optimal allocation from historical protocol APY data,
+the user's risk tolerance, and their effective risk ceiling — and returns it with
+an efficient frontier and a backtest comparison.
+
+**Everything here is advisory.** Read [The advisory
+invariant](#the-advisory-invariant) before changing anything in `src/analytics/`.
+
+---
+
+## The advisory invariant
+
+A suggestion is computed, persisted to `AllocationSuggestion`, and displayed.
+It **never**:
+
+- writes `User.strategyConfig` or `User.rebalanceStrategy`
+- moves funds, touches a wallet, or imports anything from `src/stellar/`
+- changes what the rebalancing agent does on its next tick
+
+Applying a suggestion is a separate, deliberate act by the user through the
+existing strategy update path, which already validates the config
+(`publishableConfigSchema`) and already logs the change.
+
+This is enforced structurally, not by convention.
+`tests/unit/analytics/structural.test.ts` scans the source text of every
+`src/analytics/*` file and of `src/jobs/allocationSuggestions.ts`, and fails on
+any `user.update`, any `strategyConfig:` write, any `src/stellar/` import, and
+any Prisma model access outside a fixed allowlist.
+
+The reason for the paranoia: an optimizer that can silently rewrite where
+someone's money sits is a fundamentally different — and far more dangerous —
+feature than one that draws a chart.
+
+---
+
+## Units
+
+Everything in `src/analytics/` that is a rate or a weight is a **decimal
+fraction**:
+
+| Quantity | Example | Means |
+|---|---|---|
+| expected return | `0.082` | 8.2% APY |
+| volatility | `0.014` | 1.4 percentage points of APY volatility |
+| weight | `0.425` | 42.5% of the portfolio |
+
+The **only** place fractions become percentages is `toPercentageAllocations`
+(`src/analytics/optimizer.ts`), which emits the 0–100 map that
+`User.strategyConfig.targetAllocations` speaks. Keeping the conversion at exactly
+one boundary is what makes the "sums to 100 ± 0.01" invariant assertable in one
+place — and ± 0.01 is precisely the tolerance
+`publishableConfigSchema.superRefine` already enforces, so a suggestion is
+directly acceptable by the existing update path with no re-conversion.
+
+---
+
+## The objective
+
+```
+maximize   μᵀw − (λ/2)·wᵀΣw
+
+subject to Σw = 1
+           lo_i ≤ w_i ≤ hi_i
+           Σ_{i∈S} w_i ≥ f          (optional stable-group floor)
+```
+
+The risk ceiling is **not** a term in this objective. It enters upstream as a
+universe filter, reusing the same fail-closed rule as `applyRiskCeiling`
+(`src/agent/strategies.ts`): a protocol with no known score is excluded rather
+than given the benefit of the doubt. A weighted portfolio risk score is
+*reported* for display but never separately constrained — one notion of the
+ceiling, not two.
+
+### What the covariance actually measures
+
+`ProtocolRate` is a **yield-quote series, not a price series**. Σ here is the
+covariance of protocols' quoted annual rates, so the optimizer minimizes **yield
+volatility** — how much a protocol's APY swings around.
+
+It does **not** model principal loss, depeg, or smart-contract failure. Those
+live in `ProtocolRiskScore`, which enters as the universe filter above. This
+limitation is repeated in the API response `disclaimer` rather than left for a
+user to infer from a confident-looking chart.
+
+---
+
+## Risk aversion (λ)
+
+```
+λ(rt) = LAMBDA_MAX · (LAMBDA_MIN / LAMBDA_MAX) ^ ((rt − 1) / 9)
+```
+
+with `LAMBDA_MAX = 500` (riskTolerance 1, most risk-averse) and
+`LAMBDA_MIN = 5` (riskTolerance 10). Log-spaced, because each step of risk
+appetite is naturally a constant *ratio* rather than a constant difference.
+Values outside 1–10 are clamped — `User.riskTolerance` is an `Int` column with no
+database-level range check.
+
+### Why this range, and why Σ is scaled the way it is
+
+> This is a deliberate, measured deviation from the original plan for #322.
+> Recorded in `ASSUMPTIONS.md`.
+
+The plan specified daily returns `r = apy/100/365.25`, Σ annualized by
+`× 365.25`, and λ linear on `[1, 25]`. Under those units the risk term sits
+**five to six orders of magnitude below the return term** for realistic APY
+dispersion. A protocol whose APY swings ±2 percentage points has an annualized
+variance of ~`5e-7` in that scaling, against a mean return of ~`8e-2`:
+
+| λ | `(λ/2)·wᵀΣw` at w=1 | μ | ratio |
+|---|---|---|---|
+| 1 | 5.48e-7 | 0.08 | 1.5e+5 |
+| 25 | 1.37e-5 | 0.08 | 5.8e+3 |
+
+The consequence is not "slightly aggressive". `(λ/2)wᵀΣw` can never offset `μᵀw`
+at any λ in `[1, 25]`, so the optimum is **always** the max-return corner, the
+efficient frontier collapses to a single point, and the engine degenerates into
+"put everything in the highest-APY protocol".
+
+So Σ here is the covariance of **annual rate levels** — exactly the plan's matrix
+multiplied by 365.25. Two things follow:
+
+- `expectedVolatility` comes out in the same units as the APY itself, so
+  "8.2% expected return, 1.4% expected volatility" reads directly.
+- λ must live on `[5, 500]` to span the useful trade-off. For two protocols at
+  μ = 10%/6% and σ = 3%/1%, the optimal weight in the riskier one is:
+
+  | λ | 1 | 25 | 64 | 100 | 500 |
+  |---|---|---|---|---|---|
+  | w | 1.00 (corner) | 1.00 (corner) | 0.72 | 0.50 | 0.18 |
+
+---
+
+## The concentration cap
+
+`DEFAULT_MAX_WEIGHT_PER_PROTOCOL = 0.6`, raised to `1/n` when the universe is too
+small to satisfy it.
+
+Unconstrained mean-variance is famously corner-seeking (Michaud's "error
+maximization"): it treats a historical mean as if it were known exactly, so a
+protocol whose APY averaged 3 percentage points above its peers absorbs the whole
+book unless something stops it. Measured on this repo's own scale — a 3pp return
+spread against ~1.8pp yield volatility, with the correlated rate histories DeFi
+protocols actually exhibit — **every riskTolerance from 3 to 10 returned a single
+protocol at 100%.**
+
+That is a true optimum of the stated objective and simultaneously terrible
+advice. The cap is applied as an explicit, documented, **overridable** constraint
+(an explicit `bounds.max` wins over it) rather than by quietly distorting μ or λ
+until the answer looked reasonable.
+
+---
+
+## Estimation
+
+`src/analytics/estimation.ts`, zero I/O.
+
+1. **Universe eligibility** — fail-closed at every step. A protocol is admitted
+   only when it has a `ProtocolRiskScore` row, that row is not flagged
+   `insufficientHistory`, it clears any configured ceiling, and it has rate
+   history in the window. Everything else is excluded **with a machine-readable
+   reason**, so the API can always explain a missing protocol.
+2. **Daily aggregation** — `ProtocolRate` is keyed by
+   `(protocolName, assetSymbol, network, fetchedAt)`, so a protocol routinely has
+   several rows per day. These are averaged to one value per `(protocol, UTC
+   day)` first, making the daily value a property of the day rather than an
+   artifact of scan ordering.
+3. **Alignment** — `buildDailyRateSeries` (`src/agent/backtest.ts`) forward-fills
+   onto a common daily grid, then only days on which *every* admitted protocol
+   has a value are kept.
+4. **Statistics** — `x_p(t) = apy_p(t)/100`; `μ_p = mean(x_p)`;
+   `Σ = sampleCovariance(x)` using the **n−1** convention, matching
+   `sampleStdev` in `src/agent/strategyMetrics.ts` (which this module imports
+   rather than copying — that file declares itself the one definition of
+   risk-adjusted return math).
+
+### Why not `periodReturns`
+
+A covariance matrix requires **index-aligned** observation vectors: entry (i,j)
+must pair protocol i and protocol j on the *same* day.
+
+`periodReturns` (`src/agent/strategyMetrics.ts`) cannot supply that. It **skips**
+any interval whose starting value is non-positive — correct for its own job (a
+portfolio funded from empty is a deposit, not a return) but fatal here: two
+protocols skipping different intervals produce vectors of different lengths whose
+k-th entries are different days. The resulting matrix looks perfectly well-formed
+and is silently, badly wrong.
+
+### The smoothing trap
+
+Inputs derive from `ProtocolRate.supplyApy`, a per-observation rate quote. They
+must **never** derive from `YieldSnapshot.apy`, which `snapshotter.ts` computes as
+cumulative-yield-since-`openedAt` annualized — consecutive values there are a
+smoothed running average whose variance badly understates reality. Same trap
+documented in `docs/STRATEGY_MARKETPLACE.md` §2.
+
+---
+
+## The solver
+
+Accelerated projected gradient ascent (FISTA) with adaptive restart. No new
+dependency — the repo has an explicit hand-roll precedent (`src/utils/csv.ts`,
+`src/agent/strategyMetrics.ts`).
+
+- **Projection onto `{Σw = 1, lo ≤ w ≤ hi}` is exact.**
+  `w_i(θ) = clamp(v_i − θ, lo_i, hi_i)` is monotone non-increasing in θ, so
+  bisection on θ converges to machine precision — no tolerance to tune.
+- **The stable-group floor uses an exact split, not Dykstra.** For a convex set
+  ∩ halfspace, the projection is either the plain capped-simplex projection or it
+  lies on `Σ_S w = f`, which is
+  `{Σ_S w = f} ∩ {Σ_{Sᶜ} w = 1−f} ∩ box` — two capped simplices over *disjoint*
+  index groups. Euclidean distance separates across disjoint coordinates, so
+  projecting each group onto its own target sum is the exact projection. No
+  iteration, and the floor cannot be left violated.
+- **Why acceleration.** Σ is a sample covariance over ~90 observations, so with
+  many protocols — or protocols whose APYs move together, which is the norm — it
+  is ill-conditioned or rank-deficient. The objective is then concave but not
+  *strongly* concave, and plain projected gradient converges at O(1/k). Measured:
+  a 7-protocol problem still had a 5.2e-8 residual after the full 2000-iteration
+  budget. Nesterov momentum gives O(1/k²) for the same per-iteration cost;
+  adaptive restart (drop momentum whenever an iterate is worse than its
+  predecessor) keeps it effectively monotone.
+
+**Determinism.** Protocols are sorted by name and μ/Σ permuted to match
+regardless of caller ordering, the starting point is the uniform vector projected
+onto the feasible set, the iteration budget is fixed, and there is no randomness
+anywhere. The same input produces byte-identical output.
+
+**Every iterate is a projection onto the feasible set**, so every intermediate
+value satisfies every constraint — which is what makes `bestFeasibleWeights` safe
+to return on a `non_converged` outcome.
+
+### Measured cost
+
+Full solve plus a 12-point frontier sweep:
+
+| Protocols | Time |
+|---|---|
+| 3 | 0.11 ms |
+| 10 | 1.33 ms |
+| 25 | 7.10 ms |
+
+Across 450 seeded random problems (up to 25 protocols): 0 non-converged, median
+104 iterations, max 802 of a 2000 budget.
+
+---
+
+## Outcomes
+
+A discriminated union — every failure mode is a named, inspectable state rather
+than a plausible-looking vector that quietly violates a constraint.
+
+| `status` | Meaning |
+|---|---|
+| `ok` | Weights, expected return/volatility, λ, frontier, iterations, portfolio risk score. |
+| `infeasible` | The constraints contradict each other. Names the `bindingConstraint` (`minWeights`, `maxWeights`, `stableFloor`). |
+| `insufficient_universe` | Fewer than 2 eligible protocols, with per-protocol exclusion reasons. Carries `bindingConstraint: riskCeiling` when the ceiling is what emptied it. |
+| `non_converged` | Budget exhausted. Carries the best **feasible** vector found plus the residual — never a converged-looking answer. |
+
+All four are HTTP **200**: "the optimizer ran and could not produce a portfolio"
+is a result, not a request error.
+
+---
+
+## Effective risk ceiling
+
+The agent resolves this with **two deliberately different merge rules**, and a
+suggestion computed under a third would be advice about a portfolio the agent
+will never build. Both are mirrored verbatim in `src/analytics/service.ts`:
+
+1. A **followed** strategy merges via `stricterRiskCeiling` (`Math.max` — higher
+   score means lower risk, so a follow may only ever *tighten* exposure). See
+   `src/agent/effectiveStrategy.ts`.
+2. An **ACTIVE `SavingsGoal`** then *overrides* via `??`, matching
+   `src/agent/router.ts` — a stated personal target outranks a copied config, and
+   it may legitimately loosen the ceiling.
+
+Unifying these into one rule would be tidier and wrong. The response reports
+`ceilingSource` (`goal` | `follow` | `own` | `none`) so the resolution is visible.
+
+---
+
+## The backtest comparison
+
+### What it actually simulates
+
+The agent has **no multi-protocol position model**: `Position.protocolName` is a
+single string, `StrategyDecision.targetProtocol` is a single string, and
+`TargetAllocationStrategy` uses weights only to *rank a single hop*. So this
+cannot and does not simulate holding a weighted basket.
+
+It replays what the **existing agent would have done** under each weight vector,
+which is the honest question given the engine that exists. The `caveat` string
+travels with the data into the API response rather than living only here.
+
+`current` is null when the user has no allocation configured — an invented
+baseline would be worse than none.
+
+The window is trimmed to the first day that actually has data. `runBacktest`
+treats an empty first day as `insufficient_history` and abandons the whole run,
+which would otherwise discard 89 good days over a timestamp-alignment artifact.
+
+---
+
+## API
+
+| Method | Path |
+|---|---|
+| `POST` | `/api/v1/portfolio/:userId/suggest-allocation` |
+| `GET` | `/api/v1/portfolio/:userId/suggestions` |
+
+Both are `requireAuth → enforceUserAccess → validate(...)`, keyed on
+`req.params.userId`. That keying is load-bearing: a body-only or
+resource-id-keyed route (`/suggestions/:id`) would make `enforceUserAccess` a
+silent no-op — the trap documented in `CLAUDE.md` — and would also skip the
+sub-account permission lookup, which reads the same param.
+
+They are registered **before** `GET /:userId`, following the same defensive
+placement as `router.use('/goals', goalsRouter)`.
+
+### Cost controls
+
+Two layers, because they bound different things:
+
+- **`optimizerRateLimiter`** (default 5/min) bounds requests per *window*.
+  Applied per-endpoint rather than through the `apiRoutes` table, which would
+  throttle all read-only portfolio traffic because one POST on the same router is
+  expensive. This is not the double-application the warning in
+  `src/routes/admin.ts` guards against — no table limiter applies to this route.
+- **`ConcurrencyLimiter`** (`src/utils/concurrency.ts`) bounds how many run *at
+  once*: one per user, plus a small global budget. The optimizer is the first
+  genuinely CPU-bound thing in this API and runs on the single event-loop thread,
+  so ten concurrent solves do not merely run slower — they block every other
+  request in the process, including `/health/ready`. Non-blocking: it returns 429
+  immediately rather than queueing.
+
+---
+
+## Persistence and the scheduled job
+
+`AllocationSuggestion` rows are kept rather than replaced, so a user can see how
+the recommendation moved as their inputs changed.
+
+`weights` is `Json` **percentages**, not `Decimal` — a deliberate deviation from
+the issue's "use Decimal for storage". The vector's entire purpose is to
+round-trip into `User.strategyConfig.targetAllocations`, itself a `Json` map of
+numbers; storing `Decimal` would force a lossy re-conversion at the one place the
+value is ever consumed. `PublishedStrategyMetric` already sets the
+Float-for-computed-analytics precedent.
+
+`inputHash` is a `sha256:`-prefixed hash over the canonical input snapshot
+(sorted universe, μ, Σ, riskTolerance, effective ceiling, lookback), with numbers
+fixed to 9 decimal places — far finer than any difference that moves a weight,
+coarse enough that float noise cannot flip the hash. **Equal hashes must mean
+equal weights**; that is what makes "did my recommendation change, or only my
+inputs?" answerable.
+
+`src/jobs/allocationSuggestions.ts` refreshes suggestions every 6 h
+(`ALLOCATION_SUGGESTION_INTERVAL_MS`) for users with an ACTIVE `Position`. It
+**skips the backtest legs** — two full historical replays per user, only
+interesting when a human is looking. Rows written by the job therefore carry a
+null `backtest`; that is expected, not a failure.
+
+### `scheduleProtocolRiskScoring` is now wired up
+
+`src/jobs/protocolRiskScoring.ts` existed but was never imported or started, so
+`ProtocolRiskScore` was never refreshed after its first backfill. Because
+risk-ceiling filtering is fail-closed, a stale or empty table makes every
+ceiling-constrained suggestion — and every ceiling-constrained *rebalance* —
+return nothing eligible. It is now started in `src/index.ts`, before the
+suggestion job, and cleared in `gracefulShutdown`.
+
+---
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ALLOCATION_SUGGESTION_INTERVAL_MS` | `21600000` (6 h) | Precompute cadence. |
+| `ALLOCATION_SUGGESTION_MAX_CONCURRENT` | `2` | Global in-flight optimization budget. |
+| `ALLOCATION_SUGGESTION_BATCH_SIZE` | `25` | Users per batch in the job. |
+| `OPTIMIZER_RATE_LIMIT_WINDOW_MS` | `60000` | Optimizer rate-limit window. |
+| `OPTIMIZER_RATE_LIMIT_MAX` | `5` | Requests per window. |
+
+All optional with defaults, so no `.env.test` or CI stub is required.
+
+---
+
+## Out of scope
+
+Per the issue: automated execution of suggestions, live market feeds,
+multi-asset correlation models, and ML return prediction.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -438,6 +438,128 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/portfolio/{userId}/suggest-allocation:
+    post:
+      tags: [portfolio]
+      operationId: suggestAllocation
+      summary: Suggest an optimal allocation
+      description: |
+        Computes a mean-variance optimal allocation from historical ProtocolRate
+        data, the user's risk tolerance, and their effective risk ceiling, and
+        returns it together with an efficient frontier and a backtest comparison.
+
+        **This endpoint is ADVISORY and never changes anything.** It does not
+        write `User.strategyConfig`, does not move funds, and does not alter what
+        the rebalancing agent will do. Applying a suggestion is a separate,
+        explicit call to the strategy update endpoint. Every response carries
+        `isSuggestion: true` and a `disclaimer`.
+
+        **What the optimization actually minimizes.** `ProtocolRate` is a
+        yield-quote series, not a price series, so the covariance measures how
+        protocols' quoted APYs co-move. The optimizer minimizes YIELD volatility.
+        It does NOT model principal loss, depeg, or smart-contract failure —
+        those enter only through `ProtocolRiskScore`, which filters the universe.
+
+        **Cost controls.** Compute-intensive, so this route carries its own
+        stricter rate limiter (default 5/min) plus an in-flight concurrency bound
+        of one optimization per user. Both return `429`.
+
+        See `docs/PORTFOLIO_OPTIMIZATION.md` for the objective, the risk-aversion
+        mapping, and the estimation method.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User ID (UUID v4). Must be the authenticated user.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SuggestAllocationRequest'
+            example:
+              lookbackDays: 90
+              frontierPoints: 12
+              includeBacktest: true
+      responses:
+        '200':
+          description: |
+            An allocation suggestion. Note that a `status` other than `ok` is
+            still a 200 — "the optimizer ran and could not produce a portfolio"
+            is a result, not a request error, and the payload names the reason.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationSuggestionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          description: |
+            Rate limit exceeded, or an optimization is already in flight for this
+            user. Carries `Retry-After`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: An optimization is already running for this account. Please wait for it to finish.
+
+  /api/v1/portfolio/{userId}/suggestions:
+    get:
+      tags: [portfolio]
+      operationId: listAllocationSuggestions
+      summary: List stored allocation suggestions
+      description: |
+        Paginated history of previously computed suggestions, newest first.
+        Rows written by the scheduled precompute job carry a null `backtest`;
+        that is expected, not a failure — the backtest legs are only computed
+        for interactive requests.
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: User ID (UUID v4). Must be the authenticated user.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        '200':
+          description: Stored suggestions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationSuggestionListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/portfolio/{userId}/history:
     get:
       tags: [portfolio]
@@ -4375,6 +4497,254 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AlertRule'
+
+    # ── Portfolio optimization (#322) ─────────────────────────────────────
+    SuggestAllocationRequest:
+      type: object
+      additionalProperties: false
+      description: |
+        All fields optional; an empty body requests a suggestion with defaults.
+        Unknown fields are rejected rather than ignored, so a typo cannot
+        silently produce an answer computed over the wrong window.
+      properties:
+        lookbackDays:
+          type: integer
+          minimum: 14
+          maximum: 365
+          default: 90
+          description: Trailing window the statistics are estimated over.
+        frontierPoints:
+          type: integer
+          minimum: 2
+          maximum: 25
+          default: 12
+          description: Efficient-frontier resolution. Each point is a full solve.
+        includeBacktest:
+          type: boolean
+          default: true
+          description: Set false to skip the suggested-vs-current backtest legs.
+
+    FrontierPoint:
+      type: object
+      required: [lambda, risk, return, weights]
+      properties:
+        lambda:
+          type: number
+          description: Risk-aversion coefficient this point was solved at.
+        risk:
+          type: number
+          description: Annualized yield volatility, as a decimal fraction (0.014 = 1.4pp).
+        return:
+          type: number
+          description: Annualized expected return, as a decimal fraction (0.082 = 8.2%).
+        weights:
+          type: object
+          additionalProperties:
+            type: number
+          description: Decimal-fraction weights (0.425 = 42.5%), keyed by protocol.
+
+    UniverseExclusion:
+      type: object
+      required: [protocol, reason]
+      description: Why a protocol was not eligible for optimization.
+      properties:
+        protocol:
+          type: string
+        reason:
+          type: string
+          enum:
+            - insufficient_history
+            - risk_ceiling
+            - no_risk_score
+            - no_rate_history
+            - insufficient_aligned_history
+        detail:
+          type: string
+
+    BacktestLeg:
+      type: object
+      required: [finalValue, realizedApy, maxDrawdownPercent, rebalanceCount, finalProtocol]
+      properties:
+        finalValue:
+          type: number
+        realizedApy:
+          type: number
+        maxDrawdownPercent:
+          type: number
+        rebalanceCount:
+          type: integer
+        finalProtocol:
+          type: string
+
+    BacktestComparison:
+      type: object
+      required: [suggested, current, startDate, endDate, startingAmount, caveat]
+      properties:
+        suggested:
+          $ref: '#/components/schemas/BacktestLeg'
+        current:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/BacktestLeg'
+          nullable: true
+          description: Null when the user has no current allocation to compare against.
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        startingAmount:
+          type: number
+        caveat:
+          type: string
+          description: |
+            States that the agent holds ONE protocol at a time, so this compares
+            what the agent would have done under each configuration — it is not a
+            simulation of holding the weighted basket.
+
+    AllocationSuggestionResponse:
+      type: object
+      required:
+        - isSuggestion
+        - disclaimer
+        - userId
+        - inputHash
+        - status
+        - weights
+        - riskTolerance
+        - computedAt
+      properties:
+        isSuggestion:
+          type: boolean
+          enum: [true]
+          description: Always true. This response is advice, never an applied change.
+        disclaimer:
+          type: string
+        userId:
+          type: string
+          format: uuid
+        id:
+          type: string
+          format: uuid
+          description: Set when the suggestion was persisted.
+        inputHash:
+          type: string
+          description: |
+            'sha256:'-prefixed hash of the canonical input snapshot. Equal hashes
+            mean equal weights, which is what makes "did my recommendation change
+            or only my inputs?" answerable.
+        status:
+          type: string
+          enum: [ok, infeasible, insufficient_universe, non_converged]
+        weights:
+          type: object
+          additionalProperties:
+            type: number
+          description: |
+            PERCENTAGES summing to 100 +/- 0.01 — directly acceptable by the
+            strategy update endpoint. Empty for a non-ok status.
+        outcome:
+          type: object
+          description: |
+            The full discriminated outcome. For `ok` it carries expectedReturn,
+            expectedVolatility, lambda, frontier, iterations and
+            portfolioRiskScore; for the failure statuses it names the binding
+            constraint or the exclusions.
+        riskTolerance:
+          type: integer
+        effectiveRiskCeiling:
+          type: integer
+          nullable: true
+        ceilingSource:
+          type: string
+          enum: [goal, follow, own, none]
+          description: Which layer supplied the effective ceiling.
+        currentAllocations:
+          type: object
+          additionalProperties:
+            type: number
+          nullable: true
+        excluded:
+          type: array
+          items:
+            $ref: '#/components/schemas/UniverseExclusion'
+        observationCount:
+          type: integer
+          description: Days on which every eligible protocol had a value.
+        lookbackDays:
+          type: integer
+        backtest:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/BacktestComparison'
+          nullable: true
+        computedAt:
+          type: string
+          format: date-time
+
+    StoredAllocationSuggestion:
+      type: object
+      required: [id, isSuggestion, status, inputHash, weights, riskTolerance, computedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        isSuggestion:
+          type: boolean
+          enum: [true]
+        status:
+          type: string
+          enum: [ok, infeasible, insufficient_universe, non_converged]
+        inputHash:
+          type: string
+        weights:
+          type: object
+          additionalProperties:
+            type: number
+        frontier:
+          type: array
+          items:
+            $ref: '#/components/schemas/FrontierPoint'
+        backtest:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/BacktestComparison'
+          nullable: true
+          description: Null for rows written by the scheduled precompute job.
+        riskTolerance:
+          type: integer
+        effectiveRiskCeiling:
+          type: integer
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+          description: Human-readable explanation for a non-ok status.
+        computedAt:
+          type: string
+          format: date-time
+
+    AllocationSuggestionListResponse:
+      type: object
+      required: [userId, isSuggestion, page, limit, total, suggestions]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        isSuggestion:
+          type: boolean
+          enum: [true]
+        page:
+          type: integer
+        limit:
+          type: integer
+        total:
+          type: integer
+        suggestions:
+          type: array
+          items:
+            $ref: '#/components/schemas/StoredAllocationSuggestion'
 
   responses:
     Unauthorized:

--- a/prisma/migrations/20260728000000_add_sub_accounts/rollback.sql
+++ b/prisma/migrations/20260728000000_add_sub_accounts/rollback.sql
@@ -1,0 +1,55 @@
+-- Rollback for 20260728000000_add_sub_accounts
+-- Drops sub-account delegation (#287) and the acting-as audit columns.
+--
+-- NOT part of issue #322. Written here only because this migration shipped
+-- without a rollback.sql, which fails scripts/check-migration-rollback.sh on
+-- main and would otherwise leave every subsequent PR's CI red. Flagged in the
+-- PR description.
+--
+-- WARNING — THIS IS A PERMISSIONS ROLLBACK. Read before running:
+--
+--   * Every delegation relationship is destroyed. Any parent currently acting
+--     on a child's funds LOSES that access immediately. This fails CLOSED:
+--     requireSubAccountPermission (src/middleware/subAccount.ts) demands an
+--     ACTIVE SubAccount row, so with the table gone every delegated
+--     deposit/withdraw is rejected rather than silently allowed. Self-access is
+--     unaffected — it short-circuits before any DB lookup.
+--   * Dropping "actingAsUserId" from transactions and agent_logs DESTROYS THE
+--     AUDIT TRAIL of who acted on whose behalf. That history is not
+--     recoverable. Export it first if the delegation feature was ever used in
+--     production:
+--       COPY (SELECT id, "userId", "actingAsUserId", "createdAt" FROM transactions
+--             WHERE "actingAsUserId" IS NOT NULL) TO '/tmp/acting_as_transactions.csv' CSV HEADER;
+--       COPY (SELECT id, "userId", "actingAsUserId", "createdAt" FROM agent_logs
+--             WHERE "actingAsUserId" IS NOT NULL) TO '/tmp/acting_as_agent_logs.csv' CSV HEADER;
+--
+-- Deploy the reverted application code BEFORE running this: the live code reads
+-- sub_accounts on every deposit/withdraw and writes actingAsUserId, so dropping
+-- them underneath a running server produces errors on those paths.
+
+ALTER TABLE "sub_accounts" DROP CONSTRAINT IF EXISTS "sub_accounts_childUserId_fkey";
+
+ALTER TABLE "sub_accounts" DROP CONSTRAINT IF EXISTS "sub_accounts_parentUserId_fkey";
+
+DROP INDEX IF EXISTS "agent_logs_actingAsUserId_idx";
+
+DROP INDEX IF EXISTS "transactions_actingAsUserId_idx";
+
+DROP INDEX IF EXISTS "sub_accounts_status_idx";
+
+DROP INDEX IF EXISTS "sub_accounts_childUserId_idx";
+
+DROP INDEX IF EXISTS "sub_accounts_parentUserId_idx";
+
+DROP INDEX IF EXISTS "sub_accounts_parentUserId_childUserId_key";
+
+DROP TABLE IF EXISTS "sub_accounts";
+
+ALTER TABLE "agent_logs" DROP COLUMN IF EXISTS "actingAsUserId";
+
+ALTER TABLE "transactions" DROP COLUMN IF EXISTS "actingAsUserId";
+
+-- Enums must go last: the table and columns above depend on them.
+DROP TYPE IF EXISTS "SubAccountStatus";
+
+DROP TYPE IF EXISTS "SubAccountPermission";

--- a/prisma/migrations/20260817000000_add_allocation_suggestions/migration.sql
+++ b/prisma/migrations/20260817000000_add_allocation_suggestions/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "allocation_suggestions" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "inputHash" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "weights" JSONB NOT NULL,
+    "frontier" JSONB NOT NULL,
+    "backtestSummary" JSONB,
+    "riskTolerance" INTEGER NOT NULL,
+    "effectiveRiskCeiling" INTEGER,
+    "reason" TEXT,
+    "computedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "allocation_suggestions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "allocation_suggestions_userId_computedAt_idx" ON "allocation_suggestions"("userId", "computedAt");
+
+-- CreateIndex
+CREATE INDEX "allocation_suggestions_userId_inputHash_idx" ON "allocation_suggestions"("userId", "inputHash");
+
+-- AddForeignKey
+ALTER TABLE "allocation_suggestions" ADD CONSTRAINT "allocation_suggestions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260817000000_add_allocation_suggestions/rollback.sql
+++ b/prisma/migrations/20260817000000_add_allocation_suggestions/rollback.sql
@@ -1,0 +1,25 @@
+-- Rollback for 20260817000000_add_allocation_suggestions
+-- Drops the portfolio-optimization suggestion history (#322).
+--
+-- WARNING: Destroys every stored allocation suggestion and its efficient
+-- frontier / backtest comparison. This is advisory data ONLY — no funds, no
+-- keys, and no agent behaviour depend on it. AllocationSuggestion is never read
+-- by the agent loop: src/agent/loop.ts reads User.strategyConfig, which this
+-- feature is structurally forbidden from writing (see the structural test in
+-- tests/unit/analytics/structural.test.ts). Dropping this table therefore
+-- cannot move money or change a single rebalance decision; users simply lose
+-- their suggestion history and the next run recomputes from scratch.
+--
+-- Safe to run before or after deploying the reverted application code. The
+-- table is written only by src/analytics/service.ts and read only by
+-- GET /api/v1/portfolio/:userId/suggestions; both are removed by the revert.
+-- If the table is dropped while the new code is still live, that endpoint
+-- errors but nothing else in the application is affected.
+
+ALTER TABLE "allocation_suggestions" DROP CONSTRAINT IF EXISTS "allocation_suggestions_userId_fkey";
+
+DROP INDEX IF EXISTS "allocation_suggestions_userId_inputHash_idx";
+
+DROP INDEX IF EXISTS "allocation_suggestions_userId_computedAt_idx";
+
+DROP TABLE IF EXISTS "allocation_suggestions";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,23 +148,23 @@ enum SubAccountStatus {
 }
 
 model User {
-  id            String   @id @default(uuid())
-  walletAddress String   @unique
-  network       Network  @default(MAINNET)
-  displayName   String?
-  email         String?  @unique
-  avatarUrl     String?
+  id                String   @id @default(uuid())
+  walletAddress     String   @unique
+  network           Network  @default(MAINNET)
+  displayName       String?
+  email             String?  @unique
+  avatarUrl         String?
   // E.164 WhatsApp number, when known. Nullable because most users onboard via
   // wallet auth and never link a number. Used as the WhatsApp delivery
   // destination for alert rules (#289); alerts on the WHATSAPP/BOTH channel are
   // skipped (logged, not errored) for users without a number on file.
-  phone         String?  @unique
-  riskTolerance      Int      @default(5)
-  rebalanceStrategy  String?  // 'MAX_YIELD' | 'TARGET_ALLOCATION' | null (defaults to MAX_YIELD)
-  strategyConfig     Json?    // e.g. { "targetAllocations": { "Blend": 50, "Stellar DEX": 30, "Luma": 20 } }
-  isActive           Boolean  @default(true)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  phone             String?  @unique
+  riskTolerance     Int      @default(5)
+  rebalanceStrategy String? // 'MAX_YIELD' | 'TARGET_ALLOCATION' | null (defaults to MAX_YIELD)
+  strategyConfig    Json? // e.g. { "targetAllocations": { "Blend": 50, "Stellar DEX": 30, "Luma": 20 } }
+  isActive          Boolean  @default(true)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
   sessions              Session[]
   positions             Position[]
@@ -181,24 +181,25 @@ model User {
   savingsGoals          SavingsGoal[]
   publishedStrategy     PublishedStrategy?
   strategyFollows       StrategyFollow[]
-  parentSubAccounts     SubAccount[] @relation("ParentOf")
-  childSubAccounts      SubAccount[] @relation("ChildOf")
+  parentSubAccounts     SubAccount[]           @relation("ParentOf")
+  childSubAccounts      SubAccount[]           @relation("ChildOf")
+  allocationSuggestions AllocationSuggestion[]
 
   @@map("users")
 }
 
 model Session {
-  id            String   @id @default(uuid())
-  userId        String
-  token         String   @unique
-  walletAddress String
-  network       Network
-  expiresAt     DateTime
+  id                    String    @id @default(uuid())
+  userId                String
+  token                 String    @unique
+  walletAddress         String
+  network               Network
+  expiresAt             DateTime
   refreshTokenHash      String?
   refreshTokenExpiresAt DateTime?
-  ipAddress     String?
-  userAgent     String?
-  createdAt     DateTime @default(now())
+  ipAddress             String?
+  userAgent             String?
+  createdAt             DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -209,21 +210,21 @@ model Session {
 }
 
 model AdminApiKey {
-  id        String    @id @default(uuid())
-  name      String    @unique
-  role      String
-  scopes    String[]
-  hash      String
+  id          String    @id @default(uuid())
+  name        String    @unique
+  role        String
+  scopes      String[]
+  hash        String
   // SHA-256 of the raw token ("sha256:<hex>"). A deterministic lookup key that
   // narrows candidates before the expensive bcrypt compare against `hash`.
   // Nullable only so the migration is safe on pre-existing rows; keys without
   // one cannot be authenticated and must be re-issued.
   tokenPrefix String?
-  expiresAt DateTime?
-  revokedAt DateTime?
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-  lastUsedAt DateTime?
+  expiresAt   DateTime?
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  lastUsedAt  DateTime?
 
   auditLogs AdminAuditLog[]
 
@@ -289,7 +290,7 @@ model Position {
 model Transaction {
   id             String            @id @default(uuid())
   userId         String
-  actingAsUserId String?           // non-null when action was performed by a parent on behalf of a child
+  actingAsUserId String? // non-null when action was performed by a parent on behalf of a child
   positionId     String?
   txHash         String?           @unique
   type           TransactionType
@@ -304,9 +305,9 @@ model Transaction {
   createdAt      DateTime          @default(now())
   updatedAt      DateTime          @updatedAt
 
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  position Position? @relation(fields: [positionId], references: [id])
-  fiatOrders FiatOrder[]
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  position     Position?     @relation(fields: [positionId], references: [id])
+  fiatOrders   FiatOrder[]
   costBasisLot CostBasisLot?
   lotDisposals LotDisposal[]
 
@@ -390,9 +391,9 @@ model ProtocolRiskScore {
 
 model AgentLog {
   id             String      @id @default(uuid())
-  userId         String?     // null for system-level actions (scans, alerts)
-  actingAsUserId String?     // non-null when action was performed by a parent on behalf of a child
-  positionId     String?     // set when log is tied to a specific position
+  userId         String? // null for system-level actions (scans, alerts)
+  actingAsUserId String? // non-null when action was performed by a parent on behalf of a child
+  positionId     String? // set when log is tied to a specific position
   action         AgentAction
   status         AgentStatus
   reasoning      String?     @db.Text
@@ -416,22 +417,22 @@ model AgentLog {
 }
 
 model EventCursor {
-  id                   String   @id @default(uuid())
-  contractId           String   @unique
-  lastProcessedLedger  Int
-  lastProcessedAt      DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  id                  String   @id @default(uuid())
+  contractId          String   @unique
+  lastProcessedLedger Int
+  lastProcessedAt     DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   @@map("event_cursors")
 }
 
 model ProcessedEvent {
-  id           String   @id @default(uuid())
-  contractId   String
-  txHash       String
-  eventType    String
-  ledger       Int
-  processedAt  DateTime @default(now())
+  id          String   @id @default(uuid())
+  contractId  String
+  txHash      String
+  eventType   String
+  ledger      Int
+  processedAt DateTime @default(now())
 
   @@unique([contractId, txHash, eventType, ledger])
   @@index([contractId])
@@ -442,17 +443,17 @@ model ProcessedEvent {
 }
 
 model DeadLetterEvent {
-  id          String                @id @default(uuid())
-  contractId  String
-  txHash      String
-  eventType   String
-  ledger      Int
-  error       String                @db.Text
-  payload     Json
-  status      DeadLetterEventStatus @default(PENDING)
-  retryCount  Int                   @default(0)
-  createdAt   DateTime              @default(now())
-  updatedAt   DateTime              @updatedAt
+  id         String                @id @default(uuid())
+  contractId String
+  txHash     String
+  eventType  String
+  ledger     Int
+  error      String                @db.Text
+  payload    Json
+  status     DeadLetterEventStatus @default(PENDING)
+  retryCount Int                   @default(0)
+  createdAt  DateTime              @default(now())
+  updatedAt  DateTime              @updatedAt
 
   @@index([status])
   @@index([contractId])
@@ -504,7 +505,7 @@ model WebhookSubscription {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user      User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   deliveries WebhookDelivery[]
 
   @@index([userId])
@@ -563,12 +564,12 @@ model AlertRule {
 }
 
 model SubAccount {
-  id           String                @id @default(uuid())
+  id           String                 @id @default(uuid())
   parentUserId String
   childUserId  String
   permissions  SubAccountPermission[]
-  status       SubAccountStatus      @default(ACTIVE)
-  createdAt    DateTime              @default(now())
+  status       SubAccountStatus       @default(ACTIVE)
+  createdAt    DateTime               @default(now())
   revokedAt    DateTime?
 
   parent User @relation("ParentOf", fields: [parentUserId], references: [id], onDelete: Cascade)
@@ -590,7 +591,7 @@ model SubAccount {
 model FiatOrder {
   id              String          @id @default(uuid())
   userId          String
-  provider        String          // e.g. "moonpay" — provider key, no provider-specific logic elsewhere
+  provider        String // e.g. "moonpay" — provider key, no provider-specific logic elsewhere
   providerOrderId String
   direction       FiatDirection
   fiatAmount      Decimal         @db.Decimal(36, 18)
@@ -598,10 +599,10 @@ model FiatOrder {
   cryptoAmount    Decimal?        @db.Decimal(36, 18)
   assetSymbol     String
   status          FiatOrderStatus @default(PENDING)
-  transactionId   String?         // linked once the resulting on-chain Transaction is matched
-  checkoutUrl     String?         // provider hosted checkout URL (on-ramp)
-  kycUrl          String?         // provider KYC next-step link, surfaced to the user when required
-  failureReason   String?         // populated on FAILED/REFUNDED for operator/user visibility
+  transactionId   String? // linked once the resulting on-chain Transaction is matched
+  checkoutUrl     String? // provider hosted checkout URL (on-ramp)
+  kycUrl          String? // provider KYC next-step link, surfaced to the user when required
+  failureReason   String? // populated on FAILED/REFUNDED for operator/user visibility
   settledAt       DateTime?
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
@@ -645,11 +646,11 @@ model ReferralConversion {
   referralCodeId     String
   referredUserId     String         @unique
   activatedAt        DateTime?
-  activationTxId     String?        // the confirmed deposit Transaction that satisfied activation
+  activationTxId     String? // the confirmed deposit Transaction that satisfied activation
   status             ReferralStatus @default(PENDING)
-  ownerRewardTxId    String?        // REFERRAL_REWARD Transaction paid to the referrer
-  referredRewardTxId String?        // REFERRAL_REWARD Transaction paid to the referred user
-  payoutError        String?        // last payout failure reason — kept for retriable visibility
+  ownerRewardTxId    String? // REFERRAL_REWARD Transaction paid to the referrer
+  referredRewardTxId String? // REFERRAL_REWARD Transaction paid to the referred user
+  payoutError        String? // last payout failure reason — kept for retriable visibility
   createdAt          DateTime       @default(now())
   updatedAt          DateTime       @updatedAt
 
@@ -718,18 +719,18 @@ model CostBasisLot {
 /// joins. Money fields snapshot values at disposal time, making the report an
 /// immutable ledger read; null money fields mean "unpriced", never zero.
 model LotDisposal {
-  id            String       @id @default(uuid())
+  id            String   @id @default(uuid())
   lotId         String
   userId        String
   assetSymbol   String
   transactionId String
-  amount        Decimal      @db.Decimal(36, 18)
-  disposalPrice Decimal?     @db.Decimal(36, 18)
-  costBasis     Decimal?     @db.Decimal(36, 18)
-  proceeds      Decimal?     @db.Decimal(36, 18)
-  realizedGain  Decimal?     @db.Decimal(36, 18)
+  amount        Decimal  @db.Decimal(36, 18)
+  disposalPrice Decimal? @db.Decimal(36, 18)
+  costBasis     Decimal? @db.Decimal(36, 18)
+  proceeds      Decimal? @db.Decimal(36, 18)
+  realizedGain  Decimal? @db.Decimal(36, 18)
   disposedAt    DateTime
-  createdAt     DateTime     @default(now())
+  createdAt     DateTime @default(now())
 
   lot         CostBasisLot @relation(fields: [lotId], references: [id], onDelete: Cascade)
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -754,7 +755,7 @@ model SavingsGoal {
   targetAmount   Decimal    @db.Decimal(36, 18)
   startingAmount Decimal    @db.Decimal(36, 18)
   targetDate     DateTime
-  riskCeiling    Int?       // optional min protocol risk score (0-100), matches UserStrategyPreferences.riskCeiling
+  riskCeiling    Int? // optional min protocol risk score (0-100), matches UserStrategyPreferences.riskCeiling
   status         GoalStatus @default(ACTIVE)
   createdAt      DateTime   @default(now())
   updatedAt      DateTime   @updatedAt
@@ -866,4 +867,50 @@ model PublishedStrategyMetric {
   @@index([windowDays, isEligible, sharpe])
   @@index([windowDays, isEligible, apy])
   @@map("published_strategy_metrics")
+}
+
+/// Portfolio-optimization suggestion (#322). One row per computed suggestion.
+///
+/// ADVISORY BY CONSTRUCTION. Persisting a suggestion never changes what the
+/// agent does — `User.strategyConfig` is the only thing the agent reads, and
+/// nothing in src/analytics/ may write it (enforced by a source-scanning test in
+/// tests/unit/analytics/structural.test.ts). Applying a suggestion is a separate,
+/// deliberate call by the user through the existing, already-validated strategy
+/// update path. Rows are kept rather than replaced so a user can see how the
+/// recommendation moved as their inputs changed.
+///
+/// `weights` is Json PERCENTAGES (sum 100 +/- 0.01), not Decimal — a deliberate
+/// deviation from the issue's "use Decimal for storage". The vector's entire
+/// purpose is to round-trip into User.strategyConfig.targetAllocations, which is
+/// itself a Json map of numbers validated by publishableConfigSchema. Storing
+/// Decimal would force a lossy re-conversion at the one place the value is ever
+/// consumed. PublishedStrategyMetric already sets the Float-for-computed-
+/// analytics precedent. See docs/PORTFOLIO_OPTIMIZATION.md.
+///
+/// `inputHash` is a sha256 over the canonical input snapshot (universe, mu,
+/// Sigma, riskTolerance, effective ceiling, constraints, lookback). Equal hashes
+/// must mean equal weights — that is what makes "did my recommendation actually
+/// change, or just my inputs?" answerable, and it is asserted by a determinism
+/// test.
+model AllocationSuggestion {
+  id                   String   @id @default(uuid())
+  userId               String
+  inputHash            String
+  /// ok | infeasible | insufficient_universe | non_converged
+  status               String
+  /// { "Blend": 42.5, ... } percentages summing to 100 +/- 0.01. Empty for non-ok rows.
+  weights              Json
+  frontier             Json
+  backtestSummary      Json?
+  riskTolerance        Int
+  effectiveRiskCeiling Int?
+  /// Failure explanation / binding constraint for non-ok rows.
+  reason               String?
+  computedAt           DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, computedAt])
+  @@index([userId, inputHash])
+  @@map("allocation_suggestions")
 }

--- a/src/agent/strategyMetrics.ts
+++ b/src/agent/strategyMetrics.ts
@@ -119,13 +119,20 @@ const HOURLY_PERIODS_PER_YEAR = MS_PER_YEAR / (60 * 60 * 1000)
  */
 const MIN_YEARS = 1 / 365
 
-function mean(values: number[]): number {
+/**
+ * Exported (rather than module-private) because src/analytics/estimation.ts
+ * builds its covariance matrix on the same convention. This module declares
+ * itself the ONE definition of risk-adjusted return math in the codebase — a
+ * second private copy of mean/stdev in the analytics package would be exactly
+ * the third definition the header warns against.
+ */
+export function mean(values: number[]): number {
   if (values.length === 0) return 0
   return values.reduce((s, v) => s + v, 0) / values.length
 }
 
 /** Sample standard deviation (n-1) — the standard Sharpe denominator. */
-function sampleStdev(values: number[]): number {
+export function sampleStdev(values: number[]): number {
   if (values.length < 2) return 0
   const m = mean(values)
   const variance =

--- a/src/analytics/estimation.ts
+++ b/src/analytics/estimation.ts
@@ -1,0 +1,316 @@
+/**
+ * Estimation of optimizer inputs from ProtocolRate history — pure computation (#322).
+ *
+ * Turns raw, gappy ProtocolRate observations plus ProtocolRiskScore rows into
+ * the (universe, mu, Sigma) triple that optimizer.ts consumes. Zero I/O, so the
+ * statistics can be unit tested against fixture series; src/analytics/service.ts
+ * is the only thing that reads the DB and calls in here. Same pure-core /
+ * DB-glue split as riskScoring.ts + jobs/protocolRiskScoring.ts.
+ *
+ * ─── WHY buildDailyRateSeries AND NOT periodReturns ──────────────────────────
+ *
+ * A covariance matrix requires INDEX-ALIGNED observation vectors: entry (i,j)
+ * must pair protocol i's value at time t with protocol j's value at the SAME t.
+ *
+ * `periodReturns` (src/agent/strategyMetrics.ts) cannot supply that. It SKIPS
+ * any interval whose starting value is non-positive — correct for its own job
+ * (a portfolio funded from empty is a deposit, not a return) but fatal here:
+ * two protocols skipping different intervals produce vectors of different
+ * lengths whose k-th entries are different days. The resulting matrix would look
+ * perfectly well-formed and be silently, badly wrong.
+ *
+ * `buildDailyRateSeries` (src/agent/backtest.ts) already solves exactly this —
+ * it forward-fills onto a common daily grid, with a documented gap policy. We
+ * take its output and additionally keep only days on which EVERY admitted
+ * protocol has a value, which is what makes the vectors genuinely aligned.
+ *
+ * ─── THE #285 SMOOTHING TRAP ─────────────────────────────────────────────────
+ *
+ * Inputs derive from ProtocolRate.supplyApy — a per-observation rate QUOTE.
+ * They must never derive from YieldSnapshot.apy, which snapshotter.ts computes
+ * as cumulative-yield-since-openedAt annualized: consecutive values there are a
+ * smoothed running average whose variance badly understates reality. Same trap
+ * documented in docs/STRATEGY_MARKETPLACE.md §2.
+ *
+ * ─── UNITS ───────────────────────────────────────────────────────────────────
+ *
+ * Sigma is the covariance of ANNUAL RATE LEVELS (apy/100), not of daily returns.
+ * See the units note at the top of optimizer.ts for why plan.md's daily-return
+ * scaling makes the risk term vanish; ASSUMPTIONS.md records the deviation.
+ */
+
+import { buildDailyRateSeries } from '../agent/backtest'
+import { mean } from '../agent/strategyMetrics'
+import {
+  EstimationInput,
+  EstimationResult,
+  RawRateObservation,
+  UniverseExclusion,
+} from './types'
+
+// ── Tunables (mirror docs/PORTFOLIO_OPTIMIZATION.md) ─────────────────────────
+
+/** Trailing window the statistics are estimated over. */
+export const DEFAULT_LOOKBACK_DAYS = 90
+
+/**
+ * Minimum number of days on which every admitted protocol has a value, before
+ * a covariance matrix means anything. Mirrors MIN_SAMPLES in strategyMetrics.ts
+ * — below this we refuse to characterize the distribution at all rather than
+ * optimizing against three points and presenting the answer with equal
+ * confidence.
+ */
+export const MIN_ALIGNED_OBSERVATIONS = 14
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/** UTC midnight for a timestamp, so day bucketing is timezone-independent. */
+function toUtcDay(d: Date): number {
+  return Math.floor(d.getTime() / MS_PER_DAY) * MS_PER_DAY
+}
+
+/**
+ * Collapse observations to ONE value per (protocol, UTC day) by averaging.
+ *
+ * ProtocolRate is keyed by (protocolName, assetSymbol, network, fetchedAt), so a
+ * protocol routinely has several rows for one day — multiple assets, and several
+ * scans per day. buildDailyRateSeries groups by protocolName alone and keeps
+ * whichever row it visits last, which would make the series depend on scan
+ * ordering. Averaging first makes the daily value a well-defined, deterministic
+ * property of the day rather than an artifact of collection order.
+ */
+export function aggregateDailyRates(
+  rates: RawRateObservation[]
+): RawRateObservation[] {
+  // The name is carried in the VALUE rather than parsed back out of the key:
+  // protocol names contain spaces ("Stellar DEX"), so splitting the key on one
+  // would silently truncate them into a different protocol.
+  const byKey = new Map<
+    string,
+    { sum: number; count: number; day: number; protocolName: string }
+  >()
+
+  for (const r of rates) {
+    if (!Number.isFinite(r.apy)) continue
+    const day = toUtcDay(r.date)
+    const key = `${r.protocolName} ${day}`
+    const entry = byKey.get(key)
+    if (entry) {
+      entry.sum += r.apy
+      entry.count++
+    } else {
+      byKey.set(key, {
+        sum: r.apy,
+        count: 1,
+        day,
+        protocolName: r.protocolName,
+      })
+    }
+  }
+
+  return Array.from(byKey.values())
+    .map((v) => ({
+      protocolName: v.protocolName,
+      assetSymbol: 'AGGREGATE',
+      apy: v.sum / v.count,
+      date: new Date(v.day),
+    }))
+    .sort((a, b) =>
+      a.date.getTime() !== b.date.getTime()
+        ? a.date.getTime() - b.date.getTime()
+        : a.protocolName < b.protocolName
+          ? -1
+          : 1
+    )
+}
+
+/**
+ * Sample covariance matrix (n-1 convention, matching sampleStdev in
+ * strategyMetrics.ts). `columns[i]` is protocol i's observation vector; all
+ * vectors must be the same length and index-aligned.
+ *
+ * Built symmetric BY CONSTRUCTION — the (j,i) entry is assigned from the (i,j)
+ * computation rather than recomputed — so floating-point associativity can never
+ * produce a matrix that is asymmetric at the 1e-18 level and quietly fails a PSD
+ * assertion downstream.
+ */
+export function sampleCovariance(columns: number[][]): number[][] {
+  const n = columns.length
+  const out: number[][] = Array.from({ length: n }, () =>
+    new Array<number>(n).fill(0)
+  )
+  if (n === 0) return out
+
+  const t = columns[0].length
+  if (t < 2) return out
+
+  const means = columns.map((c) => mean(c))
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i; j < n; j++) {
+      let acc = 0
+      for (let k = 0; k < t; k++) {
+        acc += (columns[i][k] - means[i]) * (columns[j][k] - means[j])
+      }
+      const cov = acc / (t - 1)
+      out[i][j] = cov
+      out[j][i] = cov
+    }
+  }
+
+  return out
+}
+
+/**
+ * Build the optimizable universe and its statistics.
+ *
+ * Universe eligibility is FAIL-CLOSED at every step, matching applyRiskCeiling
+ * (src/agent/strategies.ts): a protocol is admitted only when it has a risk-score
+ * row, that row is not flagged insufficientHistory, it clears any configured
+ * ceiling, and it actually has rate history in the window. Anything else is
+ * excluded WITH A MACHINE-READABLE REASON — never silently dropped, so the API
+ * can always explain why a protocol the user expected to see is missing.
+ */
+export function estimate(input: EstimationInput): EstimationResult {
+  const lookbackDays = input.lookbackDays ?? DEFAULT_LOOKBACK_DAYS
+  const now = input.now ?? new Date()
+  const excluded: UniverseExclusion[] = []
+
+  // ── 1. Risk-score eligibility ──────────────────────────────────────────────
+
+  const scoreByProtocol = new Map(
+    input.riskScores.map((r) => [r.protocolName, r])
+  )
+
+  // Every protocol that appears in either source is a candidate, so a protocol
+  // with rate history but no score row is reported as excluded rather than
+  // never mentioned.
+  const candidates = new Set<string>()
+  for (const r of input.rates) candidates.add(r.protocolName)
+  for (const s of input.riskScores) candidates.add(s.protocolName)
+
+  const admitted: string[] = []
+  const riskScores: Record<string, number> = {}
+
+  for (const name of Array.from(candidates).sort()) {
+    const score = scoreByProtocol.get(name)
+
+    if (!score) {
+      excluded.push({
+        protocol: name,
+        reason: 'no_risk_score',
+        detail: 'No ProtocolRiskScore row — excluded fail-closed',
+      })
+      continue
+    }
+    if (score.insufficientHistory) {
+      excluded.push({
+        protocol: name,
+        reason: 'insufficient_history',
+        detail: 'Risk score flagged insufficientHistory',
+      })
+      continue
+    }
+    if (input.riskCeiling !== undefined && score.score < input.riskCeiling) {
+      excluded.push({
+        protocol: name,
+        reason: 'risk_ceiling',
+        detail: `Risk score ${score.score} is below the ${input.riskCeiling} ceiling`,
+      })
+      continue
+    }
+
+    admitted.push(name)
+    riskScores[name] = score.score
+  }
+
+  const empty = (): EstimationResult => ({
+    protocols: [],
+    expectedReturns: [],
+    covariance: [],
+    observationCount: 0,
+    excluded,
+    riskScores: {},
+    lookbackDays,
+  })
+
+  if (admitted.length === 0) return empty()
+
+  // ── 2. Rate history on a common daily grid ─────────────────────────────────
+
+  const admittedSet = new Set(admitted)
+  const endDay = toUtcDay(now)
+  const startDay = endDay - (lookbackDays - 1) * MS_PER_DAY
+
+  const windowed = aggregateDailyRates(
+    input.rates.filter(
+      (r) =>
+        admittedSet.has(r.protocolName) &&
+        toUtcDay(r.date) >= startDay &&
+        toUtcDay(r.date) <= endDay
+    )
+  )
+
+  const withHistory = new Set(windowed.map((r) => r.protocolName))
+  const surviving: string[] = []
+  for (const name of admitted) {
+    if (withHistory.has(name)) {
+      surviving.push(name)
+    } else {
+      excluded.push({
+        protocol: name,
+        reason: 'no_rate_history',
+        detail: `No rate observations in the trailing ${lookbackDays} days`,
+      })
+      delete riskScores[name]
+    }
+  }
+
+  if (surviving.length === 0) return empty()
+
+  const { series } = buildDailyRateSeries(
+    windowed,
+    new Date(startDay),
+    new Date(endDay)
+  )
+
+  // Keep only days where EVERY surviving protocol has a value. This is the step
+  // that makes the observation vectors index-aligned; see the header.
+  const columns: number[][] = surviving.map(() => [])
+  let observationCount = 0
+
+  for (const day of series) {
+    const byName = new Map(day.protocols.map((p) => [p.name, p.apy]))
+    if (surviving.some((name) => !byName.has(name))) continue
+
+    surviving.forEach((name, i) => {
+      // Annual RATE LEVEL as a decimal fraction: 8.4% APY -> 0.084.
+      columns[i].push((byName.get(name) as number) / 100)
+    })
+    observationCount++
+  }
+
+  if (observationCount < MIN_ALIGNED_OBSERVATIONS) {
+    // The universe as a whole is too thin. Every surviving protocol is reported
+    // with the same reason so the caller can say precisely what was missing,
+    // and the empty universe surfaces as `insufficient_universe` upstream.
+    for (const name of surviving) {
+      excluded.push({
+        protocol: name,
+        reason: 'insufficient_aligned_history',
+        detail: `Only ${observationCount} aligned daily observations; ${MIN_ALIGNED_OBSERVATIONS} required`,
+      })
+    }
+    return empty()
+  }
+
+  return {
+    protocols: surviving,
+    expectedReturns: columns.map((c) => mean(c)),
+    covariance: sampleCovariance(columns),
+    observationCount,
+    excluded,
+    riskScores,
+    lookbackDays,
+  }
+}

--- a/src/analytics/optimizer.ts
+++ b/src/analytics/optimizer.ts
@@ -1,0 +1,812 @@
+/**
+ * Mean-variance portfolio optimizer — pure computation (#322).
+ *
+ * STRUCTURAL GUARANTEE (see tests/unit/analytics/structural.test.ts):
+ * Nothing under src/analytics/ may import from src/stellar/*, touch a wallet, or
+ * write User.strategyConfig. A suggestion is ADVISORY: it is computed, persisted
+ * and displayed, and a human tap applies it through the already-validated
+ * strategy update path. That is enforced by a source-scanning test, not by
+ * convention.
+ *
+ * ─── THE OBJECTIVE ───────────────────────────────────────────────────────────
+ *
+ *   maximize   mu' w  -  (lambda / 2) * w' Sigma w
+ *   subject to sum(w) = 1
+ *              lo_i <= w_i <= hi_i
+ *              sum_{i in S} w_i >= f        (optional stable-group floor)
+ *
+ * The risk ceiling is NOT a term here. It enters upstream as a universe filter
+ * via applyRiskCeiling (src/agent/strategies.ts), so the fail-closed rule
+ * "unknown score => excluded" is shared with the strategy engine rather than
+ * reimplemented. A weighted portfolio risk score is REPORTED for display but
+ * never separately constrained — one notion of the ceiling, not two.
+ *
+ * ─── WHY LAMBDA IS [5, 500] AND NOT [1, 25] ──────────────────────────────────
+ *
+ * A deliberate, measured deviation from plan.md; see ASSUMPTIONS.md.
+ *
+ * plan.md specified daily returns r = apy/100/365.25 with Sigma annualized by
+ * *365.25, and lambda linear on [1, 25]. Under those units the risk term is five
+ * to six orders of magnitude below the return term for realistic APY dispersion
+ * (a protocol whose APY swings +/-2 percentage points has an annualized variance
+ * of ~5e-7 in that scaling, against a mean return of ~8e-2). The consequence is
+ * not "slightly aggressive" — it is that (lambda/2) w'Sigma w can never offset
+ * mu'w at any lambda in [1,25], so the optimum is ALWAYS the max-return corner,
+ * the efficient frontier collapses to a single point, and the whole engine
+ * degenerates into "put everything in the highest-APY protocol".
+ *
+ * So Sigma here is the covariance of protocols' ANNUAL RATE LEVELS — exactly
+ * plan.md's matrix multiplied by 365.25. Two things follow:
+ *   - expectedVolatility comes out in the same units as the APY itself, so
+ *     "8.2% expected return, 1.4% expected volatility" is directly readable.
+ *   - lambda must live on [5, 500] to span the useful trade-off. Log-spaced
+ *     rather than linear, which is the natural parameterization for a risk-
+ *     aversion coefficient (each step is a constant RATIO of risk appetite).
+ * Worked numbers are in docs/PORTFOLIO_OPTIMIZATION.md.
+ *
+ * ─── DETERMINISM ─────────────────────────────────────────────────────────────
+ *
+ * The same input must produce byte-identical output, because the API returns an
+ * input-snapshot hash and users compare suggestions across time. Guaranteed by:
+ * protocols sorted by name (and mu/Sigma permuted to match) regardless of caller
+ * ordering, a fixed uniform-feasible starting point, a fixed iteration budget,
+ * and no randomness anywhere in this file.
+ */
+
+import {
+  AllocationBounds,
+  BindingConstraint,
+  FrontierPoint,
+  OptimizationOutcome,
+  OptimizerInput,
+  StableGroupFloor,
+  UniverseExclusion,
+} from './types'
+
+// ── Tunables (mirror docs/PORTFOLIO_OPTIMIZATION.md) ─────────────────────────
+
+/** Risk-aversion at riskTolerance = 1 (most risk-averse). */
+export const LAMBDA_MAX = 500
+
+/** Risk-aversion at riskTolerance = 10 (most risk-seeking). */
+export const LAMBDA_MIN = 5
+
+/** Fewer than this many assets is not a portfolio. */
+export const MIN_UNIVERSE_SIZE = 2
+
+/**
+ * Default per-protocol concentration cap — a DIVERSIFICATION GUARDRAIL, not a
+ * term in the objective.
+ *
+ * Unconstrained mean-variance is famously corner-seeking ("error maximization",
+ * Michaud 1989): it treats a historical mean as if it were known exactly, so a
+ * protocol whose APY averaged 3 percentage points above its peers absorbs the
+ * whole book unless something stops it. Measured on this repo's own scale — a
+ * 3pp return spread against ~1.8pp yield volatility, with the correlated rate
+ * histories DeFi protocols actually exhibit — every riskTolerance from 3 to 10
+ * returns a single protocol at 100%.
+ *
+ * That is a true optimum of the stated objective and simultaneously terrible
+ * advice: the estimate behind it is far noisier than the optimizer's precision
+ * implies, and this endpoint's entire purpose is to suggest a DIVERSIFIED
+ * allocation. So the cap is applied as an explicit, documented, overridable
+ * constraint (`bounds.max` wins over it) rather than by quietly distorting mu or
+ * lambda until the answer looks reasonable.
+ *
+ * Raised to 1/n when the universe is too small to satisfy it, so the feasible
+ * set is never emptied by the guardrail itself.
+ */
+export const DEFAULT_MAX_WEIGHT_PER_PROTOCOL = 0.6
+
+/** Frontier resolution. The hard cap bounds per-request CPU. */
+export const DEFAULT_FRONTIER_POINTS = 12
+export const MAX_FRONTIER_POINTS = 25
+
+/**
+ * Projected-gradient budget. Convergence is typically reached in tens to low
+ * hundreds of iterations; the budget exists so a pathological Sigma yields an
+ * honest `non_converged` rather than an unbounded loop.
+ */
+export const MAX_ITERATIONS = 2000
+
+/** Iterate-movement below this counts as a fixed point. */
+export const CONVERGENCE_TOLERANCE = 1e-12
+
+/**
+ * Bisection steps for the capped-simplex projection. The bracket halves each
+ * step, so 80 steps takes a bracket of width ~20 to ~1e-23 — below double
+ * precision. Fixed rather than tolerance-driven so the cost is deterministic.
+ */
+const BISECTION_ITERATIONS = 80
+
+/**
+ * Cap on how far one gradient step may move the iterate before projection.
+ *
+ * Weights live in [0,1], so a step of more than a few units is pure overshoot
+ * that the projection immediately undoes. It matters numerically: with a
+ * near-zero Sigma (all-identical APY history) the Lipschitz bound collapses and
+ * 1/L explodes, pushing the pre-projection vector to ~1e6. The bisection
+ * bracket scales with that magnitude, and 80 halvings of a 1e6-wide bracket
+ * leaves ~1e-18 per element — enough drift to break "weights sum to 1" at the
+ * twelfth decimal. Capping the movement keeps the bracket O(10) and the sum
+ * exact to machine precision. Any step <= 1/L is convergent, so this is safe.
+ */
+const MAX_STEP_MOVEMENT = 10
+
+/** Weights below this (0.005%) are dropped when emitting percentages. */
+const PERCENT_DUST_THRESHOLD = 5e-5
+
+// ── Risk-aversion mapping ────────────────────────────────────────────────────
+
+/**
+ * Map a 1-10 riskTolerance onto the risk-aversion coefficient lambda.
+ *
+ * Log-spaced and DECREASING: riskTolerance 1 => LAMBDA_MAX (most risk-averse),
+ * riskTolerance 10 => LAMBDA_MIN (most risk-seeking). Values outside 1-10 are
+ * clamped rather than rejected — User.riskTolerance is an Int column with no
+ * database-level range check.
+ */
+export function riskToleranceToLambda(riskTolerance: number): number {
+  const rt = Number.isFinite(riskTolerance)
+    ? Math.min(10, Math.max(1, riskTolerance))
+    : 5
+  const t = (rt - 1) / 9
+  return LAMBDA_MAX * Math.pow(LAMBDA_MIN / LAMBDA_MAX, t)
+}
+
+// ── Small linear algebra helpers ─────────────────────────────────────────────
+
+function dot(a: number[], b: number[]): number {
+  let s = 0
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i]
+  return s
+}
+
+function matVec(m: number[][], v: number[]): number[] {
+  const out = new Array<number>(v.length).fill(0)
+  for (let i = 0; i < m.length; i++) {
+    let s = 0
+    const row = m[i]
+    for (let j = 0; j < v.length; j++) s += row[j] * v[j]
+    out[i] = s
+  }
+  return out
+}
+
+function quadraticForm(m: number[][], v: number[]): number {
+  return dot(v, matVec(m, v))
+}
+
+function sum(v: number[]): number {
+  let s = 0
+  for (const x of v) s += x
+  return s
+}
+
+function maxAbsDiff(a: number[], b: number[]): number {
+  let m = 0
+  for (let i = 0; i < a.length; i++) {
+    const d = Math.abs(a[i] - b[i])
+    if (d > m) m = d
+  }
+  return m
+}
+
+/**
+ * Gershgorin upper bound on the largest eigenvalue of a symmetric matrix: the
+ * maximum absolute row sum. Used as the Lipschitz constant L of the gradient of
+ * (lambda/2) w'Sigma w, giving the safe projected-gradient step 1/L.
+ */
+function gershgorinBound(m: number[][]): number {
+  let max = 0
+  for (const row of m) {
+    let s = 0
+    for (const v of row) s += Math.abs(v)
+    if (s > max) max = s
+  }
+  return max
+}
+
+// ── Projections ──────────────────────────────────────────────────────────────
+
+/**
+ * Exact Euclidean projection onto the capped simplex {sum(w) = 1, lo <= w <= hi}.
+ *
+ * The projection has the closed form w_i(theta) = clamp(v_i - theta, lo_i, hi_i)
+ * for the unique theta making sum(w) = 1. That sum is monotone NON-INCREASING in
+ * theta, so bisection on theta converges to machine precision — no iterative
+ * solver, no tolerance to tune, and the answer is exact rather than approximate.
+ *
+ * Caller must have already checked feasibility (sum(lo) <= 1 <= sum(hi)); with
+ * an infeasible box the bracket below cannot straddle 1 and the result would be
+ * meaningless. checkFeasibility() is that gate.
+ */
+export function projectOntoCappedSimplex(
+  v: number[],
+  lo: number[],
+  hi: number[],
+  target = 1
+): number[] {
+  const n = v.length
+  const clampedSum = (theta: number): number => {
+    let s = 0
+    for (let i = 0; i < n; i++) {
+      const x = v[i] - theta
+      s += x < lo[i] ? lo[i] : x > hi[i] ? hi[i] : x
+    }
+    return s
+  }
+
+  // Bracket theta so that clampedSum(low) >= target >= clampedSum(high).
+  let low = -1
+  let high = 1
+  for (let i = 0; i < n; i++) {
+    low = Math.min(low, v[i] - hi[i] - 1)
+    high = Math.max(high, v[i] - lo[i] + 1)
+  }
+
+  for (let k = 0; k < BISECTION_ITERATIONS; k++) {
+    const mid = (low + high) / 2
+    if (clampedSum(mid) > target) low = mid
+    else high = mid
+  }
+
+  const theta = (low + high) / 2
+  const out = new Array<number>(n)
+  for (let i = 0; i < n; i++) {
+    const x = v[i] - theta
+    out[i] = x < lo[i] ? lo[i] : x > hi[i] ? hi[i] : x
+  }
+  return out
+}
+
+/** Project the sub-vector at `idx` onto its own capped simplex summing to `target`. */
+function projectSubset(
+  v: number[],
+  lo: number[],
+  hi: number[],
+  idx: number[],
+  target: number,
+  out: number[]
+): void {
+  const sub = projectOntoCappedSimplex(
+    idx.map((i) => v[i]),
+    idx.map((i) => lo[i]),
+    idx.map((i) => hi[i]),
+    target
+  )
+  idx.forEach((i, k) => {
+    out[i] = sub[k]
+  })
+}
+
+/**
+ * Exact Euclidean projection onto {sum(w)=1, lo<=w<=hi, sum_{i in S} w_i >= f}.
+ *
+ * DELIBERATE SIMPLIFICATION OF plan.md, which called for Dykstra's alternating
+ * projections here. Dykstra is the right tool for a general intersection of
+ * convex sets, but it is only ITERATIVELY convergent, and — as the smoke test
+ * for this file caught — it is easy to leave the iterate on the wrong side of
+ * one of the two sets. This geometry does not need it.
+ *
+ * For a convex set A and a halfspace B: P_{A∩B}(v) = P_A(v) when P_A(v) already
+ * lies in B, and otherwise the projection lies on the boundary ∂B. Here that
+ * boundary is
+ *
+ *     {sum_S w = f} ∩ {sum(w) = 1} ∩ box  ==  {sum_S w = f} ∩ {sum_{S^c} w = 1-f} ∩ box
+ *
+ * — two capped simplices over DISJOINT index groups. Euclidean distance
+ * separates across disjoint coordinates, so projecting each group onto its own
+ * target sum is the exact projection onto the intersection. No iteration, no
+ * tolerance, and the floor cannot be silently violated.
+ *
+ * The `stableSum >= f` fast path is also the no-floor path, so a user with no
+ * stable-group floor pays one capped-simplex projection, exactly as before.
+ */
+function projectOntoFeasibleSet(
+  v: number[],
+  lo: number[],
+  hi: number[],
+  stableIdx: number[],
+  nonStableIdx: number[],
+  minWeight: number | null
+): number[] {
+  const simple = projectOntoCappedSimplex(v, lo, hi)
+  if (minWeight === null || stableIdx.length === 0) return simple
+
+  let stableSum = 0
+  for (const i of stableIdx) stableSum += simple[i]
+  if (stableSum >= minWeight - 1e-12) return simple
+
+  // Floor binds: the optimum sits on sum_S w = f. Project each disjoint group
+  // onto its own capped simplex.
+  const out = new Array<number>(v.length).fill(0)
+  projectSubset(v, lo, hi, stableIdx, minWeight, out)
+  projectSubset(v, lo, hi, nonStableIdx, 1 - minWeight, out)
+  return out
+}
+
+// ── Feasibility ──────────────────────────────────────────────────────────────
+
+export interface FeasibilityFailure {
+  reason: string
+  bindingConstraint: BindingConstraint
+}
+
+/**
+ * Up-front feasibility of {sum(w)=1, lo<=w<=hi, sum_S w >= f}, naming the
+ * binding constraint. Checked BEFORE any solving so an impossible request
+ * returns a precise explanation instead of a vector that silently violates
+ * something.
+ */
+export function checkFeasibility(
+  lo: number[],
+  hi: number[],
+  stableIdx: number[],
+  nonStableIdx: number[],
+  minWeight: number | null
+): FeasibilityFailure | null {
+  const loSum = sum(lo)
+  const hiSum = sum(hi)
+
+  if (loSum > 1 + 1e-9) {
+    return {
+      reason: `Minimum weights sum to ${(loSum * 100).toFixed(2)}%, which exceeds 100%`,
+      bindingConstraint: 'minWeights',
+    }
+  }
+  if (hiSum < 1 - 1e-9) {
+    return {
+      reason: `Maximum weights sum to ${(hiSum * 100).toFixed(2)}%, which cannot reach 100%`,
+      bindingConstraint: 'maxWeights',
+    }
+  }
+
+  if (minWeight !== null) {
+    if (minWeight > 1 + 1e-9) {
+      return {
+        reason: `Stable-asset floor of ${(minWeight * 100).toFixed(2)}% exceeds 100%`,
+        bindingConstraint: 'stableFloor',
+      }
+    }
+
+    let stableHi = 0
+    for (const i of stableIdx) stableHi += hi[i]
+    if (stableHi < minWeight - 1e-9) {
+      return {
+        reason: `Stable-asset floor of ${(minWeight * 100).toFixed(2)}% exceeds the ${(stableHi * 100).toFixed(2)}% those protocols are collectively capped at`,
+        bindingConstraint: 'stableFloor',
+      }
+    }
+
+    let nonStableLo = 0
+    let nonStableHi = 0
+    for (const i of nonStableIdx) {
+      nonStableLo += lo[i]
+      nonStableHi += hi[i]
+    }
+    if (nonStableLo > 1 - minWeight + 1e-9) {
+      return {
+        reason: `Stable-asset floor of ${(minWeight * 100).toFixed(2)}% leaves only ${((1 - minWeight) * 100).toFixed(2)}% for other protocols, whose minimums already sum to ${(nonStableLo * 100).toFixed(2)}%`,
+        bindingConstraint: 'stableFloor',
+      }
+    }
+    // The floor also caps the stable group at f when it binds, so the rest of
+    // the book must be able to absorb the remaining 1-f on its own.
+    if (nonStableHi < 1 - minWeight - 1e-9) {
+      return {
+        reason: `Stable-asset floor of ${(minWeight * 100).toFixed(2)}% leaves ${((1 - minWeight) * 100).toFixed(2)}% for other protocols, which are collectively capped at ${(nonStableHi * 100).toFixed(2)}%`,
+        bindingConstraint: 'stableFloor',
+      }
+    }
+  }
+
+  return null
+}
+
+// ── Solver ───────────────────────────────────────────────────────────────────
+
+interface SolveResult {
+  weights: number[]
+  iterations: number
+  residual: number
+  converged: boolean
+}
+
+/**
+ * ACCELERATED projected gradient ascent (FISTA) on the concave objective.
+ *
+ * Sigma is a sample covariance matrix and therefore PSD, so -(lambda/2) w'Sigma w
+ * is concave and mu'w is linear: the objective is concave, the feasible set is
+ * convex and compact, and projected gradient with step 1/L converges to the
+ * global maximum.
+ *
+ * ─── WHY ACCELERATION, NOT PLAIN GRADIENT ────────────────────────────────────
+ *
+ * Sigma is estimated as a sample covariance over ~90 observations. When the
+ * number of protocols approaches the number of observations — or two protocols'
+ * APYs move nearly together, which is the norm in DeFi — Sigma is ill-conditioned
+ * or outright rank-deficient. The objective is then concave but NOT strongly
+ * concave, and plain projected gradient converges at a sublinear O(1/k) rate.
+ * Measured on this file's own property tests, a 7-protocol problem still had a
+ * 5.2e-8 residual after the full 2000-iteration budget and reported
+ * `non_converged` despite sitting on a perfectly good allocation. Reaching a
+ * 1e-10 residual that way would need on the order of a million iterations.
+ *
+ * Nesterov's momentum gives O(1/k^2) for the same per-iteration cost and closes
+ * that gap in a few hundred iterations. The ADAPTIVE RESTART is what makes it
+ * safe: momentum can overshoot and temporarily reduce the objective, so whenever
+ * an iterate is worse than its predecessor the momentum is reset. That keeps the
+ * sequence effectively monotone without giving up the acceleration.
+ *
+ * Every iterate is a projection onto the feasible set, so EVERY intermediate
+ * value satisfies every constraint. That is what makes `bestFeasibleWeights` in
+ * the non_converged outcome safe to hand back.
+ */
+function solve(
+  mu: number[],
+  sigma: number[][],
+  lambda: number,
+  lo: number[],
+  hi: number[],
+  stableIdx: number[],
+  nonStableIdx: number[],
+  minWeight: number | null
+): SolveResult {
+  const n = mu.length
+
+  // Deterministic start: the uniform vector projected onto the feasible set.
+  let w = projectOntoFeasibleSet(
+    new Array<number>(n).fill(1 / n),
+    lo,
+    hi,
+    stableIdx,
+    nonStableIdx,
+    minWeight
+  )
+
+  // L bounds the gradient's Lipschitz constant. The floor keeps a zero/degenerate
+  // Sigma (all-identical APY history) from producing an infinite step.
+  const L = Math.max(lambda * gershgorinBound(sigma), 1e-8)
+  const step = 1 / L
+
+  const objective = (v: number[]): number =>
+    dot(mu, v) - (lambda / 2) * quadraticForm(sigma, v)
+
+  let best = w
+  let bestObj = objective(w)
+  let residual = Number.POSITIVE_INFINITY
+  let iterations = 0
+  let converged = false
+
+  // Momentum state. `y` is the extrapolated point the gradient is taken at.
+  let y = w
+  let prevObj = bestObj
+  let t = 1
+
+  for (let k = 1; k <= MAX_ITERATIONS; k++) {
+    iterations = k
+
+    const sy = matVec(sigma, y)
+    const grad = new Array<number>(n)
+    let gradInf = 0
+    for (let i = 0; i < n; i++) {
+      grad[i] = mu[i] - lambda * sy[i]
+      const a = Math.abs(grad[i])
+      if (a > gradInf) gradInf = a
+    }
+
+    // See MAX_STEP_MOVEMENT: never move further than the projection can
+    // meaningfully use. A step below 1/L is still convergent.
+    const effStep =
+      gradInf > 0 ? Math.min(step, MAX_STEP_MOVEMENT / gradInf) : step
+
+    const ascent = new Array<number>(n)
+    for (let i = 0; i < n; i++) ascent[i] = y[i] + effStep * grad[i]
+
+    const next = projectOntoFeasibleSet(
+      ascent,
+      lo,
+      hi,
+      stableIdx,
+      nonStableIdx,
+      minWeight
+    )
+
+    residual = maxAbsDiff(next, w)
+
+    const nextObj = objective(next)
+    if (nextObj > bestObj) {
+      bestObj = nextObj
+      best = next
+    }
+
+    if (nextObj < prevObj) {
+      // Adaptive restart: momentum overshot. Drop it and continue from the
+      // plain iterate rather than letting the overshoot compound.
+      t = 1
+      y = next
+    } else {
+      const tNext = (1 + Math.sqrt(1 + 4 * t * t)) / 2
+      const beta = (t - 1) / tNext
+      const extrapolated = new Array<number>(n)
+      for (let i = 0; i < n; i++) {
+        extrapolated[i] = next[i] + beta * (next[i] - w[i])
+      }
+      // Re-project: the extrapolated point can leave the feasible set, and the
+      // next gradient must be taken somewhere feasible for the step bound to
+      // mean anything.
+      y = projectOntoFeasibleSet(
+        extrapolated,
+        lo,
+        hi,
+        stableIdx,
+        nonStableIdx,
+        minWeight
+      )
+      t = tNext
+    }
+
+    prevObj = nextObj
+    w = next
+
+    if (residual < CONVERGENCE_TOLERANCE) {
+      converged = true
+      break
+    }
+  }
+
+  return { weights: best, iterations, residual, converged }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+function toWeightMap(
+  protocols: string[],
+  weights: number[]
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (let i = 0; i < protocols.length; i++) out[protocols[i]] = weights[i]
+  return out
+}
+
+/**
+ * Log-spaced lambda grid, DESCENDING, so the frontier comes out ascending in
+ * risk (a larger lambda buys less risk). Not sorted after the fact: sorting
+ * would paper over a non-monotone sweep instead of exposing it.
+ */
+function lambdaGrid(points: number): number[] {
+  if (points <= 1) return [riskToleranceToLambda(5)]
+  const out: number[] = []
+  for (let i = 0; i < points; i++) {
+    const t = i / (points - 1)
+    out.push(LAMBDA_MAX * Math.pow(LAMBDA_MIN / LAMBDA_MAX, t))
+  }
+  return out
+}
+
+/**
+ * Solve the mean-variance problem and sweep the efficient frontier.
+ *
+ * The universe filter (risk ceiling, insufficient history) is applied UPSTREAM
+ * in estimation.ts — by the time input reaches here, `protocols` is already the
+ * eligible set. `excludedFromUniverse` is threaded through only so the
+ * insufficient_universe outcome can explain itself.
+ */
+export function optimize(
+  input: OptimizerInput,
+  excludedFromUniverse: UniverseExclusion[] = []
+): OptimizationOutcome {
+  // Sort by name and permute mu/Sigma to match, so the result cannot depend on
+  // the caller's ordering. This is a determinism guarantee, not a nicety.
+  const order = input.protocols
+    .map((name, i) => ({ name, i }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+  const protocols = order.map((o) => o.name)
+  const mu = order.map((o) => input.expectedReturns[o.i])
+  const sigma = order.map((a) => order.map((b) => input.covariance[a.i][b.i]))
+
+  const n = protocols.length
+
+  if (n < MIN_UNIVERSE_SIZE) {
+    const ceilingExcluded = excludedFromUniverse.some(
+      (e) => e.reason === 'risk_ceiling'
+    )
+    return {
+      status: 'insufficient_universe',
+      eligibleCount: n,
+      excluded: excludedFromUniverse,
+      ...(ceilingExcluded
+        ? { bindingConstraint: 'riskCeiling' as BindingConstraint }
+        : {}),
+    }
+  }
+
+  const { lo, hi } = resolveBounds(protocols, input.bounds)
+  const { stableIdx, nonStableIdx, minWeight } = resolveFloor(
+    protocols,
+    input.stableFloor
+  )
+
+  const infeasible = checkFeasibility(
+    lo,
+    hi,
+    stableIdx,
+    nonStableIdx,
+    minWeight
+  )
+  if (infeasible) {
+    return {
+      status: 'infeasible',
+      reason: infeasible.reason,
+      bindingConstraint: infeasible.bindingConstraint,
+    }
+  }
+
+  const lambda = riskToleranceToLambda(input.riskTolerance)
+  const primary = solve(
+    mu,
+    sigma,
+    lambda,
+    lo,
+    hi,
+    stableIdx,
+    nonStableIdx,
+    minWeight
+  )
+
+  if (!primary.converged) {
+    return {
+      status: 'non_converged',
+      bestFeasibleWeights: toWeightMap(protocols, primary.weights),
+      expectedReturn: dot(mu, primary.weights),
+      expectedVolatility: Math.sqrt(
+        Math.max(0, quadraticForm(sigma, primary.weights))
+      ),
+      iterations: primary.iterations,
+      residual: primary.residual,
+    }
+  }
+
+  const requested = input.frontierPoints ?? DEFAULT_FRONTIER_POINTS
+  const points = Math.max(1, Math.min(MAX_FRONTIER_POINTS, requested))
+
+  const frontier: FrontierPoint[] = lambdaGrid(points).map((gridLambda) => {
+    const r = solve(
+      mu,
+      sigma,
+      gridLambda,
+      lo,
+      hi,
+      stableIdx,
+      nonStableIdx,
+      minWeight
+    )
+    return {
+      lambda: gridLambda,
+      risk: Math.sqrt(Math.max(0, quadraticForm(sigma, r.weights))),
+      return: dot(mu, r.weights),
+      weights: toWeightMap(protocols, r.weights),
+    }
+  })
+
+  const weights = toWeightMap(protocols, primary.weights)
+
+  const outcome: OptimizationOutcome = {
+    status: 'ok',
+    weights,
+    expectedReturn: dot(mu, primary.weights),
+    expectedVolatility: Math.sqrt(
+      Math.max(0, quadraticForm(sigma, primary.weights))
+    ),
+    lambda,
+    frontier,
+    iterations: primary.iterations,
+  }
+
+  if (input.riskScores) {
+    let score = 0
+    for (let i = 0; i < n; i++) {
+      score += primary.weights[i] * (input.riskScores[protocols[i]] ?? 0)
+    }
+    outcome.portfolioRiskScore = score
+  }
+
+  return outcome
+}
+
+function resolveBounds(
+  protocols: string[],
+  bounds: AllocationBounds | undefined
+): { lo: number[]; hi: number[] } {
+  // Never below 1/n, so the guardrail alone can never empty the feasible set.
+  const defaultCap = Math.max(
+    DEFAULT_MAX_WEIGHT_PER_PROTOCOL,
+    1 / protocols.length
+  )
+
+  const lo = protocols.map((p) => {
+    const v = bounds?.min?.[p]
+    return typeof v === 'number' && Number.isFinite(v) ? Math.max(0, v) : 0
+  })
+  const hi = protocols.map((p) => {
+    const v = bounds?.max?.[p]
+    // An explicit cap from the caller wins over the guardrail, in either
+    // direction — this is a default, not a policy the caller cannot escape.
+    return typeof v === 'number' && Number.isFinite(v)
+      ? Math.min(1, v)
+      : defaultCap
+  })
+  // A max below its own min is a caller error that would make the bisection
+  // bracket meaningless; widen the max rather than silently inverting the box.
+  for (let i = 0; i < lo.length; i++) {
+    if (hi[i] < lo[i]) hi[i] = lo[i]
+  }
+  return { lo, hi }
+}
+
+function resolveFloor(
+  protocols: string[],
+  floor: StableGroupFloor | undefined
+): {
+  stableIdx: number[]
+  nonStableIdx: number[]
+  minWeight: number | null
+} {
+  const allIdx = protocols.map((_, i) => i)
+  if (!floor || !(floor.minWeight > 0)) {
+    return { stableIdx: [], nonStableIdx: allIdx, minWeight: null }
+  }
+  const wanted = new Set(floor.protocols)
+  const stableIdx: number[] = []
+  const nonStableIdx: number[] = []
+  for (let i = 0; i < protocols.length; i++) {
+    if (wanted.has(protocols[i])) stableIdx.push(i)
+    else nonStableIdx.push(i)
+  }
+  // When none of the named stable protocols survived the universe filter the
+  // floor is unsatisfiable at any weight (an empty group sums to 0 < f). The
+  // minWeight is deliberately kept so checkFeasibility reports it as a
+  // stableFloor binding constraint, rather than silently dropping a risk
+  // control the user asked for.
+  return { stableIdx, nonStableIdx, minWeight: floor.minWeight }
+}
+
+/**
+ * THE single fraction -> percentage boundary for the whole subsystem.
+ *
+ * Emits the 0-100 map that User.strategyConfig.targetAllocations speaks, summing
+ * to 100 within the +/-0.01 tolerance that publishableConfigSchema.superRefine
+ * already enforces (src/validators/strategy-validators.ts) — so a suggestion is
+ * directly acceptable by the existing update path with no re-conversion.
+ *
+ * Rounds to 2dp, drops dust, then settles the rounding residual onto the single
+ * largest weight (ties broken by name, for determinism). The residual is at most
+ * n * 0.005 percentage points, far inside the tolerance.
+ */
+export function toPercentageAllocations(
+  weights: Record<string, number>
+): Record<string, number> {
+  const entries = Object.entries(weights)
+    .filter(([, w]) => Number.isFinite(w) && w >= PERCENT_DUST_THRESHOLD)
+    .map(([name, w]) => [name, Math.round(w * 100 * 100) / 100] as const)
+    .filter(([, pct]) => pct > 0)
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+
+  if (entries.length === 0) return {}
+
+  const total = entries.reduce((s, [, pct]) => s + pct, 0)
+  const drift = Math.round((100 - total) * 100) / 100
+
+  let largestIdx = 0
+  for (let i = 1; i < entries.length; i++) {
+    if (entries[i][1] > entries[largestIdx][1]) largestIdx = i
+  }
+
+  const out: Record<string, number> = {}
+  entries.forEach(([name, pct], i) => {
+    out[name] = i === largestIdx ? Math.round((pct + drift) * 100) / 100 : pct
+  })
+  return out
+}

--- a/src/analytics/service.ts
+++ b/src/analytics/service.ts
@@ -1,0 +1,497 @@
+/**
+ * Allocation-suggestion service (#322) — the DB glue around the pure core.
+ *
+ * ─── THE ADVISORY INVARIANT ──────────────────────────────────────────────────
+ *
+ * This module MUST NOT write User.strategyConfig, User.rebalanceStrategy, or any
+ * other field the agent loop reads. A suggestion is computed, persisted to
+ * AllocationSuggestion, and returned for display. Applying it is a separate,
+ * deliberate act by the user through the existing strategy update path, which
+ * already validates the config (publishableConfigSchema) and already logs the
+ * change.
+ *
+ * That is not a convention — tests/unit/analytics/structural.test.ts scans this
+ * file's source text and fails on any `user.update`, `strategyConfig` write, or
+ * `src/stellar/` import. The reason for the paranoia: an optimizer that can
+ * silently rewrite where someone's money sits is a fundamentally different and
+ * far more dangerous feature than one that draws a chart.
+ *
+ * ─── PRECEDENCE, MIRRORED EXACTLY FROM THE AGENT ─────────────────────────────
+ *
+ * The agent resolves a user's effective risk ceiling with TWO deliberately
+ * different merge rules, and a suggestion that used a third would be advice
+ * about a portfolio the agent will never build. So both are mirrored verbatim:
+ *
+ *   1. A FOLLOWED strategy merges via stricterRiskCeiling (Math.max — higher
+ *      score means lower risk, so a follow may only ever TIGHTEN a follower's
+ *      exposure). See src/agent/effectiveStrategy.ts.
+ *   2. An ACTIVE SavingsGoal then OVERRIDES via `??`, matching
+ *      src/agent/router.ts — a stated personal target outranks a copied config,
+ *      and it may legitimately loosen the ceiling.
+ *
+ * Unifying these into one rule would be tidier and wrong.
+ */
+
+import crypto from 'crypto'
+import { Prisma } from '@prisma/client'
+import db from '../db'
+import { logger } from '../utils/logger'
+import { buildDailyRateSeries, runBacktest } from '../agent/backtest'
+import { TargetAllocationStrategy } from '../agent/strategies'
+import {
+  parseStrategyConfig,
+  stricterRiskCeiling,
+} from '../agent/effectiveStrategy'
+import { estimate, DEFAULT_LOOKBACK_DAYS } from './estimation'
+import { optimize, toPercentageAllocations } from './optimizer'
+import {
+  AllocationSuggestionResult,
+  BacktestComparison,
+  OptimizationOutcome,
+  RawRateObservation,
+  RiskScoreRow,
+} from './types'
+
+/**
+ * Notional starting capital for the backtest comparison when the user has no
+ * position value to anchor to. The comparison is about RELATIVE performance of
+ * two configs over identical history, so the absolute figure is arbitrary —
+ * fixed rather than random so the same inputs give the same output.
+ */
+const DEFAULT_BACKTEST_NOTIONAL = 10_000
+
+/**
+ * The caveat that ships with every backtest comparison. Not optional garnish:
+ * without it the comparison reads as "this allocation would have earned X",
+ * which is not what was simulated. See computeBacktestComparison.
+ */
+export const BACKTEST_CAVEAT =
+  'The agent holds one protocol at a time, so this compares what the agent WOULD HAVE DONE under each configuration — it is not a simulation of holding the weighted basket.'
+
+/** The advisory disclaimer returned with every suggestion. */
+export const ADVISORY_DISCLAIMER =
+  'This is a suggestion only. It has not changed your strategy, and no funds have moved. Optimization minimizes YIELD volatility from historical APY data; it does not model principal loss, depeg, or smart-contract failure.'
+
+export class SuggestionUserNotFoundError extends Error {
+  constructor(userId: string) {
+    super(`User ${userId} not found`)
+    this.name = 'SuggestionUserNotFoundError'
+  }
+}
+
+interface EffectiveInputs {
+  riskTolerance: number
+  effectiveRiskCeiling: number | undefined
+  currentAllocations: Record<string, number> | undefined
+  /** Which layer supplied the ceiling — surfaced so the API can explain it. */
+  ceilingSource: 'goal' | 'follow' | 'own' | 'none'
+}
+
+/**
+ * Resolve the user's effective optimizer inputs from their own config, the
+ * config they follow, and any ACTIVE savings goal. Pure precedence logic; the
+ * three reads are done by the caller so this stays independently testable.
+ */
+export function resolveEffectiveInputs(
+  riskTolerance: number,
+  ownConfigRaw: unknown,
+  followedConfigRaw: unknown | null,
+  goalRiskCeiling: number | null
+): EffectiveInputs {
+  const own = parseStrategyConfig(ownConfigRaw)
+  const followed = followedConfigRaw
+    ? parseStrategyConfig(followedConfigRaw)
+    : null
+
+  // Rule 1: a follow may only tighten.
+  const merged = stricterRiskCeiling(own.riskCeiling, followed?.riskCeiling)
+
+  // Rule 2: an active goal overrides outright.
+  const effectiveRiskCeiling = goalRiskCeiling ?? merged
+
+  const ceilingSource: EffectiveInputs['ceilingSource'] =
+    goalRiskCeiling !== null && goalRiskCeiling !== undefined
+      ? 'goal'
+      : merged === undefined
+        ? 'none'
+        : followed?.riskCeiling !== undefined && merged === followed.riskCeiling
+          ? 'follow'
+          : 'own'
+
+  // A follow replaces allocations WHOLESALE, never key-by-key — pairing a
+  // publisher's strategy with a follower's leftover allocations would produce a
+  // configuration neither party chose (src/agent/effectiveStrategy.ts).
+  const currentAllocations = followed?.strategyName
+    ? followed.targetAllocations
+    : (followed?.targetAllocations ?? own.targetAllocations)
+
+  return {
+    riskTolerance,
+    effectiveRiskCeiling,
+    currentAllocations,
+    ceilingSource,
+  }
+}
+
+/**
+ * Canonical input-snapshot hash.
+ *
+ * Two suggestions with the same hash MUST have the same weights — that is what
+ * makes "did the recommendation change, or only my inputs?" answerable. So the
+ * hash covers exactly the values the optimizer consumes, in a canonical form:
+ * protocols sorted, numbers fixed to a stable precision (raw float
+ * serialization would make the hash sensitive to noise far below what changes
+ * an answer), and every constraint included.
+ *
+ * Follows the canonicalisation approach of normalizeStrategyConfig
+ * (src/agent/effectiveStrategy.ts) and the `sha256:` prefix convention from
+ * deriveTokenPrefix (src/middleware/adminAuth.ts).
+ */
+export function computeInputHash(input: {
+  protocols: string[]
+  expectedReturns: number[]
+  covariance: number[][]
+  riskTolerance: number
+  effectiveRiskCeiling: number | undefined
+  lookbackDays: number
+}): string {
+  // 9 decimal places: far finer than any difference that moves a weight, coarse
+  // enough that float associativity noise cannot flip the hash.
+  const round = (n: number): string => n.toFixed(9)
+
+  const canonical = JSON.stringify({
+    protocols: input.protocols,
+    mu: input.expectedReturns.map(round),
+    sigma: input.covariance.map((row) => row.map(round)),
+    riskTolerance: input.riskTolerance,
+    riskCeiling: input.effectiveRiskCeiling ?? null,
+    lookbackDays: input.lookbackDays,
+  })
+
+  return 'sha256:' + crypto.createHash('sha256').update(canonical).digest('hex')
+}
+
+/**
+ * Backtest both configurations over the same history.
+ *
+ * ─── WHAT THIS ACTUALLY SIMULATES ────────────────────────────────────────────
+ *
+ * The agent has NO multi-protocol position model: Position.protocolName is a
+ * single string and TargetAllocationStrategy uses weights only to rank a single
+ * hop (src/agent/strategies.ts). So this cannot and does not simulate holding a
+ * weighted basket. It replays what the EXISTING agent would have done under each
+ * weight vector, which is the honest question given the engine that exists.
+ *
+ * BACKTEST_CAVEAT travels with the result into the API response and the docs
+ * rather than being left for a user to infer from a chart that looks like a
+ * portfolio simulation.
+ *
+ * Returns null when there is nothing meaningful to compare.
+ */
+export async function computeBacktestComparison(
+  suggestedPercentages: Record<string, number>,
+  currentAllocations: Record<string, number> | undefined,
+  rates: RawRateObservation[],
+  riskCeiling: number | undefined,
+  riskScores: Record<string, number>,
+  userId: string,
+  startingAmount: number,
+  now: Date
+): Promise<BacktestComparison | null> {
+  if (Object.keys(suggestedPercentages).length === 0) return null
+
+  const MS_PER_DAY = 24 * 60 * 60 * 1000
+  const endDate = new Date(Math.floor(now.getTime() / MS_PER_DAY) * MS_PER_DAY)
+  const startDate = new Date(
+    endDate.getTime() - (DEFAULT_LOOKBACK_DAYS - 1) * MS_PER_DAY
+  )
+
+  const { series } = buildDailyRateSeries(rates, startDate, endDate)
+
+  // Trim leading days that have no protocol at all.
+  //
+  // buildDailyRateSeries only carries a protocol forward from its first
+  // observation, so if the earliest observation falls even minutes after the
+  // window's opening midnight, day zero is empty — and runBacktest treats an
+  // empty first day as `insufficient_history` and abandons the whole run. That
+  // would discard 89 perfectly good days over a timestamp alignment artifact.
+  // Trimming to the first populated day makes the comparison depend on the data
+  // that exists rather than on when the rate scanner happened to run.
+  const firstPopulated = series.findIndex((d) => d.protocols.length > 0)
+  if (firstPopulated === -1) return null
+  const trimmed = series.slice(firstPopulated)
+
+  // The realized-APY denominator must match the window actually replayed.
+  const effectiveStart = trimmed[0].date
+  if (endDate.getTime() <= effectiveStart.getTime()) return null
+
+  const strategy = new TargetAllocationStrategy()
+
+  const runLeg = async (
+    targetAllocations: Record<string, number>
+  ): Promise<BacktestComparison['suggested'] | null> => {
+    const outcome = await runBacktest(strategy, trimmed, {
+      strategyName: 'TARGET_ALLOCATION',
+      startDate: effectiveStart,
+      endDate,
+      startingAmount,
+      userStrategyPreferences: [{ userId, targetAllocations }],
+      riskCeiling,
+      protocolRiskScores: riskScores,
+    })
+    if (outcome.status !== 'ok') return null
+    return {
+      finalValue: outcome.result.summary.finalValue,
+      realizedApy: outcome.result.summary.realizedApy,
+      maxDrawdownPercent: outcome.result.summary.maxDrawdownPercent,
+      rebalanceCount: outcome.result.rebalanceEvents.length,
+      finalProtocol: outcome.result.finalProtocol,
+    }
+  }
+
+  const suggested = await runLeg(suggestedPercentages)
+  if (!suggested) return null
+
+  // A user with no allocation configured yet gets the suggested leg only —
+  // there is no "current" to compare against, and inventing one would be a
+  // fabricated baseline.
+  const current =
+    currentAllocations && Object.keys(currentAllocations).length > 0
+      ? await runLeg(currentAllocations)
+      : null
+
+  return {
+    suggested,
+    current,
+    startDate: effectiveStart.toISOString().slice(0, 10),
+    endDate: endDate.toISOString().slice(0, 10),
+    startingAmount,
+    caveat: BACKTEST_CAVEAT,
+  }
+}
+
+/**
+ * Compute (and persist) an allocation suggestion for one user.
+ *
+ * @param userId  The user the suggestion is for.
+ * @param options.now         Reference "now", injected for deterministic tests.
+ * @param options.persist     Set false to compute without writing a row.
+ * @param options.runBacktest Set false to skip the backtest legs (the job does
+ *                            this — the comparison is the expensive part and is
+ *                            only interesting when a human is looking).
+ */
+export async function suggestAllocation(
+  userId: string,
+  options: {
+    now?: Date
+    persist?: boolean
+    runBacktest?: boolean
+    lookbackDays?: number
+    /** Efficient-frontier resolution. Clamped by the optimizer's hard cap. */
+    frontierPoints?: number
+  } = {}
+): Promise<AllocationSuggestionResult> {
+  const now = options.now ?? new Date()
+  const persist = options.persist ?? true
+  const wantBacktest = options.runBacktest ?? true
+  const lookbackDays = options.lookbackDays ?? DEFAULT_LOOKBACK_DAYS
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, riskTolerance: true, strategyConfig: true },
+  })
+  if (!user) throw new SuggestionUserNotFoundError(userId)
+
+  const [follow, goal] = await Promise.all([
+    db.strategyFollow.findFirst({
+      where: { followerUserId: userId, unfollowedAt: null },
+      select: { appliedConfig: true },
+    }),
+    db.savingsGoal.findFirst({
+      where: { userId, status: 'ACTIVE' },
+      select: { riskCeiling: true },
+    }),
+  ])
+
+  const effective = resolveEffectiveInputs(
+    user.riskTolerance,
+    user.strategyConfig,
+    follow?.appliedConfig ?? null,
+    goal?.riskCeiling ?? null
+  )
+
+  const MS_PER_DAY = 24 * 60 * 60 * 1000
+  const since = new Date(now.getTime() - lookbackDays * MS_PER_DAY)
+
+  const [rateRows, scoreRows] = await Promise.all([
+    db.protocolRate.findMany({
+      where: { fetchedAt: { gte: since } },
+      select: {
+        protocolName: true,
+        assetSymbol: true,
+        supplyApy: true,
+        fetchedAt: true,
+      },
+    }),
+    db.protocolRiskScore.findMany({
+      select: {
+        protocolName: true,
+        score: true,
+        insufficientHistory: true,
+      },
+    }),
+  ])
+
+  const rates: RawRateObservation[] = rateRows.map((r) => ({
+    protocolName: r.protocolName,
+    assetSymbol: r.assetSymbol,
+    apy: Number(r.supplyApy),
+    date: r.fetchedAt,
+  }))
+  const riskScores: RiskScoreRow[] = scoreRows.map((s) => ({
+    protocolName: s.protocolName,
+    score: s.score,
+    insufficientHistory: s.insufficientHistory,
+  }))
+
+  const estimation = estimate({
+    rates,
+    riskScores,
+    lookbackDays,
+    riskCeiling: effective.effectiveRiskCeiling,
+    now,
+  })
+
+  const outcome = optimize(
+    {
+      protocols: estimation.protocols,
+      expectedReturns: estimation.expectedReturns,
+      covariance: estimation.covariance,
+      riskTolerance: effective.riskTolerance,
+      riskScores: estimation.riskScores,
+      frontierPoints: options.frontierPoints,
+    },
+    estimation.excluded
+  )
+
+  const inputHash = computeInputHash({
+    protocols: estimation.protocols,
+    expectedReturns: estimation.expectedReturns,
+    covariance: estimation.covariance,
+    riskTolerance: effective.riskTolerance,
+    effectiveRiskCeiling: effective.effectiveRiskCeiling,
+    lookbackDays,
+  })
+
+  const weights =
+    outcome.status === 'ok'
+      ? toPercentageAllocations(outcome.weights)
+      : outcome.status === 'non_converged'
+        ? toPercentageAllocations(outcome.bestFeasibleWeights)
+        : {}
+
+  let backtest: BacktestComparison | null = null
+  if (wantBacktest && Object.keys(weights).length > 0) {
+    const startingAmount = await resolveNotional(userId)
+    backtest = await computeBacktestComparison(
+      weights,
+      effective.currentAllocations,
+      rates,
+      effective.effectiveRiskCeiling,
+      estimation.riskScores,
+      userId,
+      startingAmount,
+      now
+    )
+  }
+
+  const result: AllocationSuggestionResult = {
+    isSuggestion: true,
+    disclaimer: ADVISORY_DISCLAIMER,
+    userId,
+    inputHash,
+    status: outcome.status,
+    weights,
+    outcome,
+    riskTolerance: effective.riskTolerance,
+    effectiveRiskCeiling: effective.effectiveRiskCeiling ?? null,
+    ceilingSource: effective.ceilingSource,
+    currentAllocations: effective.currentAllocations ?? null,
+    excluded: estimation.excluded,
+    observationCount: estimation.observationCount,
+    lookbackDays,
+    backtest,
+    computedAt: now.toISOString(),
+  }
+
+  if (persist) {
+    const row = await db.allocationSuggestion.create({
+      data: {
+        userId,
+        inputHash,
+        status: outcome.status,
+        weights,
+        // Prisma's InputJsonValue does not accept a typed interface array
+        // directly (no index signature); these are plain JSON-safe structures.
+        frontier: (outcome.status === 'ok'
+          ? outcome.frontier
+          : []) as unknown as Prisma.InputJsonValue,
+        backtestSummary: backtest
+          ? (backtest as unknown as Prisma.InputJsonValue)
+          : undefined,
+        riskTolerance: effective.riskTolerance,
+        effectiveRiskCeiling: effective.effectiveRiskCeiling ?? null,
+        reason: describeOutcome(outcome),
+        computedAt: now,
+      },
+      select: { id: true },
+    })
+    result.id = row.id
+  }
+
+  logger.info('[Analytics] Allocation suggestion computed', {
+    userId,
+    status: outcome.status,
+    inputHash,
+    eligibleProtocols: estimation.protocols.length,
+    excludedCount: estimation.excluded.length,
+    riskCeiling: effective.effectiveRiskCeiling ?? null,
+    ceilingSource: effective.ceilingSource,
+    persisted: persist,
+  })
+
+  return result
+}
+
+/**
+ * The user's current invested value, used as the backtest's starting capital so
+ * the comparison is denominated in numbers they recognize. Falls back to a fixed
+ * notional when they hold nothing — the comparison is relative, and a fixed
+ * fallback keeps the run deterministic.
+ */
+async function resolveNotional(userId: string): Promise<number> {
+  const positions = await db.position.findMany({
+    where: { userId, status: 'ACTIVE' },
+    select: { currentValue: true },
+  })
+  const total = positions.reduce((s, p) => s + Number(p.currentValue), 0)
+  return total > 0 ? total : DEFAULT_BACKTEST_NOTIONAL
+}
+
+/** One-line human explanation of a non-ok outcome, stored on the row. */
+function describeOutcome(outcome: OptimizationOutcome): string | null {
+  switch (outcome.status) {
+    case 'ok':
+      return null
+    case 'infeasible':
+      return `${outcome.reason} (binding constraint: ${outcome.bindingConstraint})`
+    case 'insufficient_universe':
+      return `Only ${outcome.eligibleCount} protocol(s) eligible; at least 2 are required${
+        outcome.bindingConstraint
+          ? ` (binding constraint: ${outcome.bindingConstraint})`
+          : ''
+      }`
+    case 'non_converged':
+      return `Solver did not converge within ${outcome.iterations} iterations (residual ${outcome.residual.toExponential(3)}); returning the best feasible allocation found`
+  }
+}

--- a/src/analytics/types.ts
+++ b/src/analytics/types.ts
@@ -1,0 +1,248 @@
+/**
+ * Shared types for the portfolio-optimization engine (#322).
+ *
+ * ─── UNITS, ONCE, FOR THE WHOLE SUBSYSTEM ────────────────────────────────────
+ *
+ * Everything in src/analytics/ that is a rate or a weight is a DECIMAL FRACTION:
+ *   - expected returns:  0.082  means 8.2% APY
+ *   - volatility:        0.014  means 1.4 percentage points of APY volatility
+ *   - weights:           0.425  means 42.5% of the portfolio
+ *
+ * The ONLY place fractions become percentages is `toPercentageAllocations`
+ * (optimizer.ts), which emits the 0-100 map that `User.strategyConfig
+ * .targetAllocations` and `publishableConfigSchema` speak. Keeping the
+ * conversion at exactly one boundary is what makes the "sums to 100 +/- 0.01"
+ * invariant assertable in one place.
+ *
+ * ─── WHAT THE COVARIANCE ACTUALLY MEASURES ───────────────────────────────────
+ *
+ * ProtocolRate is a YIELD-QUOTE series, not a price series. Sigma here is the
+ * covariance of protocols' *quoted annual rates*, so the optimizer minimizes
+ * YIELD volatility — how much a protocol's APY swings around. It does NOT model
+ * principal loss, depeg, or smart-contract failure. Those live in
+ * ProtocolRiskScore, which enters this engine as a universe filter (via
+ * applyRiskCeiling) rather than as a term in the objective. This limitation is
+ * repeated in the API response and docs/PORTFOLIO_OPTIMIZATION.md rather than
+ * left for a user to infer.
+ */
+
+/**
+ * Per-protocol weight bounds, as decimal fractions. Absent entries default to
+ * `[0, 1]`. Keys are protocol names.
+ */
+export interface AllocationBounds {
+  min?: Record<string, number>
+  max?: Record<string, number>
+}
+
+/**
+ * Optional "keep at least this much in the stable group" constraint.
+ * `minWeight` is a decimal fraction of the whole portfolio.
+ */
+export interface StableGroupFloor {
+  protocols: string[]
+  minWeight: number
+}
+
+export interface OptimizerInput {
+  /**
+   * Protocol names. Need not be sorted — `optimize()` sorts them (and permutes
+   * `expectedReturns`/`covariance` to match) so the result never depends on the
+   * caller's ordering.
+   */
+  protocols: string[]
+  /** Annualized expected return per protocol, index-aligned with `protocols`. */
+  expectedReturns: number[]
+  /** Annualized covariance matrix, index-aligned with `protocols`. */
+  covariance: number[][]
+  /** User's 1-10 risk tolerance. 1 = most risk-averse. */
+  riskTolerance: number
+  bounds?: AllocationBounds
+  stableFloor?: StableGroupFloor
+  /** Points on the efficient frontier. Defaults to 12, hard-capped at 25. */
+  frontierPoints?: number
+  /**
+   * Protocol risk scores (0-100, higher = lower risk), used only to REPORT a
+   * weighted portfolio risk score. The ceiling itself is applied upstream as a
+   * universe filter, so there is one notion of the ceiling, not two.
+   */
+  riskScores?: Record<string, number>
+}
+
+/** One point on the efficient frontier. */
+export interface FrontierPoint {
+  lambda: number
+  /** sqrt(w' Sigma w) — annualized volatility as a decimal fraction. */
+  risk: number
+  /** mu' w — annualized expected return as a decimal fraction. */
+  return: number
+  /** Decimal-fraction weights, keyed by protocol name. */
+  weights: Record<string, number>
+}
+
+/** Why a protocol never made it into the optimizable universe. */
+export type ExclusionReason =
+  | 'insufficient_history'
+  | 'risk_ceiling'
+  | 'no_risk_score'
+  | 'no_rate_history'
+  | 'insufficient_aligned_history'
+
+export interface UniverseExclusion {
+  protocol: string
+  reason: ExclusionReason
+  /** Human-readable detail, e.g. the score that failed the ceiling. */
+  detail?: string
+}
+
+/**
+ * The optimizer's result. A discriminated union on purpose: every failure mode
+ * is a named, inspectable state rather than a plausible-looking weight vector
+ * that quietly violates a constraint.
+ */
+export type OptimizationOutcome =
+  | {
+      status: 'ok'
+      /** Decimal-fraction weights, keyed by protocol name. Sums to 1. */
+      weights: Record<string, number>
+      expectedReturn: number
+      expectedVolatility: number
+      lambda: number
+      frontier: FrontierPoint[]
+      iterations: number
+      /** Sum of w_i * riskScore_i, when scores were supplied. */
+      portfolioRiskScore?: number
+    }
+  | {
+      status: 'infeasible'
+      reason: string
+      /** Which constraint made the feasible set empty. */
+      bindingConstraint: BindingConstraint
+    }
+  | {
+      status: 'insufficient_universe'
+      eligibleCount: number
+      excluded: UniverseExclusion[]
+      /**
+       * Set when the universe was emptied by a specific constraint rather than
+       * by a plain lack of data — today only `riskCeiling`. Lets the API name
+       * the binding constraint for a too-tight ceiling without pretending the
+       * outcome was `infeasible` (the feasible SET was never the problem; there
+       * were not enough assets to form a portfolio).
+       */
+      bindingConstraint?: BindingConstraint
+    }
+  | {
+      status: 'non_converged'
+      /**
+       * The best FEASIBLE iterate found before the budget ran out — every
+       * iterate is a projection onto the feasible set, so this always satisfies
+       * every constraint. It is simply not proven optimal.
+       */
+      bestFeasibleWeights: Record<string, number>
+      expectedReturn: number
+      expectedVolatility: number
+      iterations: number
+      residual: number
+    }
+
+export type BindingConstraint =
+  'minWeights' | 'maxWeights' | 'stableFloor' | 'riskCeiling'
+
+// ── Estimation ───────────────────────────────────────────────────────────────
+
+/** One protocol's risk-score row, narrowed to what estimation needs. */
+export interface RiskScoreRow {
+  protocolName: string
+  score: number
+  insufficientHistory: boolean
+}
+
+export interface EstimationInput {
+  /** Raw ProtocolRate observations, any order, possibly gappy. */
+  rates: RawRateObservation[]
+  riskScores: RiskScoreRow[]
+  /** Trailing window in days. Defaults to DEFAULT_LOOKBACK_DAYS. */
+  lookbackDays?: number
+  /** Minimum protocol risk score to admit, or undefined for no ceiling. */
+  riskCeiling?: number
+  /** Reference "now", injected for deterministic tests. */
+  now?: Date
+}
+
+/** A single ProtocolRate row, narrowed to the columns estimation reads. */
+export interface RawRateObservation {
+  protocolName: string
+  assetSymbol: string
+  apy: number
+  date: Date
+}
+
+export interface EstimationResult {
+  /** Sorted protocol names, index-aligned with the vectors below. */
+  protocols: string[]
+  /** Annualized expected return per protocol, as a decimal fraction. */
+  expectedReturns: number[]
+  /** Annualized covariance of annual rate levels. Symmetric, PSD. */
+  covariance: number[][]
+  /** Number of days on which EVERY admitted protocol had a value. */
+  observationCount: number
+  excluded: UniverseExclusion[]
+  /** Risk scores for the admitted protocols, for reporting. */
+  riskScores: Record<string, number>
+  lookbackDays: number
+}
+
+// ── Service-level results ────────────────────────────────────────────────────
+
+/** One leg of the backtest comparison. */
+export interface BacktestLeg {
+  finalValue: number
+  realizedApy: number
+  maxDrawdownPercent: number
+  rebalanceCount: number
+  finalProtocol: string
+}
+
+/**
+ * Suggested-vs-current backtest. `current` is null when the user has no
+ * allocation configured — an invented baseline would be worse than none.
+ */
+export interface BacktestComparison {
+  suggested: BacktestLeg
+  /** Null when the user has no current allocation to compare against. */
+  current: BacktestLeg | null
+  startDate: string
+  endDate: string
+  startingAmount: number
+  /**
+   * Why this is not a basket simulation. Travels with the data rather than
+   * living only in the docs — see computeBacktestComparison in service.ts.
+   */
+  caveat: string
+}
+
+/** What suggestAllocation returns, and what the API serializes. */
+export interface AllocationSuggestionResult {
+  /** Always true. The response is advice, never an applied change. */
+  isSuggestion: true
+  disclaimer: string
+  userId: string
+  /** Set when the suggestion was persisted. */
+  id?: string
+  inputHash: string
+  status: OptimizationOutcome['status']
+  /** Percentages summing to 100 +/- 0.01. Empty for a failed outcome. */
+  weights: Record<string, number>
+  outcome: OptimizationOutcome
+  riskTolerance: number
+  effectiveRiskCeiling: number | null
+  /** Which layer supplied the ceiling, so the API can explain it. */
+  ceilingSource: 'goal' | 'follow' | 'own' | 'none'
+  currentAllocations: Record<string, number> | null
+  excluded: UniverseExclusion[]
+  observationCount: number
+  lookbackDays: number
+  backtest: BacktestComparison | null
+  computedAt: string
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -392,6 +392,17 @@ export const config = {
       windowMs: parseInt(process.env.INTERNAL_RATE_LIMIT_WINDOW_MS || '60000'),
       max: parseInt(process.env.INTERNAL_RATE_LIMIT_MAX || '500'),
     },
+    /**
+     * Portfolio optimizer (#322) — the only genuinely CPU-bound endpoint in the
+     * API. Tighter than the global limiter and applied per-endpoint rather than
+     * via the apiRoutes table, which would throttle read-only portfolio traffic
+     * too. Pairs with the in-flight semaphore in src/utils/concurrency.ts: this
+     * bounds requests per window, that bounds how many run at once.
+     */
+    optimizerRateLimit: {
+      windowMs: parseInt(process.env.OPTIMIZER_RATE_LIMIT_WINDOW_MS || '60000'),
+      max: parseInt(process.env.OPTIMIZER_RATE_LIMIT_MAX || '5'),
+    },
     /** Public webhook endpoints — resist spoofed / replay floods (e.g. Twilio) */
     webhookRateLimit: {
       windowMs: parseInt(process.env.WEBHOOK_RATE_LIMIT_WINDOW_MS || '60000'),
@@ -496,6 +507,32 @@ export const config = {
      * non-zero assumption. See docs/STRATEGY_MARKETPLACE.md.
      */
     riskFreeRate: parseFloat(process.env.STRATEGY_RISK_FREE_RATE || '0'),
+  },
+  allocationSuggestions: {
+    /**
+     * Interval between precomputed allocation-suggestion refreshes in ms
+     * (default: 6 hours, matching protocolRisk and strategyMetrics). Inputs are
+     * daily APY series and a risk-score table refreshed on the same cadence, so
+     * anything faster recomputes identical numbers.
+     */
+    intervalMs: parseInt(
+      process.env.ALLOCATION_SUGGESTION_INTERVAL_MS || '21600000'
+    ),
+    /**
+     * Global cap on simultaneously-running optimizations in this process. Small
+     * on purpose: each one occupies the single event-loop thread, so this is a
+     * bound on how long an unrelated request can be stuck behind analytics
+     * work. See src/utils/concurrency.ts.
+     */
+    maxConcurrent: parseInt(
+      process.env.ALLOCATION_SUGGESTION_MAX_CONCURRENT || '2'
+    ),
+    /**
+     * Users processed per batch by the scheduled job, with a serial await per
+     * user inside a batch — same loop shape as the neighbouring jobs, so a large
+     * user table cannot monopolize the event loop in one tick.
+     */
+    batchSize: parseInt(process.env.ALLOCATION_SUGGESTION_BATCH_SIZE || '25'),
   },
   referral: {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,14 @@ import { scheduleReferralPayout } from './jobs/referralPayout'
 import { scheduleRecurringDeposits } from './jobs/recurringDeposits'
 import { scheduleAlertRules } from './jobs/alertRules'
 import { scheduleStrategyMetrics } from './jobs/strategyMetrics'
+import { scheduleAllocationSuggestions } from './jobs/allocationSuggestions'
+// Was never imported or started, so ProtocolRiskScore rows were never refreshed
+// after their first backfill. That matters beyond staleness: risk-ceiling
+// filtering is fail-closed (applyRiskCeiling treats an unknown score as
+// ineligible), so an empty or stale table makes every ceiling-constrained
+// allocation suggestion — and every ceiling-constrained rebalance — return
+// nothing eligible. Wired up here (#322).
+import { scheduleProtocolRiskScoring } from './jobs/protocolRiskScoring'
 import { startEventListener, stopEventListener } from './stellar/events'
 import { validateStellarNetworkReady } from './config/readiness'
 import healthRouter from './routes/health'
@@ -107,6 +115,8 @@ let referralPayoutHandle: NodeJS.Timeout | null = null
 let recurringDepositsHandle: NodeJS.Timeout | null = null
 let alertRulesHandle: NodeJS.Timeout | null = null
 let strategyMetricsHandle: NodeJS.Timeout | null = null
+let allocationSuggestionsHandle: NodeJS.Timeout | null = null
+let protocolRiskScoringHandle: NodeJS.Timeout | null = null
 
 function allServicesReady(): boolean {
   return Object.values(serviceStatus).every((s) => s.ready)
@@ -369,6 +379,18 @@ async function gracefulShutdown(signal: string): Promise<void> {
     logger.info('[Shutdown] Strategy metrics timer cleared')
   }
 
+  if (protocolRiskScoringHandle) {
+    clearInterval(protocolRiskScoringHandle)
+    protocolRiskScoringHandle = null
+    logger.info('[Shutdown] Protocol risk scoring timer cleared')
+  }
+
+  if (allocationSuggestionsHandle) {
+    clearInterval(allocationSuggestionsHandle)
+    allocationSuggestionsHandle = null
+    logger.info('[Shutdown] Allocation suggestions timer cleared')
+  }
+
   if (!httpServer) {
     logger.warn('[Shutdown] No HTTP server to close')
     process.exit(0)
@@ -527,6 +549,10 @@ async function main(): Promise<void> {
   recurringDepositsHandle = scheduleRecurringDeposits()
   alertRulesHandle = scheduleAlertRules()
   strategyMetricsHandle = scheduleStrategyMetrics()
+  // Ordered before the suggestion job so the first suggestion run sees freshly
+  // scored protocols rather than whatever was last left in the table.
+  protocolRiskScoringHandle = scheduleProtocolRiskScoring()
+  allocationSuggestionsHandle = scheduleAllocationSuggestions()
 }
 
 // ── Process-level error guards ────────────────────────────────────────────────

--- a/src/jobs/allocationSuggestions.ts
+++ b/src/jobs/allocationSuggestions.ts
@@ -1,0 +1,137 @@
+import db from '../db'
+import { logger, logBackgroundJob } from '../utils/logger'
+import {
+  generateCorrelationId,
+  runWithCorrelationIdAsync,
+} from '../utils/correlation'
+import { config } from '../config/env'
+import { recordBackgroundJob } from '../utils/metrics'
+import { recordJobSuccess, recordJobFailure } from '../utils/job-metrics'
+import { suggestAllocation } from '../analytics/service'
+
+/**
+ * Allocation-suggestion precompute job (#322).
+ *
+ * Refreshes each invested user's stored AllocationSuggestion so the history
+ * endpoint has something current to show without a user paying for a solve
+ * on their first request. All the math lives in src/analytics/ (pure + unit
+ * tested); this job is DB glue and scheduling only, mirroring
+ * src/jobs/strategyMetrics.ts and src/jobs/protocolRiskScoring.ts.
+ *
+ * ─── STILL ADVISORY ──────────────────────────────────────────────────────────
+ *
+ * This job writes AllocationSuggestion rows and NOTHING else. It does not touch
+ * User.strategyConfig, so it cannot change what the agent does on its next tick.
+ * A precompute job that quietly rewrote strategy configs on a 6-hour timer would
+ * be an autonomous trading system wearing an analytics job's clothes.
+ *
+ * ─── SCOPE AND COST ──────────────────────────────────────────────────────────
+ *
+ * Only users with an ACTIVE Position: someone with no funds deployed has nothing
+ * to reallocate, and including them would multiply the cost of the most
+ * expensive job in the process by the size of the whole user table.
+ *
+ * The backtest legs are SKIPPED here (`runBacktest: false`). They are two full
+ * historical replays per user and are only interesting when a human is looking
+ * at the result, which is exactly when the POST endpoint runs them live. Rows
+ * written by this job therefore carry a null backtest — documented in
+ * docs/PORTFOLIO_OPTIMIZATION.md so an absent comparison never reads as a
+ * failure.
+ *
+ * Batches with a serial await inside each batch, same loop shape as the
+ * neighbouring jobs: the optimizer is CPU-bound on the single event-loop thread,
+ * so parallelizing users here would starve live requests rather than finish
+ * sooner.
+ */
+
+export async function computeAllocationSuggestions(
+  now: Date = new Date()
+): Promise<void> {
+  const correlationId = generateCorrelationId()
+  return runWithCorrelationIdAsync(correlationId, async () => {
+    const startTime = Date.now()
+    const jobName = 'allocation_suggestions'
+
+    try {
+      const invested = await db.position.findMany({
+        where: { status: 'ACTIVE' },
+        select: { userId: true },
+        distinct: ['userId'],
+      })
+
+      const userIds = invested.map((p) => p.userId)
+      const batchSize = Math.max(1, config.allocationSuggestions.batchSize)
+
+      let computed = 0
+      let failed = 0
+
+      for (let i = 0; i < userIds.length; i += batchSize) {
+        const batch = userIds.slice(i, i + batchSize)
+
+        for (const userId of batch) {
+          try {
+            await suggestAllocation(userId, {
+              now,
+              persist: true,
+              runBacktest: false,
+            })
+            computed++
+          } catch (error) {
+            // One user's failure must never abort the batch — a single corrupt
+            // strategyConfig or a deleted user mid-run would otherwise silently
+            // deprive everyone after them of a refreshed suggestion.
+            failed++
+            logger.error('[AllocationSuggestions] Failed to compute for user', {
+              userId,
+              error: error instanceof Error ? error.message : 'Unknown error',
+            })
+          }
+        }
+      }
+
+      const durationMs = Date.now() - startTime
+      const duration = durationMs / 1000
+
+      logBackgroundJob(jobName, 'success', duration, correlationId, {
+        usersConsidered: userIds.length,
+        computed,
+        failed,
+      })
+      recordBackgroundJob(jobName, 'success', duration)
+      recordJobSuccess(jobName, durationMs)
+    } catch (error) {
+      const durationMs = Date.now() - startTime
+      const duration = durationMs / 1000
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error'
+
+      logBackgroundJob(jobName, 'failed', duration, correlationId, {
+        error: errorMessage,
+      })
+      recordBackgroundJob(jobName, 'failed', duration)
+      recordJobFailure(jobName, durationMs)
+    }
+  })
+}
+
+/**
+ * Schedule the allocation-suggestion job. Runs once on startup then on the
+ * configured interval (default 6 h, matching protocolRisk and strategyMetrics).
+ *
+ * @returns NodeJS.Timeout handle — pass to clearInterval() on shutdown.
+ */
+export function scheduleAllocationSuggestions(): NodeJS.Timeout {
+  void computeAllocationSuggestions()
+
+  const intervalMs = config.allocationSuggestions.intervalMs
+  const handle = setInterval(() => {
+    void computeAllocationSuggestions()
+  }, intervalMs)
+
+  handle.unref?.()
+
+  logger.info(
+    `[AllocationSuggestions] Allocation suggestions scheduled every ${intervalMs / 3600000}h`
+  )
+  return handle
+}

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -187,6 +187,27 @@ export const webhookRateLimiter = buildRateLimiter({
 })
 
 /**
+ * Optimizer rate limiter (#322) — for the CPU-bound allocation-suggestion
+ * endpoint. Defaults: 5 req / 1 min (env: OPTIMIZER_RATE_LIMIT_MAX /
+ * OPTIMIZER_RATE_LIMIT_WINDOW_MS).
+ *
+ * Applied PER ENDPOINT rather than through the `apiRoutes` handlers array. The
+ * table convention is right for a resource whose routes are uniformly costly,
+ * but /portfolio is mostly cheap reads that must not inherit a 5/min budget
+ * because one POST on the same router is expensive. This is not the
+ * double-application the warning in src/routes/admin.ts guards against — no
+ * table-level limiter is applied to this route.
+ */
+export const optimizerRateLimiter = buildRateLimiter({
+  windowMs: config.security.optimizerRateLimit.windowMs,
+  max: config.security.optimizerRateLimit.max,
+  skip: isTrusted,
+  limiterType: 'optimizer',
+  message:
+    'Too many optimization requests. Portfolio optimization is compute-intensive; please try again shortly.',
+})
+
+/**
  * Internal / agent rate limiter — higher throughput for service-to-service calls.
  * Defaults: 500 req / 1 min (env: INTERNAL_RATE_LIMIT_MAX / INTERNAL_RATE_LIMIT_WINDOW_MS).
  */

--- a/src/routes/portfolio.ts
+++ b/src/routes/portfolio.ts
@@ -3,8 +3,23 @@ import { z } from 'zod'
 import db from '../db'
 import { requireAuth, enforceUserAccess } from '../middleware/authenticate'
 import { validate } from '../middleware/validate'
-import { mapPositionToResponse } from '../utils/api-formatters'
+import {
+  mapAllocationSuggestionToResponse,
+  mapPositionToResponse,
+} from '../utils/api-formatters'
 import { sendNotFound } from '../utils/errors'
+import { optimizerRateLimiter } from '../middleware/rateLimiter'
+import { ConcurrencyLimiter, isAcquireFailure } from '../utils/concurrency'
+import { config } from '../config/env'
+import { logger } from '../utils/logger'
+import {
+  suggestAllocation,
+  SuggestionUserNotFoundError,
+} from '../analytics/service'
+import {
+  listSuggestionsSchema,
+  suggestAllocationSchema,
+} from '../validators/allocation-validators'
 import {
   formatPortfolioEarningsReply,
   formatPortfolioHistoryReply,
@@ -49,6 +64,122 @@ const historySchema = z.object({
     period: z.enum(['7d', '30d', '90d']).default('30d'),
   }),
 })
+
+/**
+ * Portfolio optimization (#322).
+ *
+ * Registered BEFORE `GET /:userId` for the same defensive reason as the
+ * `/goals` mount above: these live under `/:userId/...` so they cannot actually
+ * collide, but keeping every more-specific route ahead of the bare `/:userId`
+ * means a future path never silently becomes a user ID.
+ *
+ * Both are keyed on `req.params.userId`, which is what keeps `enforceUserAccess`
+ * effective. A body-only or resource-id-keyed route (`/suggestions/:id`) would
+ * make that middleware a silent no-op — the trap documented in CLAUDE.md — and
+ * would also skip the sub-account permission lookup, which reads the same param.
+ */
+
+/**
+ * One optimization per user at a time, and a small global budget.
+ *
+ * Module-level so the limiter is shared across every request in the process,
+ * which is the only scope at which "how many solves are running on this event
+ * loop" is a meaningful question. See src/utils/concurrency.ts for why this
+ * exists in addition to the rate limiter.
+ */
+const optimizerConcurrency = new ConcurrencyLimiter({
+  globalLimit: config.allocationSuggestions.maxConcurrent,
+  perKeyLimit: 1,
+})
+
+router.post(
+  '/:userId/suggest-allocation',
+  requireAuth,
+  enforceUserAccess,
+  optimizerRateLimiter,
+  validate(suggestAllocationSchema),
+  async (req: Request, res: Response) => {
+    const userId = req.params.userId as string
+    const body = req.body as {
+      lookbackDays: number
+      frontierPoints: number
+      includeBacktest: boolean
+    }
+
+    const slot = optimizerConcurrency.tryAcquire(userId)
+    if (isAcquireFailure(slot)) {
+      logger.warn('[Analytics] Optimization rejected — concurrency limit', {
+        userId,
+        scope: slot.scope,
+        inFlight: optimizerConcurrency.inFlight,
+      })
+      res.setHeader('Retry-After', '5')
+      return res.status(429).json({
+        error:
+          slot.scope === 'key'
+            ? 'An optimization is already running for this account. Please wait for it to finish.'
+            : 'The optimizer is busy. Please try again in a few seconds.',
+      })
+    }
+
+    try {
+      const result = await suggestAllocation(userId, {
+        lookbackDays: body.lookbackDays,
+        frontierPoints: body.frontierPoints,
+        runBacktest: body.includeBacktest,
+      })
+      return res.status(200).json(result)
+    } catch (error) {
+      if (error instanceof SuggestionUserNotFoundError) {
+        return sendNotFound(res, 'User')
+      }
+      throw error
+    } finally {
+      // In `finally` so a throw cannot leak the slot and permanently wedge this
+      // user out of the endpoint for the process lifetime.
+      slot.release()
+    }
+  }
+)
+
+router.get(
+  '/:userId/suggestions',
+  requireAuth,
+  enforceUserAccess,
+  validate(listSuggestionsSchema),
+  async (req: Request, res: Response) => {
+    const userId = req.params.userId as string
+    const page = req.query.page as unknown as number
+    const limit = req.query.limit as unknown as number
+
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    })
+    if (!user) {
+      return sendNotFound(res, 'User')
+    }
+
+    const [total, rows] = await Promise.all([
+      db.allocationSuggestion.count({ where: { userId } }),
+      db.allocationSuggestion.findMany({
+        where: { userId },
+        orderBy: { computedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+    ])
+
+    return res.status(200).json({
+      userId,
+      isSuggestion: true,
+      page,
+      limit,
+      total,
+      suggestions: rows.map(mapAllocationSuggestionToResponse),
+    })
+  }
+)
 
 router.get(
   '/:userId',

--- a/src/utils/api-formatters.ts
+++ b/src/utils/api-formatters.ts
@@ -92,3 +92,30 @@ export const mapGoalToResponse = (goal: any) => ({
   createdAt: goal.createdAt.toISOString(),
   updatedAt: goal.updatedAt.toISOString(),
 })
+
+/**
+ * Portfolio-optimization suggestion (#322), for the stored-history endpoint.
+ *
+ * Hand-written allowlist, deliberately never a spread — same discipline as the
+ * marketplace mappers above. `userId` is intentionally omitted: the caller is
+ * already scoped to their own rows by enforceUserAccess, so echoing it back adds
+ * nothing and makes it that much easier for a future refactor to leak the column
+ * into a listing that is not owner-scoped.
+ *
+ * `isSuggestion` is emitted on EVERY row. A stored allocation and an applied
+ * one look identical on the wire otherwise, and this feature's whole safety
+ * story is that they are not the same thing.
+ */
+export const mapAllocationSuggestionToResponse = (suggestion: any) => ({
+  id: suggestion.id,
+  isSuggestion: true as const,
+  status: suggestion.status,
+  inputHash: suggestion.inputHash,
+  weights: suggestion.weights,
+  frontier: suggestion.frontier,
+  backtest: suggestion.backtestSummary ?? null,
+  riskTolerance: suggestion.riskTolerance,
+  effectiveRiskCeiling: suggestion.effectiveRiskCeiling ?? null,
+  reason: suggestion.reason ?? null,
+  computedAt: suggestion.computedAt.toISOString(),
+})

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,102 @@
+/**
+ * In-flight concurrency limiting for CPU-bound endpoints (#322).
+ *
+ * WHY THIS EXISTS SEPARATELY FROM THE RATE LIMITER. A rate limiter bounds
+ * requests per WINDOW; it does nothing about how many are running AT ONCE. The
+ * portfolio optimizer is the first genuinely CPU-bound thing in this API — a
+ * projected-gradient solve swept across a 12-point efficient frontier, all on
+ * the single Node event-loop thread. Ten concurrent optimizations do not merely
+ * run slower; they block every other request in the process, including
+ * /health/ready, for as long as they take. That turns one user's burst into an
+ * availability incident.
+ *
+ * So the limits are deliberately two-layered:
+ *   - per-key (per-user): 1. A user gets one optimization at a time. Nothing is
+ *     gained by letting them queue their own work, and it is the cheapest way to
+ *     make double-submit harmless.
+ *   - global: a small worker budget. Bounds the damage from many users at once,
+ *     independently of any single user's behaviour.
+ *
+ * NON-BLOCKING BY DESIGN. `tryAcquire` returns null immediately rather than
+ * queueing. Queueing would convert a CPU problem into a latency-and-memory
+ * problem and hold sockets open behind work the client has probably abandoned;
+ * a fast 429 with Retry-After lets the caller decide.
+ *
+ * In-process only, like the express-rate-limit default store. Across multiple
+ * instances each process gets its own budget — appropriate here, because the
+ * resource being protected (this process's event loop) is itself per-process.
+ */
+
+/** Releases a held slot. Idempotent — calling twice does not double-free. */
+export type ReleaseFn = () => void
+
+export interface ConcurrencyLimiterOptions {
+  /** Maximum simultaneous holders across all keys. */
+  globalLimit: number
+  /** Maximum simultaneous holders for any single key. */
+  perKeyLimit: number
+}
+
+export interface AcquireFailure {
+  /** Which bound rejected the attempt, for logging and metrics. */
+  scope: 'global' | 'key'
+}
+
+export class ConcurrencyLimiter {
+  private readonly globalLimit: number
+  private readonly perKeyLimit: number
+  private active = 0
+  private readonly perKey = new Map<string, number>()
+
+  constructor(options: ConcurrencyLimiterOptions) {
+    this.globalLimit = Math.max(1, options.globalLimit)
+    this.perKeyLimit = Math.max(1, options.perKeyLimit)
+  }
+
+  /**
+   * Take a slot, or return the reason none was available.
+   *
+   * The per-key bound is checked FIRST so a single user hammering the endpoint
+   * is reported as their own limit rather than as global saturation — the two
+   * mean very different things to whoever reads the logs.
+   */
+  tryAcquire(key: string): { release: ReleaseFn } | AcquireFailure {
+    const keyActive = this.perKey.get(key) ?? 0
+    if (keyActive >= this.perKeyLimit) return { scope: 'key' }
+    if (this.active >= this.globalLimit) return { scope: 'global' }
+
+    this.active++
+    this.perKey.set(key, keyActive + 1)
+
+    let released = false
+    const release: ReleaseFn = () => {
+      if (released) return
+      released = true
+      this.active--
+      const n = (this.perKey.get(key) ?? 1) - 1
+      // Delete at zero rather than leaving a 0 entry: this map is keyed by
+      // userId and would otherwise grow without bound for the process lifetime.
+      if (n <= 0) this.perKey.delete(key)
+      else this.perKey.set(key, n)
+    }
+
+    return { release }
+  }
+
+  /** Current global in-flight count. Exposed for metrics and tests. */
+  get inFlight(): number {
+    return this.active
+  }
+
+  /** Number of distinct keys holding a slot. Exposed for tests. */
+  get activeKeys(): number {
+    return this.perKey.size
+  }
+}
+
+/** True when `tryAcquire` returned a failure rather than a slot. */
+export function isAcquireFailure(
+  result: { release: ReleaseFn } | AcquireFailure
+): result is AcquireFailure {
+  return (result as AcquireFailure).scope !== undefined
+}

--- a/src/validators/allocation-validators.ts
+++ b/src/validators/allocation-validators.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+import {
+  MAX_FRONTIER_POINTS,
+  DEFAULT_FRONTIER_POINTS,
+} from '../analytics/optimizer'
+import {
+  DEFAULT_LOOKBACK_DAYS,
+  MIN_ALIGNED_OBSERVATIONS,
+} from '../analytics/estimation'
+
+/**
+ * Zod schemas for the allocation-suggestion endpoints (#322).
+ *
+ * Whole-request form (`{ params, body }` / `{ params, query }`) to match
+ * src/routes/portfolio.ts, where every other schema in the file is written that
+ * way and validate() writes the coerced result back onto the request.
+ *
+ * Every numeric bound here is also a CPU bound. This is the one endpoint in the
+ * API where an unbounded query parameter translates directly into event-loop
+ * time, so the caps are the same constants the optimizer enforces internally
+ * rather than a second, drifting set of magic numbers.
+ */
+
+const userIdParams = z.object({
+  userId: z.string().uuid(),
+})
+
+/**
+ * POST /portfolio/:userId/suggest-allocation
+ *
+ * Body is entirely optional — the default request is "suggest something for me"
+ * with no tuning at all. `.strict()` so a typo'd knob (`frontierPoint`,
+ * `lookback`) is a 400 rather than being silently ignored, which on this
+ * endpoint would return a confidently-wrong answer computed over the wrong
+ * window.
+ */
+export const suggestAllocationSchema = z.object({
+  params: userIdParams,
+  body: z
+    .object({
+      /**
+       * Lower bound is MIN_ALIGNED_OBSERVATIONS: below it the estimator refuses
+       * to characterize a covariance matrix at all, so accepting a smaller value
+       * would only produce an `insufficient_universe` outcome after doing the
+       * work. Upper bound is 365 — ProtocolRate is retained well past that, but
+       * a year-old APY quote says little about today's rate.
+       */
+      lookbackDays: z.coerce
+        .number()
+        .int()
+        .min(MIN_ALIGNED_OBSERVATIONS)
+        .max(365)
+        .default(DEFAULT_LOOKBACK_DAYS),
+      /** Each extra point is another full solve; hard-capped by the optimizer. */
+      frontierPoints: z.coerce
+        .number()
+        .int()
+        .min(2)
+        .max(MAX_FRONTIER_POINTS)
+        .default(DEFAULT_FRONTIER_POINTS),
+      /**
+       * Skip the suggested-vs-current backtest legs. Opt-out rather than
+       * opt-in: the comparison is the point of the feature for a human caller,
+       * and it is the scheduled job — not a user — that wants it off.
+       */
+      includeBacktest: z.coerce.boolean().default(true),
+    })
+    .strict()
+    // Spelled out rather than `.default({})`: in Zod v4 a container default is
+    // typed against the OUTPUT shape, so an empty object does not typecheck
+    // even though every field has its own default. Listing them keeps the
+    // no-body request identical to an empty-body one.
+    .default(() => ({
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+      frontierPoints: DEFAULT_FRONTIER_POINTS,
+      includeBacktest: true,
+    })),
+})
+
+/**
+ * GET /portfolio/:userId/suggestions
+ *
+ * Page/limit rather than cursor, matching the marketplace listing in
+ * strategy-validators.ts. Capped at 50 so a wide page cannot pull a large number
+ * of stored efficient frontiers into memory at once.
+ */
+export const listSuggestionsSchema = z.object({
+  params: userIdParams,
+  query: z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(50).default(20),
+  }),
+})
+
+export type SuggestAllocationBody = z.infer<
+  typeof suggestAllocationSchema
+>['body']
+export type ListSuggestionsQuery = z.infer<
+  typeof listSuggestionsSchema
+>['query']

--- a/tests/integration/allocation-suggestions.integration.test.ts
+++ b/tests/integration/allocation-suggestions.integration.test.ts
@@ -1,0 +1,361 @@
+/**
+ * #322 — Allocation-suggestion routes integration test.
+ *
+ * Mounts the REAL portfolio router on a minimal Express app with only auth and
+ * the DB mocked, so a request travels through the real validators, the real
+ * service, the real optimizer and the real mappers. Mocking the service would
+ * test nothing but the mock, and the properties that matter here — owner
+ * scoping, the 429 paths, and the fact that a response is never mistakable for
+ * an applied change — are all end-to-end properties of that chain.
+ */
+const ownerUserId = '11111111-1111-4111-8111-111111111111'
+const otherUserId = '22222222-2222-4222-8222-222222222222'
+
+import request from 'supertest'
+import express from 'express'
+
+// --- Auth: inject a fixed identity, and keep enforceUserAccess REAL ----------
+// enforceUserAccess is the thing under test for owner scoping, so it is the one
+// piece of the auth chain that must not be stubbed away.
+jest.mock('../../src/middleware/authenticate', () => {
+  const actual = jest.requireActual('../../src/middleware/authenticate')
+  return {
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.userId = ownerUserId
+      req.auth = { userId: ownerUserId, walletAddress: 'GWALLET_OWNER' }
+      next()
+    },
+    enforceUserAccess: actual.enforceUserAccess,
+  }
+})
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logBackgroundJob: jest.fn(),
+  requestLogger: (_req: any, _res: any, next: any) => next(),
+}))
+
+/**
+ * The optimizer rate limiter is a MODULE-LEVEL singleton with a shared
+ * express-rate-limit store, so its 5-requests-per-minute budget would be
+ * consumed across every test in this file regardless of how many Express apps
+ * are built — the sixth POST below would 429 for the wrong reason and the
+ * suite would be order-dependent. Stubbed to a pass-through here; the limiter's
+ * own 429/Retry-After behaviour is generic express-rate-limit config, and the
+ * genuinely new in-flight logic is covered by tests/unit/utils/concurrency.test.ts
+ * plus the concurrency case below.
+ */
+jest.mock('../../src/middleware/rateLimiter', () => ({
+  optimizerRateLimiter: (_req: any, _res: any, next: any) => next(),
+}))
+
+jest.mock('../../src/db', () => ({ __esModule: true, default: {} }))
+
+import db from '../../src/db'
+import portfolioRouter from '../../src/routes/portfolio'
+
+const mockDb = db as any
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = new Date()
+
+function rateRows(spec: Record<string, number>, days = 90) {
+  const rows: any[] = []
+  for (let d = 0; d < days; d++) {
+    const fetchedAt = new Date(NOW.getTime() - (days - 1 - d) * DAY)
+    for (const [protocolName, base] of Object.entries(spec)) {
+      rows.push({
+        protocolName,
+        assetSymbol: 'USDC',
+        supplyApy: base + Math.sin((d + protocolName.length) / 6),
+        fetchedAt,
+      })
+    }
+  }
+  return rows
+}
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/v1/portfolio', portfolioRouter)
+  return app
+}
+
+function setupDb(overrides: { suggestions?: any[]; total?: number } = {}) {
+  mockDb.user = {
+    findUnique: jest.fn().mockResolvedValue({
+      id: ownerUserId,
+      riskTolerance: 5,
+      strategyConfig: null,
+    }),
+  }
+  mockDb.strategyFollow = { findFirst: jest.fn().mockResolvedValue(null) }
+  mockDb.savingsGoal = { findFirst: jest.fn().mockResolvedValue(null) }
+  mockDb.protocolRate = {
+    findMany: jest
+      .fn()
+      .mockResolvedValue(rateRows({ Blend: 11, Luma: 8, Nova: 6 })),
+  }
+  mockDb.protocolRiskScore = {
+    findMany: jest.fn().mockResolvedValue([
+      { protocolName: 'Blend', score: 72, insufficientHistory: false },
+      { protocolName: 'Luma', score: 61, insufficientHistory: false },
+      { protocolName: 'Nova', score: 88, insufficientHistory: false },
+    ]),
+  }
+  mockDb.position = { findMany: jest.fn().mockResolvedValue([]) }
+  mockDb.allocationSuggestion = {
+    create: jest.fn().mockResolvedValue({ id: 'suggestion-1' }),
+    count: jest.fn().mockResolvedValue(overrides.total ?? 0),
+    findMany: jest.fn().mockResolvedValue(overrides.suggestions ?? []),
+  }
+}
+
+beforeEach(() => setupDb())
+
+describe('POST /api/v1/portfolio/:userId/suggest-allocation', () => {
+  it('returns an advisory suggestion for the owner', async () => {
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+
+    expect(res.status).toBe(200)
+    expect(res.body.isSuggestion).toBe(true)
+    expect(res.body.disclaimer).toEqual(expect.any(String))
+    expect(res.body.status).toBe('ok')
+
+    const sum = Object.values(
+      res.body.weights as Record<string, number>
+    ).reduce((s, v) => s + v, 0)
+    expect(Math.abs(sum - 100)).toBeLessThanOrEqual(0.01)
+  })
+
+  it('carries the efficient frontier and the backtest caveat', async () => {
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({ frontierPoints: 6 })
+
+    expect(res.status).toBe(200)
+    expect(res.body.outcome.frontier).toHaveLength(6)
+    expect(res.body.backtest.caveat).toEqual(
+      expect.stringContaining('one protocol at a time')
+    )
+  })
+
+  it('rejects acting on another user before any work is done', async () => {
+    // enforceUserAccess answers 401 (not 403) for a cross-user target — see
+    // AUTH_ERRORS.UNAUTHORIZED in src/middleware/authenticate.ts. Asserted as
+    // the real behaviour rather than the shape one might assume.
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${otherUserId}/suggest-allocation`)
+      .send({})
+
+    expect(res.status).toBe(401)
+    expect(mockDb.allocationSuggestion.create).not.toHaveBeenCalled()
+    expect(mockDb.protocolRate.findMany).not.toHaveBeenCalled()
+  })
+
+  it('400s on an unknown body field rather than silently ignoring it', async () => {
+    // A typo'd knob would otherwise return a confident answer computed over the
+    // wrong window.
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({ lookback: 30 })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('400s on an out-of-range frontierPoints', async () => {
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({ frontierPoints: 500 })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a non-uuid userId', async () => {
+    // Ownership is checked BEFORE validation (requireAuth -> enforceUserAccess
+    // -> validate), so a bogus id belonging to nobody is an auth failure, not a
+    // schema failure. Auth-before-validation is the correct order.
+    const res = await request(buildApp())
+      .post('/api/v1/portfolio/not-a-uuid/suggest-allocation')
+      .send({})
+
+    expect(res.status).toBe(401)
+  })
+
+  it('404s for a user that does not exist', async () => {
+    mockDb.user.findUnique.mockResolvedValue(null)
+
+    const res = await request(buildApp())
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+
+    expect(res.status).toBe(404)
+  })
+
+  it('429s the second concurrent optimization for the same user', async () => {
+    // The per-user in-flight bound is 1. Hold the first request inside the
+    // service by stalling a DB read, then fire the second.
+    let releaseFirst: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+
+    let call = 0
+    mockDb.protocolRate.findMany.mockImplementation(async () => {
+      call++
+      if (call === 1) await gate
+      return rateRows({ Blend: 11, Luma: 8, Nova: 6 })
+    })
+
+    const app = buildApp()
+    // `.then()` is what actually dispatches a supertest request. Without it the
+    // first request would never enter the service, the gate below would be hit
+    // by the SECOND request instead, and the test would deadlock.
+    const first = request(app)
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+      .then((r) => r)
+
+    // Give the first request time to enter the service and take the slot.
+    await new Promise((r) => setTimeout(r, 100))
+
+    const second = await request(app)
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+
+    expect(second.status).toBe(429)
+    expect(second.headers['retry-after']).toBeDefined()
+    expect(second.body.error).toEqual(
+      expect.stringContaining('already running')
+    )
+
+    releaseFirst()
+    expect((await first).status).toBe(200)
+  })
+
+  it('releases the concurrency slot after a failure', async () => {
+    // A leaked slot would wedge this user out of the endpoint permanently.
+    mockDb.user.findUnique.mockResolvedValueOnce(null)
+    const app = buildApp()
+
+    const failed = await request(app)
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+    expect(failed.status).toBe(404)
+
+    const next = await request(app)
+      .post(`/api/v1/portfolio/${ownerUserId}/suggest-allocation`)
+      .send({})
+    expect(next.status).toBe(200)
+  })
+})
+
+describe('GET /api/v1/portfolio/:userId/suggestions', () => {
+  const row = {
+    id: 'sug-1',
+    status: 'ok',
+    inputHash: 'sha256:abc',
+    weights: { Blend: 60, Luma: 40 },
+    frontier: [],
+    backtestSummary: null,
+    riskTolerance: 5,
+    effectiveRiskCeiling: null,
+    reason: null,
+    computedAt: new Date('2026-08-17T00:00:00Z'),
+  }
+
+  it('returns the paginated history for the owner', async () => {
+    setupDb({ suggestions: [row], total: 1 })
+
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${ownerUserId}/suggestions`
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body.total).toBe(1)
+    expect(res.body.page).toBe(1)
+    expect(res.body.limit).toBe(20)
+    expect(res.body.suggestions).toHaveLength(1)
+    expect(res.body.suggestions[0]).toMatchObject({
+      id: 'sug-1',
+      isSuggestion: true,
+      status: 'ok',
+      weights: { Blend: 60, Luma: 40 },
+    })
+  })
+
+  it('marks every stored row as a suggestion, never an applied change', async () => {
+    setupDb({ suggestions: [row, { ...row, id: 'sug-2' }], total: 2 })
+
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${ownerUserId}/suggestions`
+    )
+
+    for (const s of res.body.suggestions) {
+      expect(s.isSuggestion).toBe(true)
+    }
+  })
+
+  it('never leaks userId in a stored row', async () => {
+    setupDb({ suggestions: [{ ...row, userId: ownerUserId }], total: 1 })
+
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${ownerUserId}/suggestions`
+    )
+
+    expect(res.body.suggestions[0].userId).toBeUndefined()
+  })
+
+  it('applies page and limit to the query', async () => {
+    setupDb({ suggestions: [], total: 40 })
+
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${ownerUserId}/suggestions?page=3&limit=10`
+    )
+
+    expect(res.status).toBe(200)
+    const args = mockDb.allocationSuggestion.findMany.mock.calls[0][0]
+    expect(args.skip).toBe(20)
+    expect(args.take).toBe(10)
+    expect(args.where).toEqual({ userId: ownerUserId })
+    expect(args.orderBy).toEqual({ computedAt: 'desc' })
+  })
+
+  it('rejects listing another user suggestions', async () => {
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${otherUserId}/suggestions`
+    )
+
+    expect(res.status).toBe(401)
+    expect(mockDb.allocationSuggestion.findMany).not.toHaveBeenCalled()
+  })
+
+  it('400s on a limit above the cap', async () => {
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${ownerUserId}/suggestions?limit=500`
+    )
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('route ordering', () => {
+  it('does not swallow "suggestions" as a userId', async () => {
+    // GET /:userId is registered after these. If ordering regressed, the
+    // request would match GET /:userId with userId="<uuid>" and return a
+    // portfolio body instead of being scoped as a suggestions listing.
+    const res = await request(buildApp()).get(
+      `/api/v1/portfolio/${otherUserId}/suggestions`
+    )
+    expect(res.status).toBe(401)
+    expect(res.body.positions).toBeUndefined()
+  })
+})

--- a/tests/integration/rateLimiter.integration.test.ts
+++ b/tests/integration/rateLimiter.integration.test.ts
@@ -18,6 +18,9 @@ jest.mock('../../src/config/env', () => ({
       adminRateLimit: { windowMs: 900000, max: 10 },
       webhookRateLimit: { windowMs: 60000, max: 30 },
       internalRateLimit: { windowMs: 60000, max: 500 },
+      // #322 — every limiter in rateLimiter.ts is constructed at module load,
+      // so a block missing here fails the whole suite at import, not at use.
+      optimizerRateLimit: { windowMs: 60000, max: 5 },
       trustedIps: [],
       internalServiceToken: '',
     },

--- a/tests/unit/analytics/estimation.test.ts
+++ b/tests/unit/analytics/estimation.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Estimation layer unit tests (#322).
+ *
+ * The headline correctness property here is INDEX ALIGNMENT: covariance entry
+ * (i,j) must pair protocol i and protocol j on the SAME day. A misaligned matrix
+ * looks perfectly well-formed and is silently wrong, so several tests below
+ * exercise gappy and ragged inputs specifically.
+ */
+
+import {
+  DEFAULT_LOOKBACK_DAYS,
+  MIN_ALIGNED_OBSERVATIONS,
+  aggregateDailyRates,
+  estimate,
+  sampleCovariance,
+} from '../../../src/analytics/estimation'
+import { RawRateObservation, RiskScoreRow } from '../../../src/analytics/types'
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = new Date('2026-08-17T00:00:00Z')
+
+function series(
+  protocolName: string,
+  days: number,
+  apyAt: (d: number) => number,
+  opts: { skip?: (d: number) => boolean } = {}
+): RawRateObservation[] {
+  const out: RawRateObservation[] = []
+  for (let d = 0; d < days; d++) {
+    if (opts.skip?.(d)) continue
+    out.push({
+      protocolName,
+      assetSymbol: 'USDC',
+      apy: apyAt(d),
+      date: new Date(NOW.getTime() - (days - 1 - d) * DAY),
+    })
+  }
+  return out
+}
+
+const scores = (...rows: Array<[string, number, boolean?]>): RiskScoreRow[] =>
+  rows.map(([protocolName, score, insufficientHistory]) => ({
+    protocolName,
+    score,
+    insufficientHistory: insufficientHistory ?? false,
+  }))
+
+describe('aggregateDailyRates', () => {
+  it('averages multiple assets and multiple scans on the same day', () => {
+    const at = new Date('2026-08-10T00:00:00Z')
+    const out = aggregateDailyRates([
+      { protocolName: 'Blend', assetSymbol: 'USDC', apy: 10, date: at },
+      {
+        protocolName: 'Blend',
+        assetSymbol: 'XLM',
+        apy: 14,
+        date: new Date(at.getTime() + 3600_000),
+      },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].apy).toBeCloseTo(12, 10)
+  })
+
+  it('preserves protocol names containing spaces', () => {
+    // Regression: an earlier draft rebuilt the name by splitting the map key on
+    // a space, which truncated "Stellar DEX" into a different protocol.
+    const out = aggregateDailyRates([
+      {
+        protocolName: 'Stellar DEX',
+        assetSymbol: 'USDC',
+        apy: 5,
+        date: NOW,
+      },
+    ])
+    expect(out[0].protocolName).toBe('Stellar DEX')
+  })
+
+  it('ignores non-finite APYs rather than poisoning the average', () => {
+    const out = aggregateDailyRates([
+      { protocolName: 'A', assetSymbol: 'USDC', apy: NaN, date: NOW },
+      { protocolName: 'A', assetSymbol: 'XLM', apy: 8, date: NOW },
+    ])
+    expect(out[0].apy).toBe(8)
+  })
+
+  it('is deterministic regardless of input order', () => {
+    const rows = series('A', 5, (d) => 5 + d)
+    const forward = JSON.stringify(aggregateDailyRates(rows))
+    const reversed = JSON.stringify(aggregateDailyRates([...rows].reverse()))
+    expect(forward).toBe(reversed)
+  })
+})
+
+describe('sampleCovariance', () => {
+  it('uses the n-1 convention, matching sampleStdev', () => {
+    // var([1,2,3,4]) with n-1 = 5/3
+    const cov = sampleCovariance([[1, 2, 3, 4]])
+    expect(cov[0][0]).toBeCloseTo(5 / 3, 12)
+  })
+
+  it('is exactly symmetric, not merely symmetric to within epsilon', () => {
+    const cov = sampleCovariance([
+      [1, 2, 3, 4, 5],
+      [2, 1, 4, 3, 6],
+      [5, 3, 2, 4, 1],
+    ])
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 3; j++) {
+        expect(cov[i][j]).toBe(cov[j][i])
+      }
+    }
+  })
+
+  it('is positive semi-definite', () => {
+    const cov = sampleCovariance([
+      [1, 2, 3, 4, 5, 4, 3],
+      [2, 1, 4, 3, 6, 2, 5],
+      [5, 3, 2, 4, 1, 3, 2],
+    ])
+    for (let s = 1; s <= 300; s++) {
+      const v = [Math.sin(s), Math.cos(s * 1.7), Math.sin(s * 2.3)]
+      let q = 0
+      for (let i = 0; i < 3; i++) {
+        for (let j = 0; j < 3; j++) q += v[i] * cov[i][j] * v[j]
+      }
+      expect(q).toBeGreaterThanOrEqual(-1e-12)
+    }
+  })
+
+  it('returns zeros for a single observation (no n-1 divide by zero)', () => {
+    expect(sampleCovariance([[5], [7]])).toEqual([
+      [0, 0],
+      [0, 0],
+    ])
+  })
+})
+
+describe('estimate — universe eligibility', () => {
+  const rates = [
+    ...series('Good', 90, () => 8),
+    ...series('Thin', 90, () => 12),
+    ...series('Risky', 90, () => 15),
+  ]
+
+  it('excludes protocols flagged insufficientHistory, with a reason', () => {
+    const r = estimate({
+      rates,
+      riskScores: scores(['Good', 80], ['Thin', 20, true], ['Risky', 60]),
+      now: NOW,
+    })
+    expect(r.protocols).toEqual(['Good', 'Risky'])
+    expect(r.excluded).toContainEqual(
+      expect.objectContaining({
+        protocol: 'Thin',
+        reason: 'insufficient_history',
+      })
+    )
+  })
+
+  it('excludes protocols with no risk-score row at all (fail-closed)', () => {
+    const r = estimate({
+      rates,
+      riskScores: scores(['Good', 80], ['Risky', 60]),
+      now: NOW,
+    })
+    expect(r.protocols).not.toContain('Thin')
+    expect(r.excluded).toContainEqual(
+      expect.objectContaining({ protocol: 'Thin', reason: 'no_risk_score' })
+    )
+  })
+
+  it('applies the risk ceiling and records the failing score', () => {
+    const r = estimate({
+      rates,
+      riskScores: scores(['Good', 80], ['Thin', 40], ['Risky', 60]),
+      riskCeiling: 70,
+      now: NOW,
+    })
+    expect(r.protocols).toEqual(['Good'])
+    const risky = r.excluded.find((e) => e.protocol === 'Risky')
+    expect(risky?.reason).toBe('risk_ceiling')
+    expect(risky?.detail).toContain('60')
+    expect(risky?.detail).toContain('70')
+  })
+
+  it('excludes a scored protocol with no rate history in the window', () => {
+    const r = estimate({
+      rates: series('Good', 90, () => 8),
+      riskScores: scores(['Good', 80], ['Ghost', 90]),
+      now: NOW,
+    })
+    expect(r.excluded).toContainEqual(
+      expect.objectContaining({ protocol: 'Ghost', reason: 'no_rate_history' })
+    )
+    expect(r.riskScores.Ghost).toBeUndefined()
+  })
+})
+
+describe('estimate — statistics', () => {
+  it('expected return is the mean annual rate as a decimal fraction', () => {
+    // Constant 8% APY -> mu = 0.08 exactly.
+    const r = estimate({
+      rates: [...series('A', 60, () => 8), ...series('B', 60, () => 4)],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.protocols).toEqual(['A', 'B'])
+    expect(r.expectedReturns[0]).toBeCloseTo(0.08, 12)
+    expect(r.expectedReturns[1]).toBeCloseTo(0.04, 12)
+  })
+
+  it('a flat series has zero variance', () => {
+    const r = estimate({
+      rates: [...series('A', 60, () => 8), ...series('B', 60, () => 4)],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.covariance[0][0]).toBeCloseTo(0, 15)
+  })
+
+  it('perfectly co-moving protocols have correlation 1', () => {
+    const r = estimate({
+      rates: [
+        ...series('A', 60, (d) => 8 + (d % 5)),
+        ...series('B', 60, (d) => 12 + (d % 5)),
+      ],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    const corr =
+      r.covariance[0][1] / Math.sqrt(r.covariance[0][0] * r.covariance[1][1])
+    expect(corr).toBeCloseTo(1, 9)
+  })
+
+  it('anti-correlated protocols have correlation -1', () => {
+    const r = estimate({
+      rates: [
+        ...series('A', 60, (d) => 8 + (d % 5)),
+        ...series('B', 60, (d) => 12 - (d % 5)),
+      ],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    const corr =
+      r.covariance[0][1] / Math.sqrt(r.covariance[0][0] * r.covariance[1][1])
+    expect(corr).toBeCloseTo(-1, 9)
+  })
+})
+
+describe('estimate — alignment', () => {
+  it('forward-fills gaps so a gappy protocol stays index-aligned', () => {
+    // B is missing every third day; forward-fill keeps the grid complete.
+    const r = estimate({
+      rates: [
+        ...series('A', 60, (d) => 8 + (d % 4)),
+        ...series('B', 60, (d) => 5 + (d % 3), { skip: (d) => d % 3 === 1 }),
+      ],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.protocols).toEqual(['A', 'B'])
+    expect(r.observationCount).toBe(60)
+    expect(r.covariance).toHaveLength(2)
+  })
+
+  it('only counts days on which EVERY protocol has a value', () => {
+    // B's first observation is 20 days after A's, so the first 40 days of the
+    // window have no B value to hold forward and cannot be aligned.
+    const rates = [...series('A', 60, () => 8), ...series('B', 20, () => 5)]
+    const r = estimate({
+      rates,
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.observationCount).toBe(20)
+  })
+
+  it('drops the whole universe below the aligned-observation minimum', () => {
+    const shortDays = MIN_ALIGNED_OBSERVATIONS - 1
+    const r = estimate({
+      rates: [
+        ...series('A', shortDays, () => 8),
+        ...series('B', shortDays, () => 5),
+      ],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.protocols).toEqual([])
+    expect(r.observationCount).toBe(0)
+    expect(
+      r.excluded.filter((e) => e.reason === 'insufficient_aligned_history')
+    ).toHaveLength(2)
+  })
+
+  it('honours a custom lookback window', () => {
+    const r = estimate({
+      rates: [...series('A', 90, () => 8), ...series('B', 90, () => 5)],
+      riskScores: scores(['A', 80], ['B', 80]),
+      lookbackDays: 30,
+      now: NOW,
+    })
+    expect(r.lookbackDays).toBe(30)
+    expect(r.observationCount).toBe(30)
+  })
+
+  it('defaults the lookback to DEFAULT_LOOKBACK_DAYS', () => {
+    const r = estimate({
+      rates: [...series('A', 200, () => 8), ...series('B', 200, () => 5)],
+      riskScores: scores(['A', 80], ['B', 80]),
+      now: NOW,
+    })
+    expect(r.lookbackDays).toBe(DEFAULT_LOOKBACK_DAYS)
+    expect(r.observationCount).toBe(DEFAULT_LOOKBACK_DAYS)
+  })
+})
+
+describe('estimate — determinism', () => {
+  it('is invariant to input ordering', () => {
+    const rates = [
+      ...series('Zeta', 60, (d) => 8 + (d % 7)),
+      ...series('Alpha', 60, (d) => 5 + (d % 3)),
+    ]
+    const riskScores = scores(['Zeta', 80], ['Alpha', 70])
+
+    const a = estimate({ rates, riskScores, now: NOW })
+    const b = estimate({
+      rates: [...rates].reverse(),
+      riskScores: [...riskScores].reverse(),
+      now: NOW,
+    })
+    expect(JSON.stringify(b)).toBe(JSON.stringify(a))
+  })
+
+  it('returns protocols sorted by name', () => {
+    const r = estimate({
+      rates: [
+        ...series('Zeta', 60, () => 8),
+        ...series('Alpha', 60, () => 5),
+        ...series('Mid', 60, () => 6),
+      ],
+      riskScores: scores(['Zeta', 80], ['Alpha', 70], ['Mid', 75]),
+      now: NOW,
+    })
+    expect(r.protocols).toEqual(['Alpha', 'Mid', 'Zeta'])
+  })
+})

--- a/tests/unit/analytics/optimizer.test.ts
+++ b/tests/unit/analytics/optimizer.test.ts
@@ -1,0 +1,552 @@
+/**
+ * Portfolio optimizer — property-style unit tests (#322).
+ *
+ * The solver is new numeric code, so most of what matters here is not "does it
+ * return the number I hard-coded" but "does it ALWAYS satisfy the constraints it
+ * promises". Hence property tests over a seeded pseudo-random generator: many
+ * inputs, invariants asserted on every one, and reproducible on failure because
+ * the generator is deterministic.
+ *
+ * The seeded generator is deliberately hand-rolled rather than Math.random —
+ * a failing case must be reproducible from the seed printed in the test name.
+ */
+
+import {
+  DEFAULT_MAX_WEIGHT_PER_PROTOCOL,
+  LAMBDA_MAX,
+  LAMBDA_MIN,
+  MAX_FRONTIER_POINTS,
+  checkFeasibility,
+  optimize,
+  projectOntoCappedSimplex,
+  riskToleranceToLambda,
+  toPercentageAllocations,
+} from '../../../src/analytics/optimizer'
+import { OptimizerInput } from '../../../src/analytics/types'
+
+// ── Seeded generator (mulberry32) ────────────────────────────────────────────
+
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * A random PSD covariance matrix, built as A'A so it is positive semi-definite
+ * by construction — the concavity the solver relies on is a precondition, not
+ * something the test should accidentally violate.
+ */
+function randomProblem(
+  rng: () => number,
+  n: number
+): { protocols: string[]; mu: number[]; sigma: number[][] } {
+  const protocols = Array.from({ length: n }, (_, i) => `P${String(i + 1)}`)
+  const mu = Array.from({ length: n }, () => 0.02 + rng() * 0.15)
+
+  const a: number[][] = Array.from({ length: n }, () =>
+    Array.from({ length: n }, () => (rng() - 0.5) * 0.05)
+  )
+  const sigma: number[][] = Array.from({ length: n }, () =>
+    new Array<number>(n).fill(0)
+  )
+  for (let i = 0; i < n; i++) {
+    for (let j = i; j < n; j++) {
+      let s = 0
+      for (let k = 0; k < n; k++) s += a[k][i] * a[k][j]
+      sigma[i][j] = s
+      sigma[j][i] = s
+    }
+  }
+  return { protocols, mu, sigma }
+}
+
+function sumOf(weights: Record<string, number>): number {
+  return Object.values(weights).reduce((s, v) => s + v, 0)
+}
+
+describe('riskToleranceToLambda', () => {
+  it('maps 1 to the most risk-averse lambda and 10 to the least', () => {
+    expect(riskToleranceToLambda(1)).toBeCloseTo(LAMBDA_MAX, 9)
+    expect(riskToleranceToLambda(10)).toBeCloseTo(LAMBDA_MIN, 9)
+  })
+
+  it('is strictly decreasing across the 1-10 range', () => {
+    for (let rt = 1; rt < 10; rt++) {
+      expect(riskToleranceToLambda(rt + 1)).toBeLessThan(
+        riskToleranceToLambda(rt)
+      )
+    }
+  })
+
+  it('clamps out-of-range and non-finite values rather than throwing', () => {
+    // User.riskTolerance is an Int column with no DB-level range check.
+    expect(riskToleranceToLambda(0)).toBeCloseTo(LAMBDA_MAX, 9)
+    expect(riskToleranceToLambda(99)).toBeCloseTo(LAMBDA_MIN, 9)
+    expect(Number.isFinite(riskToleranceToLambda(NaN))).toBe(true)
+  })
+})
+
+describe('projectOntoCappedSimplex', () => {
+  it('hits the target sum exactly and respects the box', () => {
+    const rng = makeRng(7)
+    for (let trial = 0; trial < 200; trial++) {
+      const n = 2 + Math.floor(rng() * 8)
+      const v = Array.from({ length: n }, () => (rng() - 0.3) * 3)
+      const lo = Array.from({ length: n }, () => rng() * 0.05)
+      const hi = lo.map((l) => l + 0.2 + rng() * 0.8)
+
+      // The projection's contract is defined only on a FEASIBLE box; with
+      // sum(hi) < 1 there is no point on the simplex to project onto and the
+      // function documents checkFeasibility as the caller's gate. Skip those
+      // rather than asserting a contract that was never offered.
+      if (checkFeasibility(lo, hi, [], [], null) !== null) continue
+
+      const w = projectOntoCappedSimplex(v, lo, hi)
+
+      expect(w.reduce((s, x) => s + x, 0)).toBeCloseTo(1, 10)
+      w.forEach((x, i) => {
+        expect(x).toBeGreaterThanOrEqual(lo[i] - 1e-12)
+        expect(x).toBeLessThanOrEqual(hi[i] + 1e-12)
+      })
+    }
+  })
+
+  it('is idempotent on an already-feasible point', () => {
+    const lo = [0, 0, 0]
+    const hi = [1, 1, 1]
+    const feasible = [0.2, 0.5, 0.3]
+    const once = projectOntoCappedSimplex(feasible, lo, hi)
+    once.forEach((x, i) => expect(x).toBeCloseTo(feasible[i], 10))
+  })
+})
+
+describe('checkFeasibility', () => {
+  it('names minWeights when the minimums cannot fit in 100%', () => {
+    const f = checkFeasibility([0.7, 0.7], [1, 1], [], [0, 1], null)
+    expect(f?.bindingConstraint).toBe('minWeights')
+  })
+
+  it('names maxWeights when the maximums cannot reach 100%', () => {
+    const f = checkFeasibility([0, 0], [0.3, 0.3], [], [0, 1], null)
+    expect(f?.bindingConstraint).toBe('maxWeights')
+  })
+
+  it('names stableFloor when the stable group cannot reach the floor', () => {
+    const f = checkFeasibility([0, 0], [1, 0.2], [1], [0], 0.5)
+    expect(f?.bindingConstraint).toBe('stableFloor')
+  })
+
+  it('names stableFloor when the rest of the book cannot absorb the remainder', () => {
+    // Floor 0.5 leaves 0.5 for non-stables, but they are capped at 0.2 total.
+    const f = checkFeasibility([0, 0], [1, 0.2], [0], [1], 0.5)
+    expect(f?.bindingConstraint).toBe('stableFloor')
+  })
+
+  it('passes a satisfiable configuration', () => {
+    expect(checkFeasibility([0, 0], [1, 1], [0], [1], 0.4)).toBeNull()
+  })
+})
+
+describe('optimize — invariants over seeded random problems', () => {
+  const SEEDS = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+
+  it.each(SEEDS)(
+    'seed %i: weights sum to 1 and respect every bound',
+    (seed) => {
+      const rng = makeRng(seed)
+
+      for (let trial = 0; trial < 20; trial++) {
+        const n = 2 + Math.floor(rng() * 7)
+        const { protocols, mu, sigma } = randomProblem(rng, n)
+        const riskTolerance = 1 + Math.floor(rng() * 10)
+
+        const result = optimize({
+          protocols,
+          expectedReturns: mu,
+          covariance: sigma,
+          riskTolerance,
+          frontierPoints: 5,
+        })
+
+        expect(result.status).toBe('ok')
+        if (result.status !== 'ok') return
+
+        expect(sumOf(result.weights)).toBeCloseTo(1, 9)
+
+        // Default concentration cap, raised to 1/n on small universes.
+        const cap = Math.max(DEFAULT_MAX_WEIGHT_PER_PROTOCOL, 1 / n)
+        for (const w of Object.values(result.weights)) {
+          expect(w).toBeGreaterThanOrEqual(-1e-12)
+          expect(w).toBeLessThanOrEqual(cap + 1e-9)
+        }
+      }
+    }
+  )
+
+  it.each(SEEDS)(
+    'seed %i: explicit min/max bounds are always respected',
+    (seed) => {
+      const rng = makeRng(seed + 1000)
+
+      for (let trial = 0; trial < 15; trial++) {
+        const n = 3 + Math.floor(rng() * 5)
+        const { protocols, mu, sigma } = randomProblem(rng, n)
+
+        const min: Record<string, number> = {}
+        const max: Record<string, number> = {}
+        protocols.forEach((p) => {
+          min[p] = rng() * (0.5 / n)
+          max[p] = 0.5 + rng() * 0.5
+        })
+
+        const result = optimize({
+          protocols,
+          expectedReturns: mu,
+          covariance: sigma,
+          riskTolerance: 1 + Math.floor(rng() * 10),
+          bounds: { min, max },
+          frontierPoints: 4,
+        })
+
+        expect(result.status).toBe('ok')
+        if (result.status !== 'ok') return
+
+        expect(sumOf(result.weights)).toBeCloseTo(1, 9)
+        for (const [name, w] of Object.entries(result.weights)) {
+          expect(w).toBeGreaterThanOrEqual(min[name] - 1e-9)
+          expect(w).toBeLessThanOrEqual(max[name] + 1e-9)
+        }
+      }
+    }
+  )
+
+  it.each(SEEDS)('seed %i: the stablecoin floor is never violated', (seed) => {
+    const rng = makeRng(seed + 2000)
+
+    for (let trial = 0; trial < 15; trial++) {
+      const n = 3 + Math.floor(rng() * 5)
+      const { protocols, mu, sigma } = randomProblem(rng, n)
+      const stable = protocols.slice(0, 1 + Math.floor(rng() * 2))
+      const minWeight = 0.3 + rng() * 0.4
+
+      const result = optimize({
+        protocols,
+        expectedReturns: mu,
+        covariance: sigma,
+        riskTolerance: 1 + Math.floor(rng() * 10),
+        stableFloor: { protocols: stable, minWeight },
+        // Lift the concentration cap so the floor is the binding constraint.
+        bounds: { max: Object.fromEntries(protocols.map((p) => [p, 1])) },
+        frontierPoints: 4,
+      })
+
+      expect(result.status).toBe('ok')
+      if (result.status !== 'ok') return
+
+      const stableSum = stable.reduce((s, p) => s + (result.weights[p] ?? 0), 0)
+      expect(stableSum).toBeGreaterThanOrEqual(minWeight - 1e-9)
+      expect(sumOf(result.weights)).toBeCloseTo(1, 9)
+    }
+  })
+})
+
+describe('optimize — determinism', () => {
+  const base: OptimizerInput = {
+    protocols: ['Zeta', 'Alpha', 'Mid'],
+    expectedReturns: [0.11, 0.06, 0.08],
+    covariance: [
+      [0.0009, 0.0001, 0.0002],
+      [0.0001, 0.0001, 0.00005],
+      [0.0002, 0.00005, 0.0004],
+    ],
+    riskTolerance: 5,
+  }
+
+  it('produces byte-identical output for the same input twice', () => {
+    expect(JSON.stringify(optimize(base))).toBe(JSON.stringify(optimize(base)))
+  })
+
+  it('is invariant to the caller ordering the protocols differently', () => {
+    // Same problem, rows/cols permuted to match a different protocol order.
+    const perm = [1, 2, 0] // Alpha, Mid, Zeta
+    const reordered: OptimizerInput = {
+      protocols: perm.map((i) => base.protocols[i]),
+      expectedReturns: perm.map((i) => base.expectedReturns[i]),
+      covariance: perm.map((i) => perm.map((j) => base.covariance[i][j])),
+      riskTolerance: base.riskTolerance,
+    }
+    expect(JSON.stringify(optimize(reordered))).toBe(
+      JSON.stringify(optimize(base))
+    )
+  })
+})
+
+describe('optimize — frontier', () => {
+  const input: OptimizerInput = {
+    protocols: ['A', 'B', 'C'],
+    expectedReturns: [0.12, 0.07, 0.09],
+    covariance: [
+      [0.0016, 0.0002, 0.0004],
+      [0.0002, 0.0002, 0.0001],
+      [0.0004, 0.0001, 0.0006],
+    ],
+    riskTolerance: 5,
+  }
+
+  it('honours the requested point count and the hard cap', () => {
+    const r = optimize({ ...input, frontierPoints: 8 })
+    expect(r.status === 'ok' && r.frontier).toHaveLength(8)
+
+    const capped = optimize({ ...input, frontierPoints: 999 })
+    expect(capped.status === 'ok' && capped.frontier).toHaveLength(
+      MAX_FRONTIER_POINTS
+    )
+  })
+
+  it('is non-decreasing in risk and in return', () => {
+    const r = optimize({ ...input, frontierPoints: 12 })
+    expect(r.status).toBe('ok')
+    if (r.status !== 'ok') return
+
+    for (let i = 1; i < r.frontier.length; i++) {
+      expect(r.frontier[i].risk).toBeGreaterThanOrEqual(
+        r.frontier[i - 1].risk - 1e-9
+      )
+      // More risk must buy more return — a frontier point that took on risk for
+      // less return would mean the sweep is not tracing an efficient frontier.
+      expect(r.frontier[i].return).toBeGreaterThanOrEqual(
+        r.frontier[i - 1].return - 1e-9
+      )
+    }
+  })
+
+  it('every frontier point is itself a valid portfolio', () => {
+    const r = optimize({ ...input, frontierPoints: 12 })
+    if (r.status !== 'ok') throw new Error('expected ok')
+    for (const point of r.frontier) {
+      expect(sumOf(point.weights)).toBeCloseTo(1, 9)
+    }
+  })
+})
+
+describe('optimize — monotonicity in risk tolerance', () => {
+  it('higher riskTolerance gives weakly higher expected return and volatility', () => {
+    const input: OptimizerInput = {
+      protocols: ['A', 'B'],
+      expectedReturns: [0.1, 0.06],
+      covariance: [
+        [0.0009, 0],
+        [0, 0.0001],
+      ],
+      riskTolerance: 1,
+      bounds: { max: { A: 1, B: 1 } },
+    }
+
+    let prevReturn = -Infinity
+    let prevVol = -Infinity
+    for (let rt = 1; rt <= 10; rt++) {
+      const r = optimize({ ...input, riskTolerance: rt })
+      if (r.status !== 'ok') throw new Error('expected ok')
+      expect(r.expectedReturn).toBeGreaterThanOrEqual(prevReturn - 1e-9)
+      expect(r.expectedVolatility).toBeGreaterThanOrEqual(prevVol - 1e-9)
+      prevReturn = r.expectedReturn
+      prevVol = r.expectedVolatility
+    }
+  })
+})
+
+describe('optimize — failure outcomes', () => {
+  const twoAsset = {
+    expectedReturns: [0.1, 0.06],
+    covariance: [
+      [0.0009, 0],
+      [0, 0.0001],
+    ],
+    riskTolerance: 5,
+  }
+
+  it('returns insufficient_universe below two eligible protocols', () => {
+    const r = optimize({
+      protocols: ['Solo'],
+      expectedReturns: [0.08],
+      covariance: [[0.0004]],
+      riskTolerance: 5,
+    })
+    expect(r.status).toBe('insufficient_universe')
+    if (r.status !== 'insufficient_universe') return
+    expect(r.eligibleCount).toBe(1)
+  })
+
+  it('names riskCeiling as the binding constraint when the ceiling emptied the universe', () => {
+    const r = optimize(
+      {
+        protocols: ['Solo'],
+        expectedReturns: [0.08],
+        covariance: [[0.0004]],
+        riskTolerance: 5,
+      },
+      [
+        { protocol: 'Risky', reason: 'risk_ceiling', detail: 'score 40 < 70' },
+        { protocol: 'Thin', reason: 'insufficient_history' },
+      ]
+    )
+    expect(r.status).toBe('insufficient_universe')
+    if (r.status !== 'insufficient_universe') return
+    expect(r.bindingConstraint).toBe('riskCeiling')
+    expect(r.excluded).toHaveLength(2)
+  })
+
+  it('omits bindingConstraint when the universe was thin for non-ceiling reasons', () => {
+    const r = optimize(
+      {
+        protocols: [],
+        expectedReturns: [],
+        covariance: [],
+        riskTolerance: 5,
+      },
+      [{ protocol: 'Thin', reason: 'insufficient_history' }]
+    )
+    expect(r.status).toBe('insufficient_universe')
+    if (r.status !== 'insufficient_universe') return
+    expect(r.bindingConstraint).toBeUndefined()
+  })
+
+  it('returns infeasible with minWeights when minimums exceed 100%', () => {
+    const r = optimize({
+      ...twoAsset,
+      protocols: ['A', 'B'],
+      bounds: { min: { A: 0.7, B: 0.7 } },
+    })
+    expect(r.status).toBe('infeasible')
+    if (r.status !== 'infeasible') return
+    expect(r.bindingConstraint).toBe('minWeights')
+    expect(r.reason).toContain('140.00%')
+  })
+
+  it('returns infeasible with maxWeights when maximums cannot reach 100%', () => {
+    const r = optimize({
+      ...twoAsset,
+      protocols: ['A', 'B'],
+      bounds: { max: { A: 0.3, B: 0.3 } },
+    })
+    expect(r.status).toBe('infeasible')
+    if (r.status !== 'infeasible') return
+    expect(r.bindingConstraint).toBe('maxWeights')
+  })
+
+  it('returns infeasible when the stable floor names no surviving protocol', () => {
+    const r = optimize({
+      ...twoAsset,
+      protocols: ['A', 'B'],
+      stableFloor: { protocols: ['NotInUniverse'], minWeight: 0.5 },
+    })
+    expect(r.status).toBe('infeasible')
+    if (r.status !== 'infeasible') return
+    expect(r.bindingConstraint).toBe('stableFloor')
+  })
+})
+
+describe('optimize — degenerate covariance', () => {
+  it('handles an all-zero Sigma without drifting off the simplex', () => {
+    // All-identical APY history: PSD still holds, but the risk term vanishes.
+    const r = optimize({
+      protocols: ['C', 'A', 'B'],
+      expectedReturns: [0.05, 0.05, 0.05],
+      covariance: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      riskTolerance: 5,
+    })
+    expect(r.status).toBe('ok')
+    if (r.status !== 'ok') return
+    expect(sumOf(r.weights)).toBeCloseTo(1, 12)
+    // Ties broken deterministically by name ordering, so the tied solution is
+    // the same on every run rather than depending on iteration order.
+    expect(Object.keys(r.weights)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+describe('optimize — reported portfolio risk score', () => {
+  it('is the weighted average of the supplied protocol scores', () => {
+    const r = optimize({
+      protocols: ['A', 'B'],
+      expectedReturns: [0.1, 0.06],
+      covariance: [
+        [0.0009, 0],
+        [0, 0.0001],
+      ],
+      riskTolerance: 5,
+      riskScores: { A: 40, B: 90 },
+    })
+    if (r.status !== 'ok') throw new Error('expected ok')
+    const expected = r.weights.A * 40 + r.weights.B * 90
+    expect(r.portfolioRiskScore).toBeCloseTo(expected, 9)
+  })
+
+  it('is omitted when no scores are supplied', () => {
+    const r = optimize({
+      protocols: ['A', 'B'],
+      expectedReturns: [0.1, 0.06],
+      covariance: [
+        [0.0009, 0],
+        [0, 0.0001],
+      ],
+      riskTolerance: 5,
+    })
+    if (r.status !== 'ok') throw new Error('expected ok')
+    expect(r.portfolioRiskScore).toBeUndefined()
+  })
+})
+
+describe('toPercentageAllocations', () => {
+  it('sums to 100 within the +/-0.01 tolerance the publish validator enforces', () => {
+    const rng = makeRng(4242)
+    for (let trial = 0; trial < 300; trial++) {
+      const n = 2 + Math.floor(rng() * 8)
+      const raw = Array.from({ length: n }, () => rng())
+      const total = raw.reduce((s, v) => s + v, 0)
+      const weights = Object.fromEntries(
+        raw.map((v, i) => [`P${String(i)}`, v / total])
+      )
+
+      const pct = toPercentageAllocations(weights)
+      const sum = Object.values(pct).reduce((s, v) => s + v, 0)
+      expect(Math.abs(sum - 100)).toBeLessThanOrEqual(0.01)
+    }
+  })
+
+  it('rounds to two decimals', () => {
+    const pct = toPercentageAllocations({ A: 1 / 3, B: 1 / 3, C: 1 / 3 })
+    for (const v of Object.values(pct)) {
+      expect(Number.isInteger(Math.round(v * 100))).toBe(true)
+      expect(v).toBeCloseTo(Math.round(v * 100) / 100, 10)
+    }
+  })
+
+  it('drops dust rather than emitting 0-weight protocols', () => {
+    // 1e-6 rounds to 0.00% at two decimals, so emitting it would put a
+    // zero-weight protocol into targetAllocations for the agent to rank.
+    const pct = toPercentageAllocations({ A: 0.999999, B: 0.000001 })
+    expect(pct.B).toBeUndefined()
+    expect(pct.A).toBe(100)
+  })
+
+  it('keeps a weight that is still representable at two decimals', () => {
+    // 0.0001 is 0.01% — small, but exactly representable and not dust.
+    const pct = toPercentageAllocations({ A: 0.9999, B: 0.0001 })
+    expect(pct.B).toBe(0.01)
+    expect(Object.values(pct).reduce((s, v) => s + v, 0)).toBeCloseTo(100, 10)
+  })
+
+  it('returns an empty map for an empty input', () => {
+    expect(toPercentageAllocations({})).toEqual({})
+  })
+})

--- a/tests/unit/analytics/service.test.ts
+++ b/tests/unit/analytics/service.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Allocation-suggestion service unit tests (#322).
+ *
+ * Prisma is mocked wholesale (the repo's unit-test convention) so the precedence
+ * rules — which decide what advice someone gets about their money — are tested
+ * in isolation from the database.
+ *
+ * The rules under test are deliberately NOT unified in the implementation: a
+ * follow may only TIGHTEN a risk ceiling (Math.max), while an active goal
+ * OVERRIDES it outright (??). Both mirror the agent exactly; a suggestion
+ * computed under a third rule would be advice about a portfolio the agent will
+ * never build.
+ */
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logBackgroundJob: jest.fn(),
+}))
+
+import db from '../../../src/db'
+import {
+  ADVISORY_DISCLAIMER,
+  BACKTEST_CAVEAT,
+  SuggestionUserNotFoundError,
+  computeInputHash,
+  resolveEffectiveInputs,
+  suggestAllocation,
+} from '../../../src/analytics/service'
+
+const mockDb = db as any
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = new Date('2026-08-17T00:00:00Z')
+const USER_ID = '11111111-1111-4111-8111-111111111111'
+
+function rateRows(spec: Record<string, number>, days = 90) {
+  const rows: any[] = []
+  for (let d = 0; d < days; d++) {
+    const fetchedAt = new Date(NOW.getTime() - (days - 1 - d) * DAY)
+    for (const [protocolName, base] of Object.entries(spec)) {
+      rows.push({
+        protocolName,
+        assetSymbol: 'USDC',
+        // Deterministic oscillation so Sigma is non-degenerate and each
+        // protocol has a distinct phase.
+        supplyApy: base + Math.sin((d + protocolName.length) / 6),
+        fetchedAt,
+      })
+    }
+  }
+  return rows
+}
+
+function setupDb(
+  overrides: {
+    user?: any
+    follow?: any
+    goal?: any
+    rates?: any[]
+    scores?: any[]
+    positions?: any[]
+  } = {}
+) {
+  mockDb.user = {
+    findUnique: jest.fn().mockResolvedValue(
+      overrides.user === null
+        ? null
+        : (overrides.user ?? {
+            id: USER_ID,
+            riskTolerance: 5,
+            strategyConfig: null,
+          })
+    ),
+  }
+  mockDb.strategyFollow = {
+    findFirst: jest.fn().mockResolvedValue(overrides.follow ?? null),
+  }
+  mockDb.savingsGoal = {
+    findFirst: jest.fn().mockResolvedValue(overrides.goal ?? null),
+  }
+  mockDb.protocolRate = {
+    findMany: jest
+      .fn()
+      .mockResolvedValue(
+        overrides.rates ?? rateRows({ Blend: 11, Luma: 8, Nova: 6 })
+      ),
+  }
+  mockDb.protocolRiskScore = {
+    findMany: jest.fn().mockResolvedValue(
+      overrides.scores ?? [
+        { protocolName: 'Blend', score: 72, insufficientHistory: false },
+        { protocolName: 'Luma', score: 61, insufficientHistory: false },
+        { protocolName: 'Nova', score: 88, insufficientHistory: false },
+      ]
+    ),
+  }
+  mockDb.position = {
+    findMany: jest.fn().mockResolvedValue(overrides.positions ?? []),
+  }
+  mockDb.allocationSuggestion = {
+    create: jest.fn().mockResolvedValue({ id: 'suggestion-1' }),
+  }
+}
+
+describe('resolveEffectiveInputs — risk ceiling precedence', () => {
+  it('with no follow and no goal, uses the user own ceiling', () => {
+    const r = resolveEffectiveInputs(5, { riskCeiling: 60 }, null, null)
+    expect(r.effectiveRiskCeiling).toBe(60)
+    expect(r.ceilingSource).toBe('own')
+  })
+
+  it('a follow may only TIGHTEN — stricter (higher) ceiling wins', () => {
+    const r = resolveEffectiveInputs(
+      5,
+      { riskCeiling: 50 },
+      { riskCeiling: 80 },
+      null
+    )
+    expect(r.effectiveRiskCeiling).toBe(80)
+    expect(r.ceilingSource).toBe('follow')
+  })
+
+  it('a follow can never LOOSEN a tighter own ceiling', () => {
+    // The whole point: clicking "follow" must not widen risk exposure.
+    const r = resolveEffectiveInputs(
+      5,
+      { riskCeiling: 90 },
+      { riskCeiling: 30 },
+      null
+    )
+    expect(r.effectiveRiskCeiling).toBe(90)
+  })
+
+  it('an active goal OVERRIDES outright, even to loosen', () => {
+    const r = resolveEffectiveInputs(
+      5,
+      { riskCeiling: 90 },
+      { riskCeiling: 80 },
+      40
+    )
+    expect(r.effectiveRiskCeiling).toBe(40)
+    expect(r.ceilingSource).toBe('goal')
+  })
+
+  it('is undefined when nothing sets a ceiling', () => {
+    const r = resolveEffectiveInputs(5, null, null, null)
+    expect(r.effectiveRiskCeiling).toBeUndefined()
+    expect(r.ceilingSource).toBe('none')
+  })
+
+  it('a followed strategy replaces allocations wholesale, not key-by-key', () => {
+    const r = resolveEffectiveInputs(
+      5,
+      { targetAllocations: { Own: 100 } },
+      { strategyName: 'TARGET_ALLOCATION', targetAllocations: { Copied: 100 } },
+      null
+    )
+    expect(r.currentAllocations).toEqual({ Copied: 100 })
+  })
+
+  it('tolerates a malformed strategyConfig Json column', () => {
+    // The column has no DB-level shape guarantee.
+    const r = resolveEffectiveInputs(5, 'not-an-object', null, null)
+    expect(r.currentAllocations).toBeUndefined()
+    expect(r.effectiveRiskCeiling).toBeUndefined()
+  })
+})
+
+describe('computeInputHash', () => {
+  const base = {
+    protocols: ['A', 'B'],
+    expectedReturns: [0.08, 0.05],
+    covariance: [
+      [0.0004, 0.0001],
+      [0.0001, 0.0002],
+    ],
+    riskTolerance: 5,
+    effectiveRiskCeiling: 60,
+    lookbackDays: 90,
+  }
+
+  it('is stable for identical inputs', () => {
+    expect(computeInputHash(base)).toBe(computeInputHash(base))
+  })
+
+  it('carries the sha256: prefix convention', () => {
+    expect(computeInputHash(base)).toMatch(/^sha256:[0-9a-f]{64}$/)
+  })
+
+  it('changes when riskTolerance changes', () => {
+    expect(computeInputHash({ ...base, riskTolerance: 6 })).not.toBe(
+      computeInputHash(base)
+    )
+  })
+
+  it('changes when the effective ceiling changes', () => {
+    expect(computeInputHash({ ...base, effectiveRiskCeiling: 70 })).not.toBe(
+      computeInputHash(base)
+    )
+  })
+
+  it('changes when the universe changes', () => {
+    expect(
+      computeInputHash({
+        ...base,
+        protocols: ['A', 'C'],
+      })
+    ).not.toBe(computeInputHash(base))
+  })
+
+  it('is insensitive to float noise far below what moves a weight', () => {
+    // 1e-15 on an expected return cannot change a 2dp weight, and a hash that
+    // flipped on it would make "did my recommendation change?" unanswerable.
+    expect(
+      computeInputHash({
+        ...base,
+        expectedReturns: [0.08 + 1e-15, 0.05],
+      })
+    ).toBe(computeInputHash(base))
+  })
+
+  it('distinguishes a no-ceiling input from a ceiling of 0', () => {
+    expect(
+      computeInputHash({ ...base, effectiveRiskCeiling: undefined })
+    ).not.toBe(computeInputHash({ ...base, effectiveRiskCeiling: 0 }))
+  })
+})
+
+describe('suggestAllocation', () => {
+  beforeEach(() => setupDb())
+
+  it('throws SuggestionUserNotFoundError for an unknown user', async () => {
+    setupDb({ user: null })
+    await expect(suggestAllocation(USER_ID, { now: NOW })).rejects.toThrow(
+      SuggestionUserNotFoundError
+    )
+  })
+
+  it('returns an advisory result with weights summing to 100', async () => {
+    const r = await suggestAllocation(USER_ID, { now: NOW })
+
+    expect(r.status).toBe('ok')
+    expect(r.isSuggestion).toBe(true)
+    expect(r.disclaimer).toBe(ADVISORY_DISCLAIMER)
+
+    const sum = Object.values(r.weights).reduce((s, v) => s + v, 0)
+    expect(Math.abs(sum - 100)).toBeLessThanOrEqual(0.01)
+  })
+
+  it('NEVER writes to the user record', async () => {
+    await suggestAllocation(USER_ID, { now: NOW })
+    // The mock has no update method at all; assert nothing tried to add one.
+    expect((mockDb.user as any).update).toBeUndefined()
+    expect((mockDb.user as any).upsert).toBeUndefined()
+  })
+
+  it('persists exactly one AllocationSuggestion row', async () => {
+    const r = await suggestAllocation(USER_ID, { now: NOW })
+    expect(mockDb.allocationSuggestion.create).toHaveBeenCalledTimes(1)
+
+    const arg = mockDb.allocationSuggestion.create.mock.calls[0][0]
+    expect(arg.data.userId).toBe(USER_ID)
+    expect(arg.data.inputHash).toBe(r.inputHash)
+    expect(arg.data.status).toBe('ok')
+    expect(r.id).toBe('suggestion-1')
+  })
+
+  it('skips persistence when asked to', async () => {
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+    expect(mockDb.allocationSuggestion.create).not.toHaveBeenCalled()
+    expect(r.id).toBeUndefined()
+  })
+
+  it('is deterministic — same inputs give the same hash and weights', async () => {
+    const a = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+    const b = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+    expect(b.inputHash).toBe(a.inputHash)
+    expect(b.weights).toEqual(a.weights)
+  })
+
+  it('applies a followed strategy tighter ceiling to the universe', async () => {
+    setupDb({
+      user: { id: USER_ID, riskTolerance: 5, strategyConfig: null },
+      follow: { appliedConfig: { riskCeiling: 85 } },
+    })
+
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+
+    expect(r.effectiveRiskCeiling).toBe(85)
+    // Only Nova (88) clears an 85 ceiling, so the universe is too small.
+    expect(r.status).toBe('insufficient_universe')
+    expect(
+      r.excluded
+        .filter((e) => e.reason === 'risk_ceiling')
+        .map((e) => e.protocol)
+    ).toEqual(expect.arrayContaining(['Blend', 'Luma']))
+  })
+
+  it('an active goal ceiling overrides the followed one', async () => {
+    setupDb({
+      user: { id: USER_ID, riskTolerance: 5, strategyConfig: null },
+      follow: { appliedConfig: { riskCeiling: 85 } },
+      goal: { riskCeiling: 60 },
+    })
+
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+
+    expect(r.effectiveRiskCeiling).toBe(60)
+    expect(r.ceilingSource).toBe('goal')
+    expect(r.status).toBe('ok')
+  })
+
+  it('reports a too-tight ceiling as insufficient_universe naming riskCeiling', async () => {
+    setupDb({
+      user: {
+        id: USER_ID,
+        riskTolerance: 5,
+        strategyConfig: { riskCeiling: 99 },
+      },
+    })
+
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+
+    expect(r.status).toBe('insufficient_universe')
+    if (r.outcome.status !== 'insufficient_universe') throw new Error('shape')
+    expect(r.outcome.bindingConstraint).toBe('riskCeiling')
+    expect(r.weights).toEqual({})
+  })
+
+  it('returns insufficient_universe when history is too short', async () => {
+    setupDb({ rates: rateRows({ Blend: 11, Luma: 8 }, 5) })
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+    expect(r.status).toBe('insufficient_universe')
+    expect(
+      r.excluded.some((e) => e.reason === 'insufficient_aligned_history')
+    ).toBe(true)
+  })
+})
+
+describe('suggestAllocation — backtest comparison', () => {
+  it('returns only the suggested leg when the user has no allocation', async () => {
+    setupDb()
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+
+    expect(r.backtest).not.toBeNull()
+    expect(r.backtest?.suggested).toBeDefined()
+    expect(r.backtest?.current).toBeNull()
+    expect(r.backtest?.caveat).toBe(BACKTEST_CAVEAT)
+  })
+
+  it('returns both legs when the user has a current allocation', async () => {
+    setupDb({
+      user: {
+        id: USER_ID,
+        riskTolerance: 5,
+        strategyConfig: { targetAllocations: { Blend: 50, Luma: 50 } },
+      },
+    })
+
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+
+    expect(r.backtest?.suggested).toBeDefined()
+    expect(r.backtest?.current).not.toBeNull()
+    expect(r.currentAllocations).toEqual({ Blend: 50, Luma: 50 })
+  })
+
+  it('anchors the notional to the user active position value', async () => {
+    setupDb({ positions: [{ currentValue: 2500 }, { currentValue: 1500 }] })
+    const r = await suggestAllocation(USER_ID, { now: NOW, persist: false })
+    expect(r.backtest?.startingAmount).toBe(4000)
+  })
+
+  it('is skipped entirely when runBacktest is false', async () => {
+    setupDb()
+    const r = await suggestAllocation(USER_ID, {
+      now: NOW,
+      persist: false,
+      runBacktest: false,
+    })
+    expect(r.backtest).toBeNull()
+    // The job path must not pay for two historical replays per user.
+    expect(mockDb.position.findMany).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/analytics/structural.test.ts
+++ b/tests/unit/analytics/structural.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Structural guarantees for src/analytics/ (#322).
+ *
+ * THIS IS THE ACCEPTANCE CRITERION, not a style check. The whole safety story of
+ * the optimization feature is that a suggestion is ADVISORY: it can be computed,
+ * stored and displayed, and it structurally cannot move funds or silently
+ * rewrite the configuration the agent acts on. A comment saying so is worth
+ * nothing the first time someone adds a convenient `db.user.update`.
+ *
+ * The import assertions use the stricter specifier-parsing form from
+ * tests/integration/agent/strategy-follow.integration.test.ts rather than a bare
+ * substring scan, and assert `imports.length > 0` so a regex that silently
+ * stops matching cannot let the test pass vacuously.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const ANALYTICS_DIR = path.join(__dirname, '../../../src/analytics')
+
+const FILES = ['types.ts', 'optimizer.ts', 'estimation.ts', 'service.ts']
+
+function read(file: string): string {
+  return fs.readFileSync(path.join(ANALYTICS_DIR, file), 'utf8')
+}
+
+function importsOf(source: string): string[] {
+  return Array.from(source.matchAll(/from\s+['"]([^'"]+)['"]/g), (m) => m[1])
+}
+
+/**
+ * Strip block and line comments before scanning for forbidden CODE.
+ *
+ * These files document the very invariants asserted below, so their headers
+ * legitimately contain the strings the assertions forbid — the first version of
+ * this test failed on service.ts's own comment explaining that it must never
+ * call `user.update`. Scanning prose would either force the docs to be vague
+ * about what is banned, or force the test to be lenient. Stripping comments
+ * keeps both precise.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+describe('src/analytics/ — custody boundary', () => {
+  it('every analytics file exists', () => {
+    for (const file of FILES) {
+      expect(fs.existsSync(path.join(ANALYTICS_DIR, file))).toBe(true)
+    }
+  })
+
+  it.each(FILES)(
+    '%s imports nothing from src/stellar/ and no wallet',
+    (file) => {
+      const source = read(file)
+      const imports = importsOf(source)
+
+      // Guards against a regex that stopped matching: a file with zero parsed
+      // imports would pass every filter below for the wrong reason. types.ts is
+      // the one file that legitimately has none.
+      if (file !== 'types.ts') {
+        expect(imports.length).toBeGreaterThan(0)
+      }
+
+      expect(imports.filter((i) => i.includes('stellar'))).toEqual([])
+      expect(imports.filter((i) => i.includes('wallet'))).toEqual([])
+    }
+  )
+
+  it.each(['types.ts', 'optimizer.ts', 'estimation.ts'])(
+    '%s is pure — no database import at all',
+    (file) => {
+      const imports = importsOf(read(file))
+      expect(imports.filter((i) => /\/db$|\/db\//.test(i))).toEqual([])
+    }
+  )
+
+  it('optimizer.ts and estimation.ts contain no Prisma model access', () => {
+    for (const file of ['optimizer.ts', 'estimation.ts']) {
+      const source = read(file)
+      expect(source).not.toMatch(/\bdb\.\w+\./)
+      expect(source).not.toMatch(/prisma/i)
+    }
+  })
+})
+
+describe('src/analytics/service.ts — the advisory invariant', () => {
+  const source = stripComments(read('service.ts'))
+
+  it('never writes to the User model', () => {
+    // db.user.update / updateMany / upsert / delete — any of these could change
+    // what the agent does on its next tick.
+    expect(source).not.toMatch(/user\s*\.\s*(update|upsert|delete|create)/i)
+  })
+
+  it('never mentions strategyConfig as an assignment target', () => {
+    // Reading User.strategyConfig is required (it is an optimizer input);
+    // WRITING it is what must never happen. A `select` is a read.
+    const writeShapes = [
+      /strategyConfig\s*:/, // object literal in a `data:` payload
+      /rebalanceStrategy\s*:/,
+    ]
+    // The only permitted occurrence is inside a `select:` clause, so strip
+    // those before asserting.
+    const withoutSelects = source.replace(
+      /select:\s*\{[^}]*\}/g,
+      'select:{STRIPPED}'
+    )
+    for (const shape of writeShapes) {
+      expect(withoutSelects).not.toMatch(shape)
+    }
+  })
+
+  it('the only model it creates rows in is allocationSuggestion', () => {
+    const creates = Array.from(
+      source.matchAll(/db\.(\w+)\.(create|update|upsert|delete)\w*/g),
+      (m) => `${m[1]}.${m[2]}`
+    )
+    expect(creates).toEqual(['allocationSuggestion.create'])
+  })
+
+  it('reads only the models an optimizer input needs', () => {
+    const reads = Array.from(
+      source.matchAll(/db\.(\w+)\./g),
+      (m) => m[1]
+    ).filter((v, i, a) => a.indexOf(v) === i)
+
+    expect(reads.sort()).toEqual(
+      [
+        'allocationSuggestion',
+        'position',
+        'protocolRate',
+        'protocolRiskScore',
+        'savingsGoal',
+        'strategyFollow',
+        'user',
+      ].sort()
+    )
+  })
+})
+
+describe('src/jobs/allocationSuggestions.ts — the advisory invariant holds on the timer too', () => {
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../../../src/jobs/allocationSuggestions.ts'),
+    'utf8'
+  )
+  const source = stripComments(raw)
+
+  it('imports nothing from src/stellar/ and no wallet', () => {
+    const imports = importsOf(raw)
+    expect(imports.length).toBeGreaterThan(0)
+    expect(imports.filter((i) => i.includes('stellar'))).toEqual([])
+    expect(imports.filter((i) => i.includes('wallet'))).toEqual([])
+  })
+
+  it('never writes to the User model', () => {
+    // A precompute job that rewrote strategy configs on a 6-hour timer would be
+    // an autonomous trading system, not an analytics job.
+    expect(source).not.toMatch(/user\s*\.\s*(update|upsert|delete|create)/i)
+    expect(source).not.toMatch(/strategyConfig\s*:/)
+  })
+})

--- a/tests/unit/jobs/allocationSuggestions.test.ts
+++ b/tests/unit/jobs/allocationSuggestions.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Allocation-suggestion job unit tests (#322).
+ *
+ * The two properties that matter for a background job of this shape:
+ *   1. It runs inside a correlation-ID scope, so its logs are traceable.
+ *   2. ONE user's failure does not abort the batch. Without that, a single
+ *      corrupt strategyConfig silently deprives every user after it in the list
+ *      of a refreshed suggestion — and nothing would look broken.
+ */
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/analytics/service', () => ({
+  suggestAllocation: jest.fn(),
+}))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logBackgroundJob: jest.fn(),
+}))
+jest.mock('../../../src/utils/metrics', () => ({
+  recordBackgroundJob: jest.fn(),
+}))
+jest.mock('../../../src/utils/job-metrics', () => ({
+  recordJobSuccess: jest.fn(),
+  recordJobFailure: jest.fn(),
+}))
+
+import db from '../../../src/db'
+import { logBackgroundJob } from '../../../src/utils/logger'
+import {
+  recordJobSuccess,
+  recordJobFailure,
+} from '../../../src/utils/job-metrics'
+import { suggestAllocation } from '../../../src/analytics/service'
+import { getCorrelationId } from '../../../src/utils/correlation'
+import { computeAllocationSuggestions } from '../../../src/jobs/allocationSuggestions'
+
+const mockDb = db as any
+const mockSuggest = suggestAllocation as jest.Mock
+const NOW = new Date('2026-08-17T00:00:00Z')
+
+beforeEach(() => {
+  mockDb.position = { findMany: jest.fn().mockResolvedValue([]) }
+  mockSuggest.mockReset()
+  mockSuggest.mockResolvedValue({ status: 'ok' })
+})
+
+describe('computeAllocationSuggestions', () => {
+  it('only considers users with an ACTIVE position', async () => {
+    await computeAllocationSuggestions(NOW)
+
+    const where = mockDb.position.findMany.mock.calls[0][0]
+    expect(where.where).toEqual({ status: 'ACTIVE' })
+    expect(where.distinct).toEqual(['userId'])
+  })
+
+  it('computes a suggestion for each invested user', async () => {
+    mockDb.position.findMany.mockResolvedValue([
+      { userId: 'u1' },
+      { userId: 'u2' },
+      { userId: 'u3' },
+    ])
+
+    await computeAllocationSuggestions(NOW)
+
+    expect(mockSuggest).toHaveBeenCalledTimes(3)
+    expect(mockSuggest.mock.calls.map((c) => c[0])).toEqual(['u1', 'u2', 'u3'])
+  })
+
+  it('persists but skips the expensive backtest legs', async () => {
+    mockDb.position.findMany.mockResolvedValue([{ userId: 'u1' }])
+
+    await computeAllocationSuggestions(NOW)
+
+    expect(mockSuggest).toHaveBeenCalledWith('u1', {
+      now: NOW,
+      persist: true,
+      runBacktest: false,
+    })
+  })
+
+  it('runs inside a correlation-ID scope', async () => {
+    mockDb.position.findMany.mockResolvedValue([{ userId: 'u1' }])
+    let seen: string | undefined
+    mockSuggest.mockImplementation(async () => {
+      seen = getCorrelationId()
+      return { status: 'ok' }
+    })
+
+    await computeAllocationSuggestions(NOW)
+
+    expect(seen).toBeDefined()
+    expect(typeof seen).toBe('string')
+  })
+
+  it('one user failure does not abort the batch', async () => {
+    mockDb.position.findMany.mockResolvedValue([
+      { userId: 'u1' },
+      { userId: 'boom' },
+      { userId: 'u3' },
+    ])
+    mockSuggest.mockImplementation(async (userId: string) => {
+      if (userId === 'boom') throw new Error('corrupt strategyConfig')
+      return { status: 'ok' }
+    })
+
+    await computeAllocationSuggestions(NOW)
+
+    // u3 must still have been attempted after boom threw.
+    expect(mockSuggest.mock.calls.map((c) => c[0])).toEqual([
+      'u1',
+      'boom',
+      'u3',
+    ])
+
+    const [name, status, , , details] = (logBackgroundJob as jest.Mock).mock
+      .calls[0]
+    expect(name).toBe('allocation_suggestions')
+    expect(status).toBe('success')
+    expect(details).toMatchObject({ computed: 2, failed: 1 })
+  })
+
+  it('records job success with the standard metrics quartet', async () => {
+    mockDb.position.findMany.mockResolvedValue([{ userId: 'u1' }])
+
+    await computeAllocationSuggestions(NOW)
+
+    expect(recordJobSuccess).toHaveBeenCalledWith(
+      'allocation_suggestions',
+      expect.any(Number)
+    )
+    expect(recordJobFailure).not.toHaveBeenCalled()
+  })
+
+  it('never rethrows — a job-level failure is logged as failed', async () => {
+    mockDb.position.findMany.mockRejectedValue(new Error('db is down'))
+
+    await expect(computeAllocationSuggestions(NOW)).resolves.toBeUndefined()
+
+    expect(recordJobFailure).toHaveBeenCalledWith(
+      'allocation_suggestions',
+      expect.any(Number)
+    )
+    const [name, status] = (logBackgroundJob as jest.Mock).mock.calls[0]
+    expect(name).toBe('allocation_suggestions')
+    expect(status).toBe('failed')
+  })
+
+  it('handles an empty user set without error', async () => {
+    await expect(computeAllocationSuggestions(NOW)).resolves.toBeUndefined()
+    expect(mockSuggest).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/utils/concurrency.test.ts
+++ b/tests/unit/utils/concurrency.test.ts
@@ -1,0 +1,127 @@
+/**
+ * In-flight concurrency limiter unit tests (#322).
+ *
+ * The failure mode this guards against is a LEAKED SLOT: if a release is missed
+ * or double-counted, a user is permanently locked out of the optimizer for the
+ * process lifetime, and no error is logged anywhere. Several tests below exist
+ * purely to pin that down.
+ */
+
+import {
+  ConcurrencyLimiter,
+  isAcquireFailure,
+} from '../../../src/utils/concurrency'
+
+describe('ConcurrencyLimiter', () => {
+  it('grants a slot when nothing is in flight', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 2, perKeyLimit: 1 })
+    const slot = limiter.tryAcquire('u1')
+    expect(isAcquireFailure(slot)).toBe(false)
+    expect(limiter.inFlight).toBe(1)
+  })
+
+  it('refuses a second slot for the same key and blames the key', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 5, perKeyLimit: 1 })
+    limiter.tryAcquire('u1')
+    const second = limiter.tryAcquire('u1')
+
+    expect(isAcquireFailure(second)).toBe(true)
+    if (!isAcquireFailure(second)) return
+    expect(second.scope).toBe('key')
+  })
+
+  it('lets a different key through while one key is saturated', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 5, perKeyLimit: 1 })
+    limiter.tryAcquire('u1')
+    expect(isAcquireFailure(limiter.tryAcquire('u2'))).toBe(false)
+  })
+
+  it('refuses once the global budget is exhausted and blames global', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 2, perKeyLimit: 1 })
+    limiter.tryAcquire('u1')
+    limiter.tryAcquire('u2')
+    const third = limiter.tryAcquire('u3')
+
+    expect(isAcquireFailure(third)).toBe(true)
+    if (!isAcquireFailure(third)) return
+    expect(third.scope).toBe('global')
+  })
+
+  it('reports the per-key bound first, since the two mean different things', () => {
+    // A user hammering the endpoint must not be reported as global saturation.
+    const limiter = new ConcurrencyLimiter({ globalLimit: 1, perKeyLimit: 1 })
+    limiter.tryAcquire('u1')
+    const again = limiter.tryAcquire('u1')
+
+    expect(isAcquireFailure(again)).toBe(true)
+    if (!isAcquireFailure(again)) return
+    expect(again.scope).toBe('key')
+  })
+
+  it('frees the slot on release', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 1, perKeyLimit: 1 })
+    const slot = limiter.tryAcquire('u1')
+    if (isAcquireFailure(slot)) throw new Error('expected a slot')
+
+    slot.release()
+
+    expect(limiter.inFlight).toBe(0)
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(false)
+  })
+
+  it('release is idempotent — a double free cannot inflate the budget', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 2, perKeyLimit: 1 })
+    const a = limiter.tryAcquire('u1')
+    const b = limiter.tryAcquire('u2')
+    if (isAcquireFailure(a) || isAcquireFailure(b)) throw new Error('slots')
+
+    a.release()
+    a.release()
+    a.release()
+
+    expect(limiter.inFlight).toBe(1)
+    b.release()
+    expect(limiter.inFlight).toBe(0)
+  })
+
+  it('does not leak per-key entries after release', () => {
+    // The map is keyed by userId; leaving 0-count entries behind would grow it
+    // without bound for the process lifetime.
+    const limiter = new ConcurrencyLimiter({ globalLimit: 10, perKeyLimit: 1 })
+    for (let i = 0; i < 100; i++) {
+      const slot = limiter.tryAcquire(`user-${String(i)}`)
+      if (isAcquireFailure(slot)) throw new Error('expected a slot')
+      slot.release()
+    }
+    expect(limiter.activeKeys).toBe(0)
+    expect(limiter.inFlight).toBe(0)
+  })
+
+  it('supports a per-key limit above 1', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 10, perKeyLimit: 3 })
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(false)
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(false)
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(false)
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(true)
+  })
+
+  it('floors nonsensical limits at 1 rather than deadlocking', () => {
+    // A misconfigured env var of 0 would otherwise reject every request forever.
+    const limiter = new ConcurrencyLimiter({ globalLimit: 0, perKeyLimit: 0 })
+    expect(isAcquireFailure(limiter.tryAcquire('u1'))).toBe(false)
+  })
+
+  it('recovers full capacity after a full acquire/release cycle', () => {
+    const limiter = new ConcurrencyLimiter({ globalLimit: 2, perKeyLimit: 1 })
+    const a = limiter.tryAcquire('u1')
+    const b = limiter.tryAcquire('u2')
+    if (isAcquireFailure(a) || isAcquireFailure(b)) throw new Error('slots')
+    expect(isAcquireFailure(limiter.tryAcquire('u3'))).toBe(true)
+
+    a.release()
+    b.release()
+
+    expect(isAcquireFailure(limiter.tryAcquire('u3'))).toBe(false)
+    expect(isAcquireFailure(limiter.tryAcquire('u4'))).toBe(false)
+  })
+})


### PR DESCRIPTION
# Closes #322 

## feat: Portfolio Optimization & Optimal Allocation Suggestion Engine ([#322](#))

### Summary

Adds an engine that computes an optimal portfolio allocation from historical protocol APY data, per-protocol risk scores, and the user's risk tolerance — returned with an efficient frontier and a backtest of its simulated consequences, as a one-tap suggestion. The suggestion is advisory: it is persisted and audited, but it is structurally incapable of mutating `User.strategyConfig`.

> **Context reviewers need first:** the platform already consumed allocations but never produced one. `User.strategyConfig.targetAllocations` existed and the rebalancing agent worked toward it, but every `{ "Blend": 50, "Stellar DEX": 30, "Luma": 20 }` in the repo was a hand-written guess. There was no answer to *"given my risk tolerance, what should my allocation be?"*
>
> Three findings shaped the design, and reviewers should know them before reading the diff:
> - **The agent has no multi-protocol position model.** `Position.protocolName` is a single string, `StrategyDecision.targetProtocol` is a single string, and `TargetAllocationStrategy` (`strategies.ts:162`) uses weights only to *rank a single hop* — it never holds several protocols at once. A weight vector is therefore genuinely advisory input to the existing engine, not a new execution mode. The backtest is framed accordingly and honestly (see *Response Contract*).
> - **The plan's specified objective was mathematically degenerate.** Under `Σ = cov(apy/100/365.25) × 365.25` with `λ ∈ [1,25]`, the risk term sits 5–6 orders of magnitude below the return term. `(λ/2)wᵀΣw` can never offset `μᵀw` at any λ in that range, so the optimum is *always* the max-return corner and the efficient frontier collapses to a single point. Implementing it as written would have shipped a feature that always answers "100% into the highest-APY protocol."
> - **`ProtocolRiskScore` was never being refreshed.** `src/jobs/protocolRiskScoring.ts` existed but was never imported or started. Because risk-ceiling filtering is fail-closed, a stale table silently disables every ceiling-constrained rebalance, not just this feature.
>
> This PR is greenfield in `src/analytics/`, but it necessarily corrects the objective's units and wires up a job that was dead on `main`.

---

### Changes Made

#### New Module — `src/analytics/optimizer.ts` *(new, 812 lines)*

- Mean-variance solver: `maximize μᵀw − (λ/2)·wᵀΣw` subject to `Σw = 1`, `lo_i ≤ w_i ≤ hi_i`, and an optional stable-group floor `Σ_{i∈S} w_i ≥ f`
- **Exact** Euclidean projection onto the capped simplex — `w_i(θ) = clamp(v_i − θ, lo_i, hi_i)` is monotone in θ, so bisection converges to machine precision with no tolerance to tune
- **Exact** projection onto the floor constraint via a disjoint-group split, *not* the planned Dykstra alternating projections *(see Design Decisions)*
- Accelerated projected gradient (FISTA + adaptive restart) with a Gershgorin step bound
- Log-spaced λ mapping over `[5, 500]`; efficient-frontier sweep, default 12 points, hard max 25
- Up-front feasibility check that names the binding constraint before any solving
- `toPercentageAllocations` — the single fraction→percent boundary for the whole package
- Zero I/O, zero randomness, no new dependency

#### New Module — `src/analytics/estimation.ts` *(new, 316 lines)*

- Builds μ and Σ from gappy `ProtocolRate` history
- Daily aggregation to one value per `(protocol, UTC day)` — `ProtocolRate` is keyed by `(protocolName, assetSymbol, network, fetchedAt)`, so without this the series would depend on scan ordering
- Index alignment via the existing `buildDailyRateSeries`, then keeping only days on which *every* admitted protocol has a value
- Sample covariance, n−1 convention, symmetric **by construction** (the `(j,i)` entry is assigned from the `(i,j)` computation, so float associativity cannot produce a matrix that fails a PSD assertion at the 1e-18 level)
- Fail-closed universe eligibility with machine-readable exclusion reasons
- Deliberately does **not** use `periodReturns` *(see Design Decisions)*

#### New Module — `src/analytics/service.ts` *(new, 497 lines)*

- `suggestAllocation(userId)`: effective-ceiling resolution → estimation → optimization → backtest → persistence
- Mirrors the agent's **two deliberately different** ceiling merge rules verbatim
- Canonical `sha256:`-prefixed input-snapshot hash, numbers fixed to 9 dp
- Backtest harness running suggested vs. current config over identical history
- The only module in the package that touches the database

#### New Module — `src/analytics/types.ts` *(new, 248 lines)*

Shared types and the units contract for the package. Zero imports — a pure type module.

#### New Module — `src/utils/concurrency.ts` *(new, 102 lines)*

`ConcurrencyLimiter` — per-key + global in-flight semaphore, non-blocking, idempotent release, no per-key map growth. The repo's first. Bounds a different thing from the rate limiter *(see Design Decisions)*.

#### New Job — `src/jobs/allocationSuggestions.ts` *(new, 137 lines)*

6-hour precompute over users with an ACTIVE `Position`. Standard observability quartet (`logBackgroundJob` + `recordBackgroundJob` + `recordJobSuccess`/`recordJobFailure`), correlation-ID scope, batched with serial await, per-user failure isolation, errors logged and never rethrown.

#### New Validators — `src/validators/allocation-validators.ts` *(new, 100 lines)*

Whole-request Zod schemas matching the file they mount in. `.strict()` on the body so a typo'd knob is a 400 rather than a confidently-wrong answer computed over the wrong window. Every numeric bound is also a CPU bound, expressed with the optimizer's own exported constants rather than duplicated magic numbers.

#### Migration — `prisma/migrations/20260817000000_add_allocation_suggestions/` *(new, 25 + 25 lines)*

`allocation_suggestions` table, two indexes (`userId, computedAt` and `userId, inputHash`), FK to `users` with `ON DELETE CASCADE`. Hand-written `rollback.sql` alongside, per the CI gate, documenting that this is advisory data only — no funds, keys, or agent behaviour depend on it.

#### Handlers — `src/routes/portfolio.ts` *(+133)*

- `POST /:userId/suggest-allocation` and `GET /:userId/suggestions`, both `requireAuth → enforceUserAccess → validate(...)`
- Registered **before** `GET /:userId`, following the `router.use('/goals', …)` precedent
- Module-level `ConcurrencyLimiter`; 429 with `Retry-After`; slot released in `finally` so a throw cannot permanently wedge a user out of the endpoint

#### Shared — `src/agent/strategyMetrics.ts` *(+11 / −4)*

Exports `mean` and `sampleStdev`, previously module-private, so estimation reuses them. That file declares itself the one definition of risk-adjusted return math in the codebase; a private copy in `src/analytics/` would have been the third.

#### Schema — `prisma/schema.prisma` *(+47 real)*

`AllocationSuggestion` model + `allocationSuggestions` relation on `User`. **The raw diff shows ±215 lines; `--ignore-all-space` shows 47 added / 0 removed** — the remainder is `prisma format` column reflow from running codegen, with no semantic change.

#### Config / Middleware / Startup / Formatters

- `src/config/env.ts` *(+37)* — `security.optimizerRateLimit` and `allocationSuggestions` blocks, all optional with defaults
- `src/middleware/rateLimiter.ts` *(+21)* — `optimizerRateLimiter` via the existing `buildRateLimiter` factory
- `src/index.ts` *(+26)* — registers the new job **and `scheduleProtocolRiskScoring`, which existed on `main` but was never started**; two module handles; two `gracefulShutdown` clear blocks
- `src/utils/api-formatters.ts` *(+27)* — `mapAllocationSuggestionToResponse`, hand-written allowlist, `userId` deliberately omitted, `isSuggestion: true` on every row

#### Tests — 7 new suites, **+161 tests** *(2,097 lines)*

`optimizer` 60 · `service` 28 · `estimation` 23 · `integration` 16 · `structural` 15 · `concurrency` 11 · `job` 8. One existing file touched: `tests/integration/rateLimiter.integration.test.ts` *(+3)* needed `optimizerRateLimit` in its config mock — every limiter is constructed at module load, so a missing block fails that suite at import, not at use.

#### Documentation

`docs/PORTFOLIO_OPTIMIZATION.md` *(new, 393 lines)*, `docs/openapi.yaml` *(+370: 2 paths, 8 schemas)*, `ASSUMPTIONS.md` *(+52: entries 12–18)*, `docs/DOCUMENTATION_INDEX.md` *(+1)*.

---

### Invariants

| | Invariant |
|--|-----------|
| **I1** | Nothing in `src/analytics/` or `src/jobs/allocationSuggestions.ts` writes `User.strategyConfig` or `User.rebalanceStrategy`. `allocationSuggestion.create` is the only write in the entire package |
| **I2** | Nothing in the package imports from `src/stellar/` or anything matching `wallet`. No suggestion path can touch custody |
| **I3** | Emitted weights sum to 100 within ±0.01 percentage points — precisely the tolerance `publishableConfigSchema.superRefine` already enforces, so a suggestion is directly acceptable by the existing update path with no re-conversion |
| **I4** | Every returned weight respects its `[lo, hi]` bound and any stable-group floor. Every solver iterate is a projection onto the feasible set, so even an abandoned run yields a constraint-satisfying vector |
| **I5** | A configured `riskCeiling` is fail-closed: a protocol with no known score is excluded, never given the benefit of the doubt. Mirrors `applyRiskCeiling` rather than reimplementing it |
| **I6** | A follow may only ever *tighten* a follower's risk ceiling (`Math.max`); an ACTIVE `SavingsGoal` overrides outright (`??`). Both mirror the agent exactly |
| **I7** | Identical inputs produce byte-identical output — protocols sorted by name with μ/Σ permuted to match, fixed feasible start, fixed budget, no randomness |
| **I8** | Equal `inputHash` implies equal weights, which is what makes *"did my recommendation change, or only my inputs?"* answerable |

**I1 and I2 are enforced by `tests/unit/analytics/structural.test.ts`**, which scans source text and fails on any `user.update`/`upsert`/`delete`/`create`, any `strategyConfig:` write outside a `select`, any forbidden import, and any Prisma model access outside a fixed allowlist. It uses the stricter specifier-parsing form from `strategy-follow.integration.test.ts` — asserting `imports.length > 0` — so a regex that silently stops matching cannot pass vacuously. Comments are stripped first, so the files can document exactly what is banned without tripping their own assertions.

---

### Failure Modes and Protections

| Failure Mode | Protection |
|-------------|-----------|
| Optimizer silently rewrites a user's live strategy | Structural source-scan test; `allocationSuggestion.create` is the only permitted write (I1) |
| A precompute job rewrites strategy configs on a 6-hour timer | Same structural test applied to the job file — otherwise this is an autonomous trading system wearing an analytics job's clothes |
| Solver returns a plausible vector that violates a constraint | 4-variant discriminated outcome union; every iterate is a feasible-set projection, so `non_converged` still carries a constraint-satisfying vector |
| Contradictory constraints | Up-front `checkFeasibility` naming the binding constraint, run *before* any solving |
| Risk ceiling too tight to form a portfolio | `insufficient_universe` with per-protocol exclusion reasons and `bindingConstraint: riskCeiling` — never a ceiling-violating vector |
| Misaligned covariance matrix (silent, looks well-formed) | Only days on which *every* admitted protocol has a value are kept; `periodReturns` deliberately avoided |
| Smoothed `YieldSnapshot.apy` understating volatility | Inputs derive from `ProtocolRate.supplyApy` only — the trap documented in `STRATEGY_MARKETPLACE.md` §2 |
| Cross-user access to suggestions | Routes keyed on `req.params.userId`, which is what keeps `enforceUserAccess` effective; a body-only or `/suggestions/:id` route would make it a silent no-op |
| CPU exhaustion by one user | `ConcurrencyLimiter` per-key bound of 1, non-blocking 429 |
| CPU exhaustion in aggregate | Global in-flight budget + `optimizerRateLimiter` (5/min) — the two bound different things |
| Concurrency slot leaked by a thrown handler | Released in `finally`; asserted by a test that a 404 is followed by a successful 200 |
| Unbounded query param translating into event-loop time | `.strict()` Zod body with bounds drawn from the optimizer's own constants; frontier hard-capped at 25 |
| Weights drift outside the ±0.01 sum tolerance | Rounding residual settled onto the single largest weight, ties broken by name; asserted over 300 seeded inputs |
| Stale `ProtocolRiskScore` silently disabling all ceiling-constrained rebalancing | `scheduleProtocolRiskScoring` wired up and started before the suggestion job |

---

### Response Contract *(clients need these)*

**`weights` are PERCENTAGES**, not fractions, and sum to 100 ± 0.01 — directly acceptable by the existing strategy update endpoint with no conversion. Everything else in the payload (`expectedReturn`, `expectedVolatility`, frontier `risk`/`return`) is a **decimal fraction**: `0.082` means 8.2 % APY, `0.014` means 1.4 percentage points of APY volatility.

**All four outcome statuses return HTTP 200.** "The optimizer ran and could not produce a portfolio" is a result, not a request error:

| `status` | Meaning |
|---|---|
| `ok` | Weights, expected return/volatility, λ, frontier, iterations, portfolio risk score |
| `infeasible` | Constraints contradict; `bindingConstraint` names which |
| `insufficient_universe` | Fewer than 2 eligible protocols, with per-protocol exclusion reasons |
| `non_converged` | Budget exhausted; carries the best **feasible** vector plus the residual |

**Two caveats ship inside the payload, not just in the docs**, because the chart would otherwise be misread:

- `backtest.caveat` — the agent holds **one protocol at a time**, so the comparison is *what the agent would have done under each configuration*. It is **not** a simulation of holding the weighted basket. `backtest.current` is `null` when the user has no allocation configured; an invented baseline would be worse than none.
- `disclaimer` — Σ measures **APY co-movement, not capital risk**. `ProtocolRate` is a yield-quote series, so the optimizer minimizes *yield volatility*; it does not model principal loss, depeg, or smart-contract failure. Those enter only through `ProtocolRiskScore` as a universe filter.

`ceilingSource` (`goal` | `follow` | `own` | `none`) reports which layer supplied the effective ceiling, so the resolution is visible rather than inferred.

---

### Breaking Changes

**None.** Both endpoints are new, no existing response shape changed, no existing column changed, and no dependency was added or removed.

The `AllocationSuggestion` table is additive with a nullable-safe `ON DELETE CASCADE` FK. The only non-additive change anywhere is `src/agent/strategyMetrics.ts` widening two functions from module-private to exported, which cannot break a caller.

---

### How Has This Been Tested?

```bash
npx prisma generate                       # required after the schema edit

npm run lint                              # CI-blocking
npm run format:check                      # CI-blocking
npm run build                             # CI-blocking
npm test                                  # CI-blocking
npm run typecheck                         # NOT run in CI — must be run locally

npx jest tests/unit/analytics             # solver + estimation + service + structural
npx jest tests/integration/allocation-suggestions.integration.test.ts

npm run validate:spec                     # redocly gate on docs/openapi.yaml
npx redocly bundle docs/openapi.yaml --output /tmp/o.yaml   # verify all $refs resolve
bash scripts/check-migration-rollback.sh  # rollback.sql presence gate
npm audit --audit-level=high              # CI security-audit job
npx license-checker --onlyAllow '...' --excludePrivatePackages
```

| Check | Result |
|-------|--------|
| `npm test` | **817 passed / 66 suites** (was 770 / 62) |
| New suites | **161 passed**, 0 failed |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run build` | clean |
| `npm run typecheck` | clean |
| `scripts/check-migration-rollback.sh` | pass *(this gate was **failing on `main`** before this branch)* |
| `redocly lint` | 0 errors, 16 warnings — all pre-existing categories |
| `redocly bundle` | all `$ref`s resolve |
| `npm audit --audit-level=high` | exit 0 |
| `license-checker` | exit 0 |
| Jest "worker failed to exit gracefully" warning | **pre-existing** — reproduced on a 55-suite run with every new test excluded |

**Acceptance criteria, mapped to tests:**

- `weights sum to 1 and respect every bound` / `sums to 100 within the ±0.01 tolerance` — property-style over a seeded mulberry32 generator, 10 seeds × 20 problems, plus 300 randomized percentage conversions
- `explicit min/max bounds are always respected` and `the stablecoin floor is never violated` — 10 seeds × 15 problems each, floor asserted to `1e-9`
- `higher riskTolerance gives weakly higher expected return and volatility` — monotonicity across the full 1–10 range
- `is non-decreasing in risk and in return` / `every frontier point is itself a valid portfolio` — a point that took on risk for less return would mean the sweep is not tracing an efficient frontier
- `produces byte-identical output for the same input twice` and `is invariant to the caller ordering the protocols differently` — determinism (I7)
- `a follow can never LOOSEN a tighter own ceiling` / `an active goal OVERRIDES outright, even to loosen` — the two merge rules (I6)
- `NEVER writes to the user record` + the whole `structural.test.ts` suite — the advisory invariant (I1, I2)
- `429s the second concurrent optimization for the same user` — holds the first request inside the service by stalling a DB read, fires the second, asserts 429 + `Retry-After`, then releases and asserts the first still completes 200
- `releases the concurrency slot after a failure` — a leaked slot would wedge a user out permanently with nothing logged
- `only counts days on which EVERY protocol has a value` / `forward-fills gaps so a gappy protocol stays index-aligned` — the silent-corruption path
- `one user failure does not abort the batch` — asserts the third user is still attempted after the second throws

**Verified by hand beyond the assertions:** the optimizer was re-run end-to-end on realistic 90-day data to confirm *behaviour*, not just passing assertions. As `riskTolerance` rises 1 → 10, expected return climbs 7.42 % → 10.31 %, volatility climbs 0.697 pp → 1.573 pp, and the weighted risk score *falls* 70.6 → 65.2 — the conservative profile diversifies into the safest protocol (score 88), the aggressive one concentrates in the high-yield pair. Weights summed to exactly 100 at every level and output was byte-identical on repeat.

**Measured cost** (full solve + 12-point frontier sweep): **0.11 ms** at 3 protocols, **1.33 ms** at 10, **7.10 ms** at 25. Across 450 seeded problems: **0 non-converged**, median 104 iterations, max 802 of a 2000 budget.

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing completed *(pure-computation paths only — see below)*

> ⚠️ **Not verified, and a reviewer with a database should close this gap.** `migration-smoke` and `api-contract`'s contract smoke tests both need a live Postgres and could not run locally, so **the new migration has never been executed against a real database.** Please: (1) `npx prisma migrate dev`, confirm `allocation_suggestions` is created, then apply `rollback.sql` on a scratch DB and confirm it drops cleanly; (2) seed `ProtocolRate` history + `ProtocolRiskScore` rows for ≥ 3 protocols and exercise both endpoints against a real server — `npx ts-node src/index.ts`, **not** `npm run dev`; (3) confirm `SELECT strategy_config FROM users` is unchanged throughout, verifying I1 against a real database rather than a mock.

---

### Pre-existing Bugs Found — NOT Fixed Here

**1. `npm run dev` and `npm start` both point at a stale demo file.** `src/index.ts` is the real application, but `"dev": "nodemon --exec ts-node src/app.ts"` runs `src/app.ts` — a standalone CORS demo with its own express app, its own `listen`, and hard-coded `/api/data` handlers that nothing imports. Worse, `"start": "node dist/src/app.js"` targets a path the build never produces: `tsconfig.build.json` sets `rootDir: ./src`, so the output is `dist/index.js`. Verified both: `dist/src/app.js` does not exist after `npm run build`. The Dockerfile is correct and authoritative. Fixing the scripts is a one-line change but touches how everyone runs the project locally, so it deserves its own PR.

**2. `src/routes/backtest.ts` is dead code masquerading as a route file.** It is a near-identical stale copy of `src/agent/backtest.ts`, differing only in import paths and a missing BigInt fix for the `1e21` exponential-notation bug. Verified nothing imports it and nothing mounts it. Deleting it is safe but out of scope here.

**3. `enforceUserAccess` returns 401, not 403, for a cross-user target.** `authenticate.ts:145` answers `AUTH_ERRORS.UNAUTHORIZED` when `req.auth.userId !== targetUserId` — but the caller *is* authenticated; they are simply not authorised, which is a 403. This PR's tests assert **401**, the behaviour that actually exists, rather than the behaviour one might assume. Changing it is a cross-cutting API contract change affecting every owner-scoped route.

**4. `enforceUserAccess` silently no-ops when neither `req.params.userId` nor `req.body.userId` is present.** Already documented in `CLAUDE.md` as a known trap. Not a new bug, but it is the direct reason both new routes are keyed on `req.params.userId` — noted so the keying is not "simplified" later.

**5. `docs/openapi.yaml` gains one new `no-ambiguous-paths` warning**, between `/portfolio/{userId}/suggest-allocation` and `/portfolio/goals/{id}` — the same spec-level ambiguity the pre-existing `/transactions/*` pair already has. It resolves correctly at runtime because `router.use('/goals', …)` is mounted before `/:userId`. Fixing it properly means restructuring the `/goals` mount, which is a separate change.

---

### Design Decisions

**Σ is the covariance of annual rate levels, and λ is log-spaced over `[5, 500]`.** This deviates from the issue plan and is one decision, not two. Under the plan's `Σ = cov(apy/100/365.25) × 365.25` with `λ ∈ [1,25]`, the risk term is 5–6 orders of magnitude below the return term:

| λ | `(λ/2)·wᵀΣw` at w=1 | μ | ratio |
|---|---|---|---|
| 1 | 5.48e-7 | 0.08 | 1.5e+5 |
| 25 | 1.37e-5 | 0.08 | 5.8e+3 |

The consequence is not "slightly aggressive" — the optimum is always the max-return corner and the frontier collapses to a point. The chosen Σ is exactly the plan's matrix × 365.25, which also makes `expectedVolatility` read in the same units as the APY, so *"8.2 % expected return, 1.4 % expected volatility"* is directly legible. Log spacing is the natural parameterization for a risk-aversion coefficient — each step is a constant *ratio* of risk appetite.

**A default 60 % per-protocol concentration cap, applied as an explicit constraint.** Even after rescaling, unconstrained mean-variance is corner-seeking (Michaud's "error maximization" — it treats a historical mean as if known exactly). Measured on this repo's scale, *every* `riskTolerance` from 3 to 10 returned a single protocol at 100 %. That is a true optimum of the stated objective and simultaneously terrible advice for an endpoint whose purpose is to suggest a **diversified** allocation. Applied as an overridable `bounds.max` default, raised to `1/n` on small universes so the guardrail can never empty the feasible set — rather than quietly distorting μ or λ until the answer looked reasonable.

**Exact split projection instead of Dykstra.** The plan called for Dykstra's alternating projections for the stable-group floor. For a convex set ∩ halfspace, the projection is either the plain capped-simplex projection or it lies on `Σ_S w = f`, which is two capped simplices over *disjoint* index groups — and Euclidean distance separates across disjoint coordinates. So the split is exact and non-iterative. This is not merely tidier: the Dykstra draft's final re-projection pushed the iterate back out of the floor halfspace, returning 0.30 for a 0.60 floor.

**Nesterov acceleration is load-bearing, not an optimization.** Σ is a sample covariance over ~90 observations, so with many protocols — or protocols whose APYs move together, which is the norm in DeFi — it is ill-conditioned or rank-deficient. The objective is then concave but not *strongly* concave, and plain projected gradient converges at O(1/k). A 7-protocol problem still had a 5.2e-8 residual after the full 2000-iteration budget and reported `non_converged` while sitting on a perfectly good allocation; reaching 1e-10 that way needs ~10⁶ iterations.

**`buildDailyRateSeries`, deliberately not `periodReturns`.** A covariance matrix requires index-aligned vectors — entry `(i,j)` must pair protocols `i` and `j` on the *same* day. `periodReturns` **skips** any interval whose starting value is non-positive, which is correct for its own job (a portfolio funded from empty is a deposit, not a return) and fatal here: two protocols skipping different intervals produce vectors of different lengths whose k-th entries are different days. The resulting matrix looks perfectly well-formed and is silently, badly wrong.

**`weights` stored as `Json` percentages, not `Decimal`.** A deliberate deviation from the issue's "use Decimal for storage". The vector's entire purpose is to round-trip into `User.strategyConfig.targetAllocations`, itself a `Json` map of numbers validated by `publishableConfigSchema`; `Decimal` would force a lossy re-conversion at the one place the value is ever consumed. `PublishedStrategyMetric` already sets the Float-for-computed-analytics precedent.

**The rate limiter is applied per-endpoint, not through the `apiRoutes` table.** The table convention is right for a resource whose routes are uniformly costly, but `/portfolio` is mostly cheap reads that must not inherit a 5/min budget because one POST on the same router is expensive. This is *not* the double-application the warning in `src/routes/admin.ts` guards against — no table-level limiter applies to this route.

**A concurrency semaphore in addition to the rate limiter, because they bound different things.** A rate limiter bounds requests per *window*; it says nothing about how many run *at once*. The optimizer is the first genuinely CPU-bound thing in this API and runs on the single event-loop thread, so ten concurrent solves do not merely run slower — they block every other request in the process, including `/health/ready`. Non-blocking by design: queueing would convert a CPU problem into a latency-and-memory problem and hold sockets open behind work the client has probably abandoned.

**The scheduled job stores suggestions without backtest legs.** They are two full historical replays per user and are only interesting when a human is looking — which is exactly when the POST endpoint computes them live. Job rows carry a null `backtest`, documented so an absent comparison never reads as a failure.

**The two ceiling merge rules were mirrored, not unified.** A follow merges via `Math.max` (may only tighten); an ACTIVE goal overrides via `??` (may loosen). Unifying them into one rule would be tidier and wrong — a suggestion computed under a third rule would be advice about a portfolio the agent will never build.

---

### Checklist

- [x] Code follows the project's style guidelines *(`npm run lint`, `npm run format:check`)*
- [x] Self-review performed
- [x] Comments added for complex logic *(the units contract, the projection geometry, and why acceleration is required are each documented at the site that depends on them)*
- [x] Documentation updated *(`docs/PORTFOLIO_OPTIMIZATION.md` new; `docs/openapi.yaml` + `ASSUMPTIONS.md` + `docs/DOCUMENTATION_INDEX.md` updated in the same change, per the repo's route-change rule)*
- [x] No new warnings *(`npm run lint` clean; `redocly` gains 1 pre-existing-category warning, noted above)*
- [x] Tests prove the fix/feature works *(+161 tests; the acceptance criterion is a structural test, not a comment)*
- [x] All existing tests pass locally *(817 / 66 suites; the jest worker-teardown warning is pre-existing and was reproduced without any new test loaded)*
- [x] Branch merged with latest `main` — clean descendant of `96a47e8`; one add/add conflict on `add_sub_accounts/rollback.sql` resolved by keeping `main`'s SQL **byte-identical** *(verified with comments stripped)* while preserving an operator-safety header
- [x] No breaking changes
- [ ] Migration executed against a real database *(**cannot be done locally** — `migration-smoke` needs a live Postgres; see the warning under How Has This Been Tested?)*
