### PR TITLE
feat: add wallet encryption key registry and provenance

### DIFF
--- a/prisma/migrations/20260818120000_add_wallet_encryption_key_registry/migration.sql
+++ b/prisma/migrations/20260818120000_add_wallet_encryption_key_registry/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "KeyStatus" AS ENUM ('ACTIVE', 'RETIRED', 'COMPROMISED');
+
+-- CreateTable
+CREATE TABLE "wallet_encryption_keys" (
+    "id" TEXT NOT NULL,
+    "keyLabel" TEXT NOT NULL,
+    "hash" TEXT NOT NULL,
+    "status" "KeyStatus" NOT NULL DEFAULT 'ACTIVE',
+    "rotatedFromId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "retiredAt" TIMESTAMP(3),
+
+    CONSTRAINT "wallet_encryption_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "wallet_encryption_keys_keyLabel_key" ON "wallet_encryption_keys"("keyLabel");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "wallet_encryption_keys_hash_key" ON "wallet_encryption_keys"("hash");
+
+-- CreateIndex
+CREATE INDEX "wallet_encryption_keys_status_idx" ON "wallet_encryption_keys"("status");
+
+-- AddForeignKey
+ALTER TABLE "wallet_encryption_keys" ADD CONSTRAINT "wallet_encryption_keys_rotatedFromId_fkey" FOREIGN KEY ("rotatedFromId") REFERENCES "wallet_encryption_keys"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "custodial_wallets" ADD COLUMN "encryptionKeyId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "custodial_wallets_encryptionKeyId_idx" ON "custodial_wallets"("encryptionKeyId");
+
+-- AddForeignKey
+ALTER TABLE "custodial_wallets" ADD CONSTRAINT "custodial_wallets_encryptionKeyId_fkey" FOREIGN KEY ("encryptionKeyId") REFERENCES "wallet_encryption_keys"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260818120000_add_wallet_encryption_key_registry/rollback.sql
+++ b/prisma/migrations/20260818120000_add_wallet_encryption_key_registry/rollback.sql
@@ -1,0 +1,22 @@
+-- Rollback for 20260818120000_add_wallet_encryption_key_registry
+-- Reverses the wallet_encryption_keys registry table and the
+-- encryptionKeyId provenance column on custodial_wallets.
+-- WARNING: Destroys any recorded key-rotation provenance/history.
+
+-- DropForeignKey
+ALTER TABLE "custodial_wallets" DROP CONSTRAINT IF EXISTS "custodial_wallets_encryptionKeyId_fkey";
+
+-- DropIndex
+DROP INDEX IF EXISTS "custodial_wallets_encryptionKeyId_idx";
+
+-- DropColumn
+ALTER TABLE "custodial_wallets" DROP COLUMN IF EXISTS "encryptionKeyId";
+
+-- DropForeignKey
+ALTER TABLE "wallet_encryption_keys" DROP CONSTRAINT IF EXISTS "wallet_encryption_keys_rotatedFromId_fkey";
+
+-- DropTable (indexes drop with their table)
+DROP TABLE IF EXISTS "wallet_encryption_keys";
+
+-- DropEnum
+DROP TYPE IF EXISTS "KeyStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -471,12 +471,49 @@ model CustodialWallet {
   iv              String
   authTag         String
   keyVersion      Int      @default(1)
+  // Which WalletEncryptionKey encrypted this row, set at write time. Null on
+  // rows written before provenance tracking existed (#323) — such rows are
+  // read via the legacy dual-key fallback in src/stellar/wallet.ts until a
+  // backfill (scripts/backfill-wallet-key-provenance.ts) or a rotation writes
+  // a value here. Deliberately not a required FK for that reason.
+  encryptionKeyId String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  encryptionKey WalletEncryptionKey? @relation(fields: [encryptionKeyId], references: [id])
+
   @@index([userId])
   @@index([keyVersion])
+  @@index([encryptionKeyId])
   @@map("custodial_wallets")
+}
+
+enum KeyStatus {
+  ACTIVE
+  RETIRED
+  COMPROMISED
+}
+
+/// Registry of wallet-encryption key *metadata* (#323) — never the key
+/// material itself. `hash` is SHA-256 over the hex key, letting a
+/// CustodialWallet row's `encryptionKeyId` prove which key encrypted it
+/// without the registry ever holding anything an attacker could decrypt
+/// with. See src/keys/registry.ts.
+model WalletEncryptionKey {
+  id             String    @id @default(uuid())
+  keyLabel       String    @unique
+  hash           String    @unique
+  status         KeyStatus @default(ACTIVE)
+  rotatedFromId  String?
+  createdAt      DateTime  @default(now())
+  retiredAt      DateTime?
+
+  rotatedFrom WalletEncryptionKey?  @relation("KeyRotation", fields: [rotatedFromId], references: [id])
+  rotatedTo   WalletEncryptionKey[] @relation("KeyRotation")
+  wallets     CustodialWallet[]
+
+  @@index([status])
+  @@map("wallet_encryption_keys")
 }
 
 model AuthNonce {

--- a/scripts/backfill-wallet-key-provenance.ts
+++ b/scripts/backfill-wallet-key-provenance.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env ts-node
+/**
+ * Backfill CustodialWallet.encryptionKeyId provenance (#323)
+ *
+ * Existing custodial_wallets rows predate row-level key provenance and have
+ * encryptionKeyId = null, so they're read via the legacy try-primary-
+ * then-fallback heuristic in src/stellar/wallet.ts. This script attempts
+ * decryption of every such row with the active key, then the fallback key
+ * (if configured), verifies the derived public key matches the stored one,
+ * and records which key registry entry owns the row.
+ *
+ * Deterministic and idempotent: only rows with encryptionKeyId = null are
+ * considered, so interrupting and re-running just resumes with whatever is
+ * left. A row that decrypts with neither key is quarantined (left untouched,
+ * reported) rather than aborting the whole run.
+ *
+ * Usage:
+ *   npx ts-node scripts/backfill-wallet-key-provenance.ts [--dry-run]
+ *
+ * Environment:
+ *   - DATABASE_URL
+ *   - WALLET_ENCRYPTION_KEY (required, 64 hex chars)
+ *   - WALLET_ENCRYPTION_KEY_OLD (optional, 64 hex chars — rows still on a
+ *     previously-retired key are matched against this)
+ */
+
+import { Keypair } from '@stellar/stellar-sdk'
+import db from '../src/db'
+import { logger } from '../src/utils/logger'
+import { decryptSecretWithKey } from '../src/stellar/wallet'
+import { getOrRegisterKey, deriveBootstrapLabel } from '../src/keys/registry'
+
+const BATCH_SIZE = 500
+const DRY_RUN = process.argv.includes('--dry-run')
+const HEX_64_REGEX = /^[0-9a-fA-F]{64}$/
+
+function requireHexKey(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required environment variable: ${name}`)
+  if (!HEX_64_REGEX.test(value)) {
+    throw new Error(`${name} must be 64 hexadecimal characters (32 bytes)`)
+  }
+  return value
+}
+
+function readOptionalHexKey(name: string): string | undefined {
+  const value = process.env[name]
+  if (!value) return undefined
+  if (!HEX_64_REGEX.test(value)) {
+    throw new Error(`${name} must be 64 hexadecimal characters (32 bytes)`)
+  }
+  return value
+}
+
+async function main(): Promise<void> {
+  const activeKeyHex = requireHexKey('WALLET_ENCRYPTION_KEY')
+  const fallbackKeyHex = readOptionalHexKey('WALLET_ENCRYPTION_KEY_OLD')
+
+  logger.info('[Key Provenance Backfill] Starting', {
+    dryRun: DRY_RUN,
+    fallbackConfigured: Boolean(fallbackKeyHex),
+  })
+
+  const activeKey = await getOrRegisterKey(
+    activeKeyHex,
+    deriveBootstrapLabel(activeKeyHex),
+    'ACTIVE'
+  )
+  const fallbackKey = fallbackKeyHex
+    ? await getOrRegisterKey(
+        fallbackKeyHex,
+        deriveBootstrapLabel(fallbackKeyHex),
+        'RETIRED'
+      )
+    : undefined
+
+  let backfilledActive = 0
+  let backfilledFallback = 0
+  let quarantined = 0
+  const quarantinedRows: { id: string; userId: string }[] = []
+
+  let cursor: string | undefined
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch = await db.custodialWallet.findMany({
+      where: { encryptionKeyId: null },
+      take: BATCH_SIZE,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      orderBy: { id: 'asc' },
+    })
+    if (batch.length === 0) break
+    cursor = batch[batch.length - 1].id
+
+    for (const wallet of batch) {
+      let matchedKeyId: string | undefined
+      let matchedLabel: 'active' | 'fallback' | undefined
+
+      try {
+        const secret = decryptSecretWithKey(
+          wallet.encryptedSecret,
+          wallet.iv,
+          wallet.authTag,
+          activeKeyHex
+        )
+        if (Keypair.fromSecret(secret).publicKey() === wallet.publicKey) {
+          matchedKeyId = activeKey.id
+          matchedLabel = 'active'
+        }
+      } catch {
+        // Not decryptable with the active key — try the fallback below.
+      }
+
+      if (!matchedKeyId && fallbackKeyHex && fallbackKey) {
+        try {
+          const secret = decryptSecretWithKey(
+            wallet.encryptedSecret,
+            wallet.iv,
+            wallet.authTag,
+            fallbackKeyHex
+          )
+          if (Keypair.fromSecret(secret).publicKey() === wallet.publicKey) {
+            matchedKeyId = fallbackKey.id
+            matchedLabel = 'fallback'
+          }
+        } catch {
+          // Not decryptable with the fallback key either — quarantine below.
+        }
+      }
+
+      if (!matchedKeyId) {
+        quarantined++
+        quarantinedRows.push({ id: wallet.id, userId: wallet.userId })
+        logger.warn(
+          '[Key Provenance Backfill] Quarantined row: decrypts with neither the active nor fallback key',
+          { walletId: wallet.id }
+        )
+        continue
+      }
+
+      if (!DRY_RUN) {
+        await db.custodialWallet.update({
+          where: { id: wallet.id },
+          data: { encryptionKeyId: matchedKeyId },
+        })
+      }
+
+      if (matchedLabel === 'active') backfilledActive++
+      else backfilledFallback++
+    }
+  }
+
+  logger.info('[Key Provenance Backfill] Complete', {
+    dryRun: DRY_RUN,
+    backfilledActive,
+    backfilledFallback,
+    quarantined,
+  })
+
+  if (quarantined > 0) {
+    console.log('')
+    console.log(
+      `⚠️  ${quarantined} row(s) could not be matched to a known key and were left untouched:`
+    )
+    quarantinedRows
+      .slice(0, 20)
+      .forEach((r) => console.log(`   - wallet ${r.id} (user ${r.userId})`))
+    if (quarantinedRows.length > 20) {
+      console.log(`   ... and ${quarantinedRows.length - 20} more`)
+    }
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch((err) => {
+    logger.error('[Key Provenance Backfill] Failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    process.exitCode = 1
+  })
+  .finally(() => db.$disconnect())

--- a/src/keys/registry.ts
+++ b/src/keys/registry.ts
@@ -1,0 +1,91 @@
+import * as crypto from 'crypto'
+import db from '../db'
+import type { KeyStatus, WalletEncryptionKey } from '@prisma/client'
+
+const HEX_64_REGEX = /^[0-9a-fA-F]{64}$/
+
+/**
+ * SHA-256 of the raw hex key. The registry stores this and a label only —
+ * never the key material itself — so a CustodialWallet row's
+ * `encryptionKeyId` can prove which key encrypted it without the registry
+ * ever holding anything an attacker could decrypt with.
+ */
+export function hashKey(keyHex: string): string {
+  return crypto.createHash('sha256').update(keyHex, 'hex').digest('hex')
+}
+
+/** A deterministic, collision-free label for a key that has no operator-assigned
+ * one yet (e.g. auto-registered from an env var at read time). Derived from the
+ * key's own hash so it is stable across repeated calls for the same key without
+ * ever encoding the key material itself. */
+export function deriveBootstrapLabel(keyHex: string): string {
+  return `bootstrap-${hashKey(keyHex).slice(0, 12)}`
+}
+
+export async function findKeyByHash(
+  hash: string
+): Promise<WalletEncryptionKey | null> {
+  return db.walletEncryptionKey.findUnique({ where: { hash } })
+}
+
+export async function findKeyById(
+  id: string
+): Promise<WalletEncryptionKey | null> {
+  return db.walletEncryptionKey.findUnique({ where: { id } })
+}
+
+export async function listKeys(): Promise<WalletEncryptionKey[]> {
+  return db.walletEncryptionKey.findMany({ orderBy: { createdAt: 'asc' } })
+}
+
+/**
+ * Register a key's metadata in the registry if it isn't already tracked
+ * (looked up by hash). Idempotent: safe to call on every process start or
+ * every wallet read — returns the existing row rather than erroring if the
+ * key is already registered under a different label.
+ */
+export async function getOrRegisterKey(
+  keyHex: string,
+  keyLabel: string,
+  status: KeyStatus = 'ACTIVE'
+): Promise<WalletEncryptionKey> {
+  if (!keyHex || !HEX_64_REGEX.test(keyHex)) {
+    throw new Error(
+      'getOrRegisterKey: key must be 64 hexadecimal characters (32 bytes)'
+    )
+  }
+
+  const hash = hashKey(keyHex)
+  const existing = await findKeyByHash(hash)
+  if (existing) return existing
+
+  try {
+    return await db.walletEncryptionKey.create({
+      data: { keyLabel, hash, status },
+    })
+  } catch (err) {
+    // Two concurrent callers can both miss the findKeyByHash lookup at cold
+    // start and race to create the same row; the loser hits the unique
+    // constraint on `hash`. Re-read and return the winner's row instead of
+    // failing the caller.
+    const existingAfterRace = await findKeyByHash(hash)
+    if (existingAfterRace) return existingAfterRace
+    throw err
+  }
+}
+
+export async function retireKey(id: string): Promise<WalletEncryptionKey> {
+  return db.walletEncryptionKey.update({
+    where: { id },
+    data: { status: 'RETIRED', retiredAt: new Date() },
+  })
+}
+
+export async function markCompromised(
+  id: string
+): Promise<WalletEncryptionKey> {
+  return db.walletEncryptionKey.update({
+    where: { id },
+    data: { status: 'COMPROMISED' },
+  })
+}

--- a/src/stellar/wallet.ts
+++ b/src/stellar/wallet.ts
@@ -2,6 +2,11 @@ import { Keypair } from '@stellar/stellar-sdk'
 import * as crypto from 'crypto'
 import db from '../db'
 import { logger } from '../utils/logger'
+import {
+  deriveBootstrapLabel,
+  getOrRegisterKey,
+  hashKey,
+} from '../keys/registry'
 
 const ALGORITHM = 'aes-256-gcm'
 const HEX_64_REGEX = /^[0-9a-fA-F]{64}$/
@@ -99,6 +104,33 @@ function decryptSecret(encrypted: string, iv: string, authTag: string): string {
 }
 
 /**
+ * Decrypt a secret with an explicit key (not read from env). Used by the
+ * row-provenance read path to decrypt with whichever key an environment's
+ * WALLET_ENCRYPTION_KEY / WALLET_ENCRYPTION_KEY_OLD is proven (by hash) to
+ * match a row's recorded encryptionKeyId, and by rotation/backfill tooling.
+ */
+export function decryptSecretWithKey(
+  encrypted: string,
+  iv: string,
+  authTag: string,
+  keyHex: string
+): string {
+  assertValidHexKey(keyHex, 'Key')
+  const key = Buffer.from(keyHex, 'hex')
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    key,
+    Buffer.from(iv, 'hex')
+  )
+  decipher.setAuthTag(Buffer.from(authTag, 'hex'))
+
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8')
+  decrypted += decipher.final('utf8')
+
+  return decrypted
+}
+
+/**
  * Decrypt a secret with dual-key support.
  * Tries the primary key first; if that fails and a fallback key is configured,
  * attempts decryption with the fallback key.
@@ -159,6 +191,70 @@ function decryptSecretDualKey(
 }
 
 /**
+ * Register the currently-configured active key (WALLET_ENCRYPTION_KEY) in the
+ * key registry, returning its registry row. Idempotent — looked up by hash,
+ * so repeated calls (every wallet creation/backfill) do not create duplicates.
+ */
+async function registerActiveKey() {
+  const keyHex = getEncryptionKey()
+  return getOrRegisterKey(keyHex, deriveBootstrapLabel(keyHex), 'ACTIVE')
+}
+
+/**
+ * Resolve the raw key material (hex) for a row's recorded encryptionKeyId by
+ * matching its registry hash against the key(s) actually available in this
+ * environment. Returns undefined if the row's key isn't registered, or if
+ * neither WALLET_ENCRYPTION_KEY nor WALLET_ENCRYPTION_KEY_OLD in this
+ * environment produces the recorded hash (operator must supply the right key).
+ */
+async function resolveKeyMaterialForRegistryId(
+  encryptionKeyId: string
+): Promise<string | undefined> {
+  const record = await db.walletEncryptionKey.findUnique({
+    where: { id: encryptionKeyId },
+  })
+  if (!record) return undefined
+
+  const candidates = [getEncryptionKey(), getFallbackEncryptionKey()].filter(
+    (k): k is string => Boolean(k)
+  )
+
+  return candidates.find((candidate) => hashKey(candidate) === record.hash)
+}
+
+/**
+ * Opportunistically record which key decrypted a legacy (encryptionKeyId ===
+ * null) row, so subsequent reads take the deterministic provenance path
+ * instead of the dual-key fallback heuristic. Best-effort: failures are
+ * logged, not thrown — provenance backfill must never break a read.
+ */
+async function backfillProvenance(
+  walletId: string,
+  keyUsed: 'primary' | 'fallback'
+): Promise<void> {
+  try {
+    const keyHex =
+      keyUsed === 'primary' ? getEncryptionKey() : getFallbackEncryptionKey()
+    if (!keyHex) return
+
+    const registryKey = await getOrRegisterKey(
+      keyHex,
+      deriveBootstrapLabel(keyHex),
+      keyUsed === 'primary' ? 'ACTIVE' : 'RETIRED'
+    )
+
+    await db.custodialWallet.update({
+      where: { id: walletId },
+      data: { encryptionKeyId: registryKey.id },
+    })
+  } catch (err) {
+    logger.warn(
+      `[Wallet] Failed to backfill encryptionKeyId for wallet ${walletId}: ${err instanceof Error ? err.message : 'unknown error'}`
+    )
+  }
+}
+
+/**
  * Create a custodial wallet for a user and persist it to the database.
  *
  * SECURITY NOTE: This is a custodial solution where the backend holds user keys.
@@ -179,6 +275,7 @@ export async function createCustodialWallet(userId: string) {
 
   const keypair = Keypair.random()
   const { encrypted, iv, authTag } = encryptSecret(keypair.secret())
+  const activeKey = await registerActiveKey()
 
   const wallet = await db.custodialWallet.create({
     data: {
@@ -188,6 +285,7 @@ export async function createCustodialWallet(userId: string) {
       iv,
       authTag,
       keyVersion: 2,
+      encryptionKeyId: activeKey.id,
     },
   })
 
@@ -204,7 +302,13 @@ export async function getWalletByUserId(userId: string) {
 
 /**
  * Decrypt and return the Stellar Keypair for a user.
- * Supports dual-key reads if WALLET_ENCRYPTION_KEY_OLD is configured.
+ *
+ * Rows with a recorded `encryptionKeyId` (#323) take a deterministic path:
+ * look up which key encrypted this row, decrypt with exactly that key. Rows
+ * without one (written before provenance tracking existed) fall back to the
+ * legacy try-primary-then-fallback heuristic as a compatibility shim, and
+ * opportunistically backfill `encryptionKeyId` so subsequent reads take the
+ * deterministic path.
  */
 export async function getKeypairForUser(userId: string): Promise<Keypair> {
   const wallet = await getWalletByUserId(userId)
@@ -213,7 +317,26 @@ export async function getKeypairForUser(userId: string): Promise<Keypair> {
     throw new Error(`No wallet found for user ${userId}`)
   }
 
-  // Use dual-key decryption for smooth key rotation support
+  if (wallet.encryptionKeyId) {
+    const keyHex = await resolveKeyMaterialForRegistryId(wallet.encryptionKeyId)
+    if (!keyHex) {
+      throw new Error(
+        `[Wallet] No key material available in this environment for user ${userId}'s ` +
+          `recorded encryption key (registry id ${wallet.encryptionKeyId}). Configure ` +
+          `WALLET_ENCRYPTION_KEY / WALLET_ENCRYPTION_KEY_OLD to match the key that encrypted this row.`
+      )
+    }
+
+    const secret = decryptSecretWithKey(
+      wallet.encryptedSecret,
+      wallet.iv,
+      wallet.authTag,
+      keyHex
+    )
+    return Keypair.fromSecret(secret)
+  }
+
+  // Legacy row with no recorded provenance: compatibility shim only.
   const { secret, keyUsed } = decryptSecretDualKey(
     wallet.encryptedSecret,
     wallet.iv,
@@ -226,10 +349,12 @@ export async function getKeypairForUser(userId: string): Promise<Keypair> {
     )
   }
 
-  // Lazy re-encryption for wallets on v1
+  // Lazy re-encryption for wallets on v1 — this rewrites the ciphertext under
+  // the active key, so provenance can be set directly rather than backfilled.
   if (wallet.keyVersion === 1) {
     try {
       const { encrypted, iv, authTag } = encryptSecret(secret)
+      const activeKey = await registerActiveKey()
       await db.custodialWallet.update({
         where: { id: wallet.id },
         data: {
@@ -237,6 +362,7 @@ export async function getKeypairForUser(userId: string): Promise<Keypair> {
           iv,
           authTag,
           keyVersion: 2,
+          encryptionKeyId: activeKey.id,
         },
       })
       logger.info(
@@ -248,6 +374,9 @@ export async function getKeypairForUser(userId: string): Promise<Keypair> {
       )
       // Non-fatal, we still return the keypair
     }
+  } else {
+    // v2 row, ciphertext untouched — just record which key it decrypted with.
+    await backfillProvenance(wallet.id, keyUsed)
   }
 
   return Keypair.fromSecret(secret)

--- a/tests/unit/keys/registry.test.ts
+++ b/tests/unit/keys/registry.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Wallet-encryption key registry unit tests (#323).
+ *
+ * The registry never stores key material — only a label and a SHA-256 hash —
+ * so the properties that matter are: hashing is deterministic, registration
+ * is idempotent under both a clean lookup-miss and a concurrent create race,
+ * and status transitions (retire/compromise) write what they claim to.
+ */
+
+const mockFindUnique = jest.fn()
+const mockCreate = jest.fn()
+const mockFindMany = jest.fn()
+const mockUpdate = jest.fn()
+
+jest.mock('../../../src/db', () => ({
+  __esModule: true,
+  default: {
+    walletEncryptionKey: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      create: (...args: unknown[]) => mockCreate(...args),
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      update: (...args: unknown[]) => mockUpdate(...args),
+    },
+  },
+}))
+
+import {
+  hashKey,
+  deriveBootstrapLabel,
+  findKeyByHash,
+  findKeyById,
+  listKeys,
+  getOrRegisterKey,
+  retireKey,
+  markCompromised,
+} from '../../../src/keys/registry'
+
+const KEY_A = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+const KEY_B = 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('hashKey', () => {
+  it('is deterministic for the same key', () => {
+    expect(hashKey(KEY_A)).toBe(hashKey(KEY_A))
+  })
+
+  it('produces different hashes for different keys', () => {
+    expect(hashKey(KEY_A)).not.toBe(hashKey(KEY_B))
+  })
+
+  it('never leaks the key material back out (produces a fixed-length hex digest, not the key)', () => {
+    const hash = hashKey(KEY_A)
+    expect(hash).not.toContain(KEY_A)
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('deriveBootstrapLabel', () => {
+  it('is deterministic and does not encode the key itself', () => {
+    const label = deriveBootstrapLabel(KEY_A)
+    expect(label).toBe(deriveBootstrapLabel(KEY_A))
+    expect(label).not.toContain(KEY_A)
+    expect(label.startsWith('bootstrap-')).toBe(true)
+  })
+
+  it('differs for different keys', () => {
+    expect(deriveBootstrapLabel(KEY_A)).not.toBe(deriveBootstrapLabel(KEY_B))
+  })
+})
+
+describe('findKeyByHash / findKeyById / listKeys', () => {
+  it('looks up by hash', async () => {
+    mockFindUnique.mockResolvedValue({ id: 'k1', hash: hashKey(KEY_A) })
+    const result = await findKeyByHash(hashKey(KEY_A))
+    expect(result).toEqual({ id: 'k1', hash: hashKey(KEY_A) })
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { hash: hashKey(KEY_A) },
+    })
+  })
+
+  it('looks up by id', async () => {
+    mockFindUnique.mockResolvedValue({ id: 'k1' })
+    await findKeyById('k1')
+    expect(mockFindUnique).toHaveBeenCalledWith({ where: { id: 'k1' } })
+  })
+
+  it('lists keys ordered by createdAt ascending', async () => {
+    mockFindMany.mockResolvedValue([])
+    await listKeys()
+    expect(mockFindMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: 'asc' },
+    })
+  })
+})
+
+describe('getOrRegisterKey', () => {
+  it('rejects a key that is not 64 hex characters', async () => {
+    await expect(getOrRegisterKey('short', 'label')).rejects.toThrow(
+      '64 hexadecimal characters'
+    )
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns the existing row when the key is already registered (by hash)', async () => {
+    const existing = { id: 'existing-id', hash: hashKey(KEY_A) }
+    mockFindUnique.mockResolvedValue(existing)
+
+    const result = await getOrRegisterKey(KEY_A, 'some-label')
+
+    expect(result).toBe(existing)
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('creates a new row when the key is not yet registered', async () => {
+    mockFindUnique.mockResolvedValue(null)
+    mockCreate.mockResolvedValue({ id: 'new-id', hash: hashKey(KEY_A) })
+
+    const result = await getOrRegisterKey(KEY_A, 'v1', 'ACTIVE')
+
+    expect(result).toEqual({ id: 'new-id', hash: hashKey(KEY_A) })
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: { keyLabel: 'v1', hash: hashKey(KEY_A), status: 'ACTIVE' },
+    })
+  })
+
+  it('defaults status to ACTIVE when not specified', async () => {
+    mockFindUnique.mockResolvedValue(null)
+    mockCreate.mockResolvedValue({ id: 'new-id' })
+
+    await getOrRegisterKey(KEY_A, 'v1')
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'ACTIVE' }),
+      })
+    )
+  })
+
+  it('recovers from a concurrent-create race by re-reading the winning row', async () => {
+    const winner = { id: 'winner-id', hash: hashKey(KEY_A) }
+    // First lookup misses (both callers race past it), create fails on the
+    // unique hash constraint, second lookup finds the row the other caller won.
+    mockFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(winner)
+    mockCreate.mockRejectedValue(new Error('Unique constraint failed on hash'))
+
+    const result = await getOrRegisterKey(KEY_A, 'v1')
+
+    expect(result).toBe(winner)
+  })
+
+  it('rethrows if create fails and no row exists on re-read (a real error, not a race)', async () => {
+    mockFindUnique.mockResolvedValue(null)
+    mockCreate.mockRejectedValue(new Error('connection lost'))
+
+    await expect(getOrRegisterKey(KEY_A, 'v1')).rejects.toThrow(
+      'connection lost'
+    )
+  })
+})
+
+describe('retireKey / markCompromised', () => {
+  it('retireKey sets status RETIRED and stamps retiredAt', async () => {
+    mockUpdate.mockResolvedValue({ id: 'k1', status: 'RETIRED' })
+    await retireKey('k1')
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'k1' },
+      data: { status: 'RETIRED', retiredAt: expect.any(Date) },
+    })
+  })
+
+  it('markCompromised sets status COMPROMISED', async () => {
+    mockUpdate.mockResolvedValue({ id: 'k1', status: 'COMPROMISED' })
+    await markCompromised('k1')
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'k1' },
+      data: { status: 'COMPROMISED' },
+    })
+  })
+})

--- a/tests/unit/stellar/wallet-provenance.test.ts
+++ b/tests/unit/stellar/wallet-provenance.test.ts
@@ -1,0 +1,303 @@
+/**
+ * CustodialWallet key-provenance unit tests (#323).
+ *
+ * getKeypairForUser has two read paths:
+ *   1. Deterministic: wallet.encryptionKeyId is set — look up which key
+ *      encrypted the row, decrypt with exactly that key. No guessing.
+ *   2. Legacy compatibility shim: encryptionKeyId is null (pre-provenance
+ *      row) — try-primary-then-fallback, then opportunistically backfill
+ *      encryptionKeyId so the next read takes path 1.
+ *
+ * These tests exercise both paths against a mocked db, plus the "operator
+ * hasn't configured the right key" and "row belongs to neither active nor
+ * fallback key" failure modes, since those are exactly the cases a real
+ * rotation can hit.
+ */
+
+import * as crypto from 'crypto'
+import { Keypair } from '@stellar/stellar-sdk'
+
+const ACTIVE_KEY =
+  'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+const OLD_KEY =
+  'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3'
+const UNKNOWN_KEY =
+  'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'
+
+function hashHex(keyHex: string): string {
+  return crypto.createHash('sha256').update(keyHex, 'hex').digest('hex')
+}
+
+function encryptWithKey(
+  secret: string,
+  keyHex: string
+): { encrypted: string; iv: string; authTag: string } {
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = crypto.randomBytes(16)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  let encrypted = cipher.update(secret, 'utf8', 'hex')
+  encrypted += cipher.final('hex')
+  return {
+    encrypted,
+    iv: iv.toString('hex'),
+    authTag: cipher.getAuthTag().toString('hex'),
+  }
+}
+
+const mockWalletFindUnique = jest.fn()
+const mockWalletUpdate = jest.fn()
+const mockWalletCreate = jest.fn()
+const mockKeyFindUnique = jest.fn()
+const mockKeyCreate = jest.fn()
+
+jest.mock('../../../src/db', () => ({
+  __esModule: true,
+  default: {
+    custodialWallet: {
+      findUnique: (...args: unknown[]) => mockWalletFindUnique(...args),
+      update: (...args: unknown[]) => mockWalletUpdate(...args),
+      create: (...args: unknown[]) => mockWalletCreate(...args),
+    },
+    walletEncryptionKey: {
+      findUnique: (...args: unknown[]) => mockKeyFindUnique(...args),
+      create: (...args: unknown[]) => mockKeyCreate(...args),
+    },
+  },
+}))
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}))
+
+import {
+  getKeypairForUser,
+  createCustodialWallet,
+} from '../../../src/stellar/wallet'
+
+const realUser = Keypair.random()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env.WALLET_ENCRYPTION_KEY = ACTIVE_KEY
+  delete process.env.WALLET_ENCRYPTION_KEY_OLD
+})
+
+describe('getKeypairForUser — deterministic (encryptionKeyId set)', () => {
+  it('decrypts with exactly the key recorded for the row, matching the active env key', async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      ACTIVE_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-1',
+      userId: 'user-1',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: 'key-active',
+    })
+    mockKeyFindUnique.mockResolvedValue({
+      id: 'key-active',
+      hash: hashHex(ACTIVE_KEY),
+    })
+
+    const keypair = await getKeypairForUser('user-1')
+
+    expect(keypair.publicKey()).toBe(realUser.publicKey())
+    // Deterministic path never touches the write path.
+    expect(mockWalletUpdate).not.toHaveBeenCalled()
+  })
+
+  it('decrypts with the fallback env key when the recorded key matches it instead of the active key', async () => {
+    process.env.WALLET_ENCRYPTION_KEY_OLD = OLD_KEY
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      OLD_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-2',
+      userId: 'user-2',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: 'key-old',
+    })
+    mockKeyFindUnique.mockResolvedValue({
+      id: 'key-old',
+      hash: hashHex(OLD_KEY),
+    })
+
+    const keypair = await getKeypairForUser('user-2')
+
+    expect(keypair.publicKey()).toBe(realUser.publicKey())
+  })
+
+  it("throws a clear, actionable error when no configured env key matches the row's recorded key", async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      UNKNOWN_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-3',
+      userId: 'user-3',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: 'key-unknown',
+    })
+    mockKeyFindUnique.mockResolvedValue({
+      id: 'key-unknown',
+      hash: hashHex(UNKNOWN_KEY),
+    })
+
+    await expect(getKeypairForUser('user-3')).rejects.toThrow(
+      /No key material available in this environment/
+    )
+  })
+
+  it('throws when the recorded encryptionKeyId no longer exists in the registry', async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      ACTIVE_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-4',
+      userId: 'user-4',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: 'missing-key-id',
+    })
+    mockKeyFindUnique.mockResolvedValue(null)
+
+    await expect(getKeypairForUser('user-4')).rejects.toThrow(
+      /No key material available in this environment/
+    )
+  })
+})
+
+describe('getKeypairForUser — legacy rows (encryptionKeyId null)', () => {
+  it('decrypts via the dual-key heuristic and backfills provenance for a v2 row', async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      ACTIVE_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-5',
+      userId: 'user-5',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: null,
+    })
+    // Registry: active key not yet registered -> create it.
+    mockKeyFindUnique.mockResolvedValue(null)
+    mockKeyCreate.mockResolvedValue({ id: 'new-active-key' })
+
+    const keypair = await getKeypairForUser('user-5')
+
+    expect(keypair.publicKey()).toBe(realUser.publicKey())
+    expect(mockKeyCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'ACTIVE' }),
+      })
+    )
+    expect(mockWalletUpdate).toHaveBeenCalledWith({
+      where: { id: 'wallet-5' },
+      data: { encryptionKeyId: 'new-active-key' },
+    })
+  })
+
+  it('lazily re-encrypts a v1 row under the active key and sets provenance directly', async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      ACTIVE_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-6',
+      userId: 'user-6',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 1,
+      encryptionKeyId: null,
+    })
+    mockKeyFindUnique.mockResolvedValue(null)
+    mockKeyCreate.mockResolvedValue({ id: 'new-active-key' })
+
+    const keypair = await getKeypairForUser('user-6')
+
+    expect(keypair.publicKey()).toBe(realUser.publicKey())
+    expect(mockWalletUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'wallet-6' },
+        data: expect.objectContaining({
+          keyVersion: 2,
+          encryptionKeyId: 'new-active-key',
+        }),
+      })
+    )
+  })
+
+  it('does not fail the read if provenance backfill itself fails', async () => {
+    const { encrypted, iv, authTag } = encryptWithKey(
+      realUser.secret(),
+      ACTIVE_KEY
+    )
+    mockWalletFindUnique.mockResolvedValue({
+      id: 'wallet-7',
+      userId: 'user-7',
+      publicKey: realUser.publicKey(),
+      encryptedSecret: encrypted,
+      iv,
+      authTag,
+      keyVersion: 2,
+      encryptionKeyId: null,
+    })
+    mockKeyFindUnique.mockResolvedValue(null)
+    mockKeyCreate.mockRejectedValue(new Error('db unavailable'))
+
+    const keypair = await getKeypairForUser('user-7')
+
+    expect(keypair.publicKey()).toBe(realUser.publicKey())
+  })
+})
+
+describe('createCustodialWallet', () => {
+  it('registers the active key and stamps the new wallet with its registry id', async () => {
+    mockWalletFindUnique.mockResolvedValue(null) // no existing wallet for user
+    mockKeyFindUnique.mockResolvedValue(null) // active key not yet registered
+    mockKeyCreate.mockResolvedValue({ id: 'active-key-id' })
+    mockWalletCreate.mockImplementation(({ data }) =>
+      Promise.resolve({ id: 'new-wallet-id', ...data })
+    )
+
+    const wallet = await createCustodialWallet('user-8')
+
+    expect(wallet.encryptionKeyId).toBe('active-key-id')
+    expect(mockWalletCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'user-8',
+          encryptionKeyId: 'active-key-id',
+        }),
+      })
+    )
+  })
+})


### PR DESCRIPTION
closes #323 

Summary

Added wallet encryption key registry with ACTIVE, RETIRED, and COMPROMISED states.
Added row-level encryption-key provenance to custodial wallets.
Added deterministic key lookup and legacy-wallet backfill support.
Added key registry and wallet provenance tests.

Testing

841/841 tests passed
68/68 test suites passed

Notes

No key material is stored in the registry; only key labels and SHA-256 hashes are stored.
No rotation job, dual-signing, split-custody, or admin API changes were included.