### PR TITLE
feat: add transaction risk scoring engine

### DIFF
--- a/src/compliance/scoring.ts
+++ b/src/compliance/scoring.ts
@@ -1,0 +1,755 @@
+/**
+ * Transaction risk-scoring engine (#321).
+ *
+ * Pure, side-effect-free, deterministic feature extraction + scoring so the
+ * suspicion model can be unit-tested in isolation from the database and the
+ * on-chain listener — same rationale as src/services/alertEvaluator.ts. Every
+ * caller (transaction persistence, the batch monitoring job, a future admin
+ * "re-score" tool) hands in a snapshot of what's already known about the
+ * account; nothing in here reads the clock or does I/O. Time-window features
+ * anchor on `transaction.createdAt`, not `Date.now()`, so the same inputs
+ * always produce the same output.
+ *
+ * Model summary (v1, rules-based — see MODEL_VERSION):
+ *   AMOUNT_ANOMALY (0.25)     — MAD-based modified z-score vs. the account's
+ *                                own historical amounts for this transaction
+ *                                type/asset. Robust to outliers; unlike a
+ *                                mean/stddev z-score, a handful of large past
+ *                                transactions can't numb the model to a new
+ *                                one that's equally large.
+ *   VELOCITY (0.20)           — count/volume of deposits+withdrawals in a
+ *                                window, plus round-trip detection (an
+ *                                opposite-direction transaction of a similar
+ *                                amount shortly before/after).
+ *   STRUCTURING (0.20)        — repeated deposits/withdrawals just under a
+ *                                configured reporting-style threshold.
+ *   NEW_DESTINATION (0.15)    — transfer to a Stellar address with no prior
+ *                                history on this account.
+ *   ACCOUNT_AGE (0.05)        — how new the account is at transaction time.
+ *   SUB_ACCOUNT_FANOUT (0.10) — a parent account whose children are
+ *                                concentrating deposit activity (mule
+ *                                pattern).
+ *   REFERRAL_GRAPH (0.05)     — a referred user's first-ever action being a
+ *                                large withdrawal.
+ *
+ * Weights sum to 1.0 (see DEFAULT_SCORING_CONFIG.weights); each feature's own
+ * score is bounded to [0, 100], so the weighted sum is always a valid 0-100
+ * suspicion score. MODEL_VERSION is carried on every result so a future
+ * recalibration (different weights/thresholds) never rewrites the meaning of
+ * a score already persisted against an old version.
+ *
+ * Agent-driven exemption: VELOCITY and STRUCTURING both look for rapid,
+ * repeated deposit/withdraw-like patterns — exactly what the agent's own
+ * rebalances legitimately produce (src/agent/). A transaction linked to an
+ * AgentLog entry (`isAgentDriven: true`) skips both features entirely
+ * (reason code AGENT_DRIVEN_EXEMPT), and agent-driven rows are excluded from
+ * every other feature's historical baseline so they can't inflate a user's
+ * own velocity/structuring/amount profile either. See
+ * scoreTransaction.agentRebalance tests for the false-positive guard this
+ * exists to satisfy.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+export type TransactionTypeLike =
+  | 'DEPOSIT'
+  | 'WITHDRAWAL'
+  | 'YIELD_CLAIM'
+  | 'REBALANCE'
+  | 'SWAP'
+  | 'REFERRAL_REWARD'
+
+/** A prior transaction on the account, used as scoring context. */
+export interface HistoricalTransaction {
+  type: TransactionTypeLike
+  amount: number
+  assetSymbol: string
+  createdAt: Date
+  destinationAddress?: string | null
+  /** True when linked to an AgentLog entry (agent-initiated, not user-initiated). */
+  isAgentDriven: boolean
+}
+
+/** The transaction being scored right now. */
+export interface ScoredTransaction {
+  id: string
+  userId: string
+  type: TransactionTypeLike
+  amount: number
+  assetSymbol: string
+  createdAt: Date
+  destinationAddress?: string | null
+  isAgentDriven: boolean
+}
+
+export interface SubAccountContext {
+  /** Number of child sub-accounts this user is the parent of. */
+  childCount: number
+  /** Distinct children who made a deposit within the fan-out detection window. */
+  recentChildDepositCount: number
+}
+
+export interface ReferralContext {
+  isReferred: boolean
+  /** True when the transaction being scored is this user's first-ever transaction. */
+  isFirstAction: boolean
+}
+
+export interface AccountContext {
+  userId: string
+  accountCreatedAt: Date
+  /** Prior transactions on this account, in any order, EXCLUDING the one being scored. */
+  transactionHistory: HistoricalTransaction[]
+  /** Every destination address this account has transacted with before. */
+  knownDestinationAddresses: string[]
+  /**
+   * Age (ms) of the destination's own platform account at transaction time,
+   * when the destination is a known platform user. null/undefined when the
+   * destination is external or unknown — treated as "can't assess," not "old."
+   */
+  destinationAccountAgeMs?: number | null
+  subAccount?: SubAccountContext
+  referral?: ReferralContext
+}
+
+export interface TransactionContext {
+  transaction: ScoredTransaction
+  account: AccountContext
+}
+
+export type FeatureCode =
+  | 'AMOUNT_ANOMALY'
+  | 'VELOCITY'
+  | 'STRUCTURING'
+  | 'NEW_DESTINATION'
+  | 'ACCOUNT_AGE'
+  | 'SUB_ACCOUNT_FANOUT'
+  | 'REFERRAL_GRAPH'
+
+export interface FeatureScore {
+  feature: FeatureCode
+  /** This feature's own bounded sub-score, independent of its weight. */
+  score: number
+  /** Configured weight for this feature (sums to 1.0 across all features). */
+  weight: number
+  /** score * weight — this feature's share of the total. */
+  contribution: number
+  triggered: boolean
+  reasonCodes: string[]
+  detail: string
+}
+
+export interface ScoringResult {
+  modelVersion: string
+  transactionId: string
+  userId: string
+  /** 0-100 total suspicion score, rounded. */
+  totalScore: number
+  features: FeatureScore[]
+  /** Flattened reason codes of every triggered feature, for quick display. */
+  reasonCodes: string[]
+}
+
+export interface ScoringConfig {
+  weights: Record<FeatureCode, number>
+  amount: {
+    /** Below this many historical samples, the feature is skipped (not enough data for a norm). */
+    minHistorySamples: number
+    /** |z| at/below which the amount is unremarkable (score 0). */
+    lowZ: number
+    /** |z| at/above which the score saturates at 100. */
+    highZ: number
+  }
+  velocity: {
+    windowMs: number
+    /** Count (including the current transaction) at/below which score is 0. */
+    lowCountThreshold: number
+    /** Count at/above which the frequency score saturates at 100. */
+    highCountThreshold: number
+    /** Volume as a multiple of the account's historical median at which the volume score saturates. */
+    highVolumeMultiple: number
+    roundTrip: {
+      /** How soon before/after an opposite-direction transaction still counts as a round-trip. */
+      windowMs: number
+      /** Fraction (e.g. 0.05 = 5%) two amounts must be within to count as "the same amount." */
+      amountTolerancePct: number
+    }
+  }
+  structuring: {
+    /** The reporting-style amount being structured under (e.g. a CTR-style threshold). */
+    threshold: number
+    /** Fraction below `threshold` considered "just under" it (e.g. 0.10 = 90%-100% of threshold). */
+    bandPct: number
+    windowMs: number
+    /** Occurrences (including the current transaction) at/above which score saturates at 100. */
+    minOccurrences: number
+  }
+  newDestination: {
+    /** Amount at/above which a first-time destination scores at its maximum. */
+    largeAmountThreshold: number
+    /** Destination account age below which it's treated as elevated risk. */
+    youngAccountMs: number
+  }
+  accountAge: {
+    /** Below this age, score ramps from 100 (brand new) down to 0 (at the window edge). */
+    newAccountWindowMs: number
+  }
+  subAccountFanOut: {
+    /** Child count at/above which fan-out scoring engages at all. */
+    childCountThreshold: number
+    /** Recent child deposit count at/above which score saturates at 100. */
+    childDepositConcentrationThreshold: number
+  }
+  referralGraph: {
+    /** Amount at/above which a referred user's first-action withdrawal saturates at 100. */
+    firstActionLargeWithdrawalThreshold: number
+  }
+}
+
+// ── Default configuration ────────────────────────────────────────────────
+
+export const MODEL_VERSION = 'v1'
+
+export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
+  weights: {
+    AMOUNT_ANOMALY: 0.25,
+    VELOCITY: 0.2,
+    STRUCTURING: 0.2,
+    NEW_DESTINATION: 0.15,
+    ACCOUNT_AGE: 0.05,
+    SUB_ACCOUNT_FANOUT: 0.1,
+    REFERRAL_GRAPH: 0.05,
+  },
+  amount: {
+    minHistorySamples: 5,
+    lowZ: 2.5,
+    highZ: 6,
+  },
+  velocity: {
+    windowMs: 24 * 60 * 60 * 1000, // 24h
+    lowCountThreshold: 3,
+    highCountThreshold: 8,
+    highVolumeMultiple: 5,
+    roundTrip: {
+      windowMs: 2 * 60 * 60 * 1000, // 2h
+      amountTolerancePct: 0.05,
+    },
+  },
+  structuring: {
+    // Loosely modeled on the classic $10,000 CTR-style reporting threshold;
+    // operator-configurable per environment/asset, not a legal determination.
+    threshold: 10_000,
+    bandPct: 0.1,
+    windowMs: 7 * 24 * 60 * 60 * 1000, // 7d
+    minOccurrences: 3,
+  },
+  newDestination: {
+    largeAmountThreshold: 5_000,
+    youngAccountMs: 7 * 24 * 60 * 60 * 1000, // 7d
+  },
+  accountAge: {
+    newAccountWindowMs: 7 * 24 * 60 * 60 * 1000, // 7d
+  },
+  subAccountFanOut: {
+    childCountThreshold: 5,
+    childDepositConcentrationThreshold: 5,
+  },
+  referralGraph: {
+    firstActionLargeWithdrawalThreshold: 2_000,
+  },
+}
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : T[K]
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// Untyped at the recursive core (arbitrary nesting depth), typed only at the
+// deepMerge boundary below — a generic constrained to Record<string, unknown>
+// doesn't unify cleanly with a fixed-shape interface like ScoringConfig.
+function mergeDeep(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+  for (const key of Object.keys(override)) {
+    const overrideValue = override[key]
+    const baseValue = base[key]
+    result[key] =
+      isPlainObject(overrideValue) && isPlainObject(baseValue)
+        ? mergeDeep(baseValue, overrideValue)
+        : overrideValue
+  }
+  return result
+}
+
+function deepMerge(
+  base: ScoringConfig,
+  override: DeepPartial<ScoringConfig> | undefined
+): ScoringConfig {
+  if (!override) return base
+  return mergeDeep(
+    base as unknown as Record<string, unknown>,
+    override as Record<string, unknown>
+  ) as unknown as ScoringConfig
+}
+
+// ── Math helpers ──────────────────────────────────────────────────────────
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+// Scales MAD to be comparable to a standard-deviation-based z-score under a
+// normal distribution, per the standard "modified z-score" definition.
+const MAD_CONSISTENCY_CONSTANT = 0.6745
+// Equivalent consistency constant for mean absolute deviation, used only as
+// a fallback (see modifiedZScore below).
+const MEAN_AD_CONSISTENCY_CONSTANT = 1.253314
+
+/**
+ * Modified (MAD-based) z-score of `value` against a historical population.
+ * Robust to outliers, unlike a mean/stddev z-score: a few unusually large
+ * historical transactions can't numb the model to a new one just like them.
+ */
+export function modifiedZScore(value: number, population: number[]): number {
+  if (population.length === 0) return 0
+  const med = median(population)
+  const mad = median(population.map((v) => Math.abs(v - med)))
+
+  if (mad !== 0) {
+    return (MAD_CONSISTENCY_CONSTANT * (value - med)) / mad
+  }
+
+  // MAD is 0 when at least half the population is identical (e.g. an account
+  // that always deposits exactly the same amount). Falling back to z=0 here
+  // would mean such an account can never trigger an amount anomaly no matter
+  // how far a new transaction deviates — fall back to mean absolute deviation
+  // instead so a real deviation still registers.
+  const meanAbsDev =
+    population.reduce((sum, v) => sum + Math.abs(v - med), 0) /
+    population.length
+  if (meanAbsDev === 0) return value === med ? 0 : Infinity
+  return (value - med) / (meanAbsDev * MEAN_AD_CONSISTENCY_CONSTANT)
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Linear ramp from 0 (at/below `low`) to 100 (at/above `high`). */
+export function linearRamp(value: number, low: number, high: number): number {
+  if (!Number.isFinite(value)) return value > 0 ? 100 : 0
+  if (value <= low) return 0
+  if (value >= high) return 100
+  return ((value - low) / (high - low)) * 100
+}
+
+export function isWithinTolerance(a: number, b: number, pct: number): boolean {
+  const base = Math.max(Math.abs(a), Math.abs(b))
+  if (base === 0) return true
+  return Math.abs(a - b) / base <= pct
+}
+
+function featureResult(
+  feature: FeatureCode,
+  score: number,
+  reasonCodes: string[],
+  detail: string
+): Omit<FeatureScore, 'weight' | 'contribution'> {
+  const clamped = clamp(score, 0, 100)
+  return {
+    feature,
+    score: clamped,
+    triggered: clamped > 0,
+    reasonCodes,
+    detail,
+  }
+}
+
+const AGENT_EXEMPT_RESULT = (feature: FeatureCode) =>
+  featureResult(
+    feature,
+    0,
+    ['AGENT_DRIVEN_EXEMPT'],
+    'Agent-initiated transaction (AgentLog-linked) — excluded from this feature.'
+  )
+
+// ── Feature: AMOUNT_ANOMALY ─────────────────────────────────────────────
+
+export function computeAmountAnomalyFeature(
+  transaction: ScoredTransaction,
+  history: HistoricalTransaction[],
+  cfg: ScoringConfig['amount']
+) {
+  const population = history
+    .filter(
+      (h) =>
+        !h.isAgentDriven &&
+        h.type === transaction.type &&
+        h.assetSymbol === transaction.assetSymbol
+    )
+    .map((h) => h.amount)
+
+  if (population.length < cfg.minHistorySamples) {
+    return featureResult(
+      'AMOUNT_ANOMALY',
+      0,
+      [],
+      `Insufficient history (${population.length} sample(s), need ${cfg.minHistorySamples}) to establish a norm.`
+    )
+  }
+
+  const z = modifiedZScore(transaction.amount, population)
+  const absZ = Math.abs(z)
+  const score = linearRamp(absZ, cfg.lowZ, cfg.highZ)
+
+  return featureResult(
+    'AMOUNT_ANOMALY',
+    score,
+    score > 0 ? ['AMOUNT_ZSCORE_HIGH'] : [],
+    `Modified z-score ${Number.isFinite(absZ) ? absZ.toFixed(2) : 'Infinity'} against ${population.length} historical ${transaction.type} amount(s).`
+  )
+}
+
+// ── Feature: VELOCITY ────────────────────────────────────────────────────
+
+export function computeVelocityFeature(
+  transaction: ScoredTransaction,
+  history: HistoricalTransaction[],
+  cfg: ScoringConfig['velocity']
+) {
+  if (transaction.isAgentDriven) return AGENT_EXEMPT_RESULT('VELOCITY')
+
+  const isMoneyMovement = (t: TransactionTypeLike) =>
+    t === 'DEPOSIT' || t === 'WITHDRAWAL'
+  if (!isMoneyMovement(transaction.type)) {
+    return featureResult(
+      'VELOCITY',
+      0,
+      [],
+      'Velocity only applies to deposits/withdrawals.'
+    )
+  }
+
+  const userDriven = history.filter((h) => !h.isAgentDriven)
+  const windowStart = transaction.createdAt.getTime() - cfg.windowMs
+  const inWindow = userDriven.filter(
+    (h) =>
+      isMoneyMovement(h.type) &&
+      h.assetSymbol === transaction.assetSymbol &&
+      h.createdAt.getTime() >= windowStart &&
+      h.createdAt.getTime() <= transaction.createdAt.getTime()
+  )
+
+  const count = inWindow.length + 1
+  const volume =
+    inWindow.reduce((sum, h) => sum + h.amount, 0) + transaction.amount
+
+  const historicalAmounts = userDriven
+    .filter((h) => isMoneyMovement(h.type))
+    .map((h) => h.amount)
+  const baselineMedian = median(historicalAmounts)
+
+  const countScore = linearRamp(
+    count,
+    cfg.lowCountThreshold,
+    cfg.highCountThreshold
+  )
+  const volumeScore =
+    baselineMedian > 0
+      ? linearRamp(volume / baselineMedian, 1, cfg.highVolumeMultiple)
+      : 0
+
+  const oppositeType: TransactionTypeLike | null =
+    transaction.type === 'DEPOSIT'
+      ? 'WITHDRAWAL'
+      : transaction.type === 'WITHDRAWAL'
+        ? 'DEPOSIT'
+        : null
+  const roundTripWindowStart =
+    transaction.createdAt.getTime() - cfg.roundTrip.windowMs
+  const roundTripMatch = oppositeType
+    ? userDriven.find(
+        (h) =>
+          h.type === oppositeType &&
+          h.assetSymbol === transaction.assetSymbol &&
+          h.createdAt.getTime() >= roundTripWindowStart &&
+          h.createdAt.getTime() <= transaction.createdAt.getTime() &&
+          isWithinTolerance(
+            h.amount,
+            transaction.amount,
+            cfg.roundTrip.amountTolerancePct
+          )
+      )
+    : undefined
+
+  const score = Math.max(countScore, volumeScore, roundTripMatch ? 100 : 0)
+  const reasonCodes: string[] = []
+  if (countScore > 0) reasonCodes.push('VELOCITY_HIGH_FREQUENCY')
+  if (volumeScore > 0) reasonCodes.push('VELOCITY_HIGH_VOLUME')
+  if (roundTripMatch) reasonCodes.push('VELOCITY_ROUND_TRIP')
+
+  return featureResult(
+    'VELOCITY',
+    score,
+    reasonCodes,
+    `${count} deposit/withdrawal(s) totalling ${volume} in the last ${cfg.windowMs}ms` +
+      (roundTripMatch
+        ? '; matches an opposite-direction transaction of a similar amount within the round-trip window'
+        : '.')
+  )
+}
+
+// ── Feature: STRUCTURING ─────────────────────────────────────────────────
+
+export function computeStructuringFeature(
+  transaction: ScoredTransaction,
+  history: HistoricalTransaction[],
+  cfg: ScoringConfig['structuring']
+) {
+  if (transaction.isAgentDriven) return AGENT_EXEMPT_RESULT('STRUCTURING')
+
+  if (transaction.type !== 'DEPOSIT' && transaction.type !== 'WITHDRAWAL') {
+    return featureResult(
+      'STRUCTURING',
+      0,
+      [],
+      'Structuring only applies to deposits/withdrawals.'
+    )
+  }
+
+  const bandLow = cfg.threshold * (1 - cfg.bandPct)
+  const isJustUnder = (amount: number) =>
+    amount >= bandLow && amount < cfg.threshold
+
+  if (!isJustUnder(transaction.amount)) {
+    return featureResult(
+      'STRUCTURING',
+      0,
+      [],
+      `Amount is outside the structuring band (${bandLow}-${cfg.threshold}).`
+    )
+  }
+
+  const windowStart = transaction.createdAt.getTime() - cfg.windowMs
+  const priorOccurrences = history.filter(
+    (h) =>
+      !h.isAgentDriven &&
+      h.type === transaction.type &&
+      h.assetSymbol === transaction.assetSymbol &&
+      h.createdAt.getTime() >= windowStart &&
+      h.createdAt.getTime() <= transaction.createdAt.getTime() &&
+      isJustUnder(h.amount)
+  ).length
+
+  const occurrences = priorOccurrences + 1
+  const score = linearRamp(occurrences, 1, cfg.minOccurrences)
+
+  return featureResult(
+    'STRUCTURING',
+    score,
+    score > 0 ? ['STRUCTURING_SUB_THRESHOLD_PATTERN'] : [],
+    `${occurrences} ${transaction.type.toLowerCase()}(s) between ${bandLow} and ${cfg.threshold} within the last ${cfg.windowMs}ms.`
+  )
+}
+
+// ── Feature: NEW_DESTINATION ─────────────────────────────────────────────
+
+export function computeNewDestinationFeature(
+  transaction: ScoredTransaction,
+  account: AccountContext,
+  cfg: ScoringConfig['newDestination']
+) {
+  if (!transaction.destinationAddress) {
+    return featureResult(
+      'NEW_DESTINATION',
+      0,
+      [],
+      'Transaction has no external destination address.'
+    )
+  }
+
+  if (
+    account.knownDestinationAddresses.includes(transaction.destinationAddress)
+  ) {
+    return featureResult(
+      'NEW_DESTINATION',
+      0,
+      [],
+      'Destination has prior history with this account.'
+    )
+  }
+
+  let score = transaction.amount >= cfg.largeAmountThreshold ? 100 : 60
+  const reasonCodes = ['NEW_DESTINATION_NO_HISTORY']
+
+  const destAge = account.destinationAccountAgeMs
+  if (destAge != null && destAge < cfg.youngAccountMs) {
+    score = 100
+    reasonCodes.push('NEW_DESTINATION_YOUNG_ACCOUNT')
+  }
+
+  return featureResult(
+    'NEW_DESTINATION',
+    score,
+    reasonCodes,
+    `First transaction to this destination${destAge != null ? `; destination account age ${destAge}ms` : ' (destination account age unknown)'}.`
+  )
+}
+
+// ── Feature: ACCOUNT_AGE ─────────────────────────────────────────────────
+
+export function computeAccountAgeFeature(
+  transaction: ScoredTransaction,
+  account: AccountContext,
+  cfg: ScoringConfig['accountAge']
+) {
+  const ageMs = Math.max(
+    0,
+    transaction.createdAt.getTime() - account.accountCreatedAt.getTime()
+  )
+
+  if (ageMs >= cfg.newAccountWindowMs) {
+    return featureResult(
+      'ACCOUNT_AGE',
+      0,
+      [],
+      `Account age ${ageMs}ms is at/beyond the new-account window (${cfg.newAccountWindowMs}ms).`
+    )
+  }
+
+  // Newer accounts score higher; risk decays linearly to 0 at the window edge.
+  const score = 100 * (1 - ageMs / cfg.newAccountWindowMs)
+
+  return featureResult(
+    'ACCOUNT_AGE',
+    score,
+    score > 0 ? ['NEW_ACCOUNT'] : [],
+    `Account is ${ageMs}ms old (window: ${cfg.newAccountWindowMs}ms).`
+  )
+}
+
+// ── Feature: SUB_ACCOUNT_FANOUT ──────────────────────────────────────────
+
+export function computeSubAccountFanOutFeature(
+  account: AccountContext,
+  cfg: ScoringConfig['subAccountFanOut']
+) {
+  const sub = account.subAccount
+  if (!sub || sub.childCount < cfg.childCountThreshold) {
+    return featureResult(
+      'SUB_ACCOUNT_FANOUT',
+      0,
+      [],
+      sub
+        ? `Child count ${sub.childCount} is below the fan-out threshold (${cfg.childCountThreshold}).`
+        : 'Account has no sub-accounts.'
+    )
+  }
+
+  const score = linearRamp(
+    sub.recentChildDepositCount,
+    1,
+    cfg.childDepositConcentrationThreshold
+  )
+
+  return featureResult(
+    'SUB_ACCOUNT_FANOUT',
+    score,
+    score > 0 ? ['SUB_ACCOUNT_FANOUT_MULE_PATTERN'] : [],
+    `${sub.childCount} child sub-account(s), ${sub.recentChildDepositCount} recent child deposit(s).`
+  )
+}
+
+// ── Feature: REFERRAL_GRAPH ──────────────────────────────────────────────
+
+export function computeReferralGraphFeature(
+  transaction: ScoredTransaction,
+  account: AccountContext,
+  cfg: ScoringConfig['referralGraph']
+) {
+  const referral = account.referral
+  if (
+    !referral?.isReferred ||
+    !referral.isFirstAction ||
+    transaction.type !== 'WITHDRAWAL'
+  ) {
+    return featureResult(
+      'REFERRAL_GRAPH',
+      0,
+      [],
+      "Not a referred user's first-action withdrawal."
+    )
+  }
+
+  const score = linearRamp(
+    transaction.amount,
+    cfg.firstActionLargeWithdrawalThreshold * 0.5,
+    cfg.firstActionLargeWithdrawalThreshold
+  )
+
+  return featureResult(
+    'REFERRAL_GRAPH',
+    score,
+    score > 0 ? ['REFERRAL_FIRST_ACTION_LARGE_WITHDRAWAL'] : [],
+    `Referred user's first action is a withdrawal of ${transaction.amount}.`
+  )
+}
+
+// ── Combine ───────────────────────────────────────────────────────────────
+
+/**
+ * Score a transaction 0-100 with per-feature reason codes. Deterministic:
+ * calling this twice with the same context and config produces an identical
+ * result, since nothing here reads the clock, randomness, or external state.
+ */
+export function scoreTransaction(
+  context: TransactionContext,
+  configOverrides?: DeepPartial<ScoringConfig>
+): ScoringResult {
+  const cfg = deepMerge(DEFAULT_SCORING_CONFIG, configOverrides)
+  const { transaction, account } = context
+  const history = account.transactionHistory
+
+  const raw = [
+    computeAmountAnomalyFeature(transaction, history, cfg.amount),
+    computeVelocityFeature(transaction, history, cfg.velocity),
+    computeStructuringFeature(transaction, history, cfg.structuring),
+    computeNewDestinationFeature(transaction, account, cfg.newDestination),
+    computeAccountAgeFeature(transaction, account, cfg.accountAge),
+    computeSubAccountFanOutFeature(account, cfg.subAccountFanOut),
+    computeReferralGraphFeature(transaction, account, cfg.referralGraph),
+  ]
+
+  const features: FeatureScore[] = raw.map((f) => {
+    const weight = cfg.weights[f.feature]
+    return { ...f, weight, contribution: f.score * weight }
+  })
+
+  const totalScore = clamp(
+    Math.round(features.reduce((sum, f) => sum + f.contribution, 0)),
+    0,
+    100
+  )
+  const reasonCodes = features.flatMap((f) => f.reasonCodes)
+
+  return {
+    modelVersion: MODEL_VERSION,
+    transactionId: transaction.id,
+    userId: transaction.userId,
+    totalScore,
+    features,
+    reasonCodes,
+  }
+}

--- a/tests/unit/compliance/scoring.test.ts
+++ b/tests/unit/compliance/scoring.test.ts
@@ -1,0 +1,764 @@
+/**
+ * Transaction risk-scoring engine unit tests (#321).
+ *
+ * scoring.ts is pure (no DB, no clock reads), so every test builds its own
+ * context and asserts directly on the result — same style as
+ * tests/unit/services/alertEvaluator.test.ts. The one non-negotiable
+ * property from the issue: the agent's own rebalances must never
+ * false-positive on velocity/structuring, however suspicious the raw pattern
+ * looks — that gets its own dedicated describe block at the bottom.
+ */
+
+import {
+  scoreTransaction,
+  computeAmountAnomalyFeature,
+  computeVelocityFeature,
+  computeStructuringFeature,
+  computeNewDestinationFeature,
+  computeAccountAgeFeature,
+  computeSubAccountFanOutFeature,
+  computeReferralGraphFeature,
+  median,
+  modifiedZScore,
+  linearRamp,
+  clamp,
+  isWithinTolerance,
+  DEFAULT_SCORING_CONFIG,
+  MODEL_VERSION,
+  type ScoredTransaction,
+  type HistoricalTransaction,
+  type AccountContext,
+  type TransactionContext,
+  type FeatureCode,
+  type ScoringResult,
+} from '../../../src/compliance/scoring'
+
+const NOW = new Date('2026-01-15T12:00:00.000Z')
+const DAY = 24 * 60 * 60 * 1000
+
+function tx(overrides: Partial<ScoredTransaction> = {}): ScoredTransaction {
+  return {
+    id: 'tx-1',
+    userId: 'user-1',
+    type: 'DEPOSIT',
+    amount: 100,
+    assetSymbol: 'USDC',
+    createdAt: NOW,
+    destinationAddress: null,
+    isAgentDriven: false,
+    ...overrides,
+  }
+}
+
+function hist(
+  overrides: Partial<HistoricalTransaction> = {}
+): HistoricalTransaction {
+  return {
+    type: 'DEPOSIT',
+    amount: 100,
+    assetSymbol: 'USDC',
+    createdAt: new Date(NOW.getTime() - 10 * DAY),
+    destinationAddress: null,
+    isAgentDriven: false,
+    ...overrides,
+  }
+}
+
+function account(overrides: Partial<AccountContext> = {}): AccountContext {
+  return {
+    userId: 'user-1',
+    // 1 year old — well outside every "new account" window used below.
+    accountCreatedAt: new Date(NOW.getTime() - 365 * DAY),
+    transactionHistory: [],
+    knownDestinationAddresses: [],
+    destinationAccountAgeMs: null,
+    subAccount: undefined,
+    referral: undefined,
+    ...overrides,
+  }
+}
+
+function feature(result: ScoringResult, code: FeatureCode) {
+  const found = result.features.find((f) => f.feature === code)
+  if (!found) throw new Error(`Feature ${code} missing from result`)
+  return found
+}
+
+// ── Math helpers ─────────────────────────────────────────────────────────
+
+describe('median', () => {
+  it('returns 0 for an empty array', () => {
+    expect(median([])).toBe(0)
+  })
+
+  it('returns the middle value for an odd-length array', () => {
+    expect(median([3, 1, 2])).toBe(2)
+  })
+
+  it('averages the two middle values for an even-length array', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5)
+  })
+})
+
+describe('modifiedZScore', () => {
+  it('returns 0 for an empty population', () => {
+    expect(modifiedZScore(100, [])).toBe(0)
+  })
+
+  it('returns ~0 for a value at the population median', () => {
+    expect(modifiedZScore(100, [80, 90, 100, 110, 120])).toBeCloseTo(0, 5)
+  })
+
+  it('returns a large positive z for a value far above a tight population', () => {
+    const population = [98, 99, 100, 101, 102]
+    expect(modifiedZScore(500, population)).toBeGreaterThan(5)
+  })
+
+  it('is robust to a single outlier (MAD, not stddev)', () => {
+    // A mean/stddev z-score would be heavily dragged toward the 5000 outlier;
+    // the median-based approach should still flag 100 vs. a population that's
+    // otherwise tightly clustered around 10.
+    const population = [10, 11, 9, 10, 5000]
+    const z = modifiedZScore(100, population)
+    expect(Math.abs(z)).toBeGreaterThan(5)
+  })
+
+  it('falls back to mean-absolute-deviation when MAD is 0 but the population has some spread', () => {
+    // Median of |x - median| is 0 (more than half the population is 100), but
+    // the population isn't fully identical (one 200). A naive implementation
+    // would divide by zero or always return 0, making such an account immune
+    // to ever triggering an amount anomaly.
+    const population = [100, 100, 100, 100, 200]
+    expect(modifiedZScore(100, population)).toBe(0)
+    expect(modifiedZScore(10_000, population)).toBeGreaterThan(0)
+    expect(Number.isFinite(modifiedZScore(10_000, population))).toBe(true)
+  })
+
+  it('returns Infinity when the population has zero spread and the value differs', () => {
+    // Degenerate case: MAD and mean-AD are both 0 (identical population) and
+    // the new value isn't equal to it — there's no scale to divide by at all.
+    expect(modifiedZScore(200, [100, 100])).toBe(Infinity)
+  })
+})
+
+describe('linearRamp', () => {
+  it('is 0 at/below the low bound', () => {
+    expect(linearRamp(1, 2, 10)).toBe(0)
+    expect(linearRamp(2, 2, 10)).toBe(0)
+  })
+
+  it('is 100 at/above the high bound', () => {
+    expect(linearRamp(10, 2, 10)).toBe(100)
+    expect(linearRamp(50, 2, 10)).toBe(100)
+  })
+
+  it('ramps linearly in between', () => {
+    expect(linearRamp(6, 2, 10)).toBe(50)
+  })
+
+  it('treats +Infinity as saturated and non-positive infinities as 0', () => {
+    expect(linearRamp(Infinity, 2, 10)).toBe(100)
+    expect(linearRamp(-Infinity, 2, 10)).toBe(0)
+  })
+})
+
+describe('clamp', () => {
+  it('bounds a value to [min, max]', () => {
+    expect(clamp(-5, 0, 100)).toBe(0)
+    expect(clamp(150, 0, 100)).toBe(100)
+    expect(clamp(50, 0, 100)).toBe(50)
+  })
+})
+
+describe('isWithinTolerance', () => {
+  it('treats two zeros as within tolerance', () => {
+    expect(isWithinTolerance(0, 0, 0.05)).toBe(true)
+  })
+
+  it('accepts a difference within the percentage band', () => {
+    expect(isWithinTolerance(100, 104, 0.05)).toBe(true)
+  })
+
+  it('rejects a difference outside the percentage band', () => {
+    expect(isWithinTolerance(100, 120, 0.05)).toBe(false)
+  })
+})
+
+// ── AMOUNT_ANOMALY ───────────────────────────────────────────────────────
+
+describe('computeAmountAnomalyFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.amount
+
+  it('is not triggered with fewer than minHistorySamples', () => {
+    const history = [hist(), hist(), hist()] // 3 < default 5
+    const result = computeAmountAnomalyFeature(
+      tx({ amount: 100_000 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+    expect(result.score).toBe(0)
+  })
+
+  it('is not triggered for an amount consistent with history', () => {
+    const history = [100, 95, 105, 98, 102, 101].map((amount) =>
+      hist({ amount })
+    )
+    const result = computeAmountAnomalyFeature(
+      tx({ amount: 100 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered for an amount far outside the historical norm', () => {
+    const history = [100, 95, 105, 98, 102, 101].map((amount) =>
+      hist({ amount })
+    )
+    const result = computeAmountAnomalyFeature(
+      tx({ amount: 50_000 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.score).toBeGreaterThan(0)
+    expect(result.reasonCodes).toContain('AMOUNT_ZSCORE_HIGH')
+  })
+
+  it('only compares against the same transaction type and asset', () => {
+    const history = [
+      hist({ type: 'WITHDRAWAL', amount: 50_000 }), // wrong type, would look normal-ish
+      hist({ assetSymbol: 'XLM', amount: 50_000 }), // wrong asset
+      hist({ amount: 100 }),
+      hist({ amount: 105 }),
+      hist({ amount: 98 }),
+      hist({ amount: 102 }),
+      hist({ amount: 101 }),
+    ]
+    const result = computeAmountAnomalyFeature(
+      tx({ amount: 50_000 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+  })
+
+  it('excludes agent-driven rows from the historical baseline', () => {
+    const history = [
+      hist({ amount: 50_000, isAgentDriven: true }),
+      hist({ amount: 100 }),
+      hist({ amount: 105 }),
+      hist({ amount: 98 }),
+      hist({ amount: 102 }),
+      hist({ amount: 101 }),
+    ]
+    // If the agent row leaked into the baseline, 50_000 would look normal.
+    const result = computeAmountAnomalyFeature(
+      tx({ amount: 50_000 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+  })
+})
+
+// ── VELOCITY ─────────────────────────────────────────────────────────────
+
+describe('computeVelocityFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.velocity
+
+  it('is not triggered for an isolated deposit with no recent history', () => {
+    const result = computeVelocityFeature(tx(), [], cfg)
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered by a high-frequency burst within the window', () => {
+    const history = Array.from({ length: 8 }, (_, i) =>
+      hist({ createdAt: new Date(NOW.getTime() - (i + 1) * 60 * 60 * 1000) })
+    )
+    const result = computeVelocityFeature(tx(), history, cfg)
+    expect(result.triggered).toBe(true)
+    expect(result.reasonCodes).toContain('VELOCITY_HIGH_FREQUENCY')
+  })
+
+  it('ignores transactions outside the velocity window', () => {
+    const history = Array.from({ length: 8 }, () =>
+      hist({ createdAt: new Date(NOW.getTime() - 30 * DAY) })
+    )
+    const result = computeVelocityFeature(tx(), history, cfg)
+    expect(result.triggered).toBe(false)
+  })
+
+  it('detects a round-trip: withdrawal shortly after a deposit of a similar amount', () => {
+    const history = [
+      hist({
+        type: 'DEPOSIT',
+        amount: 1000,
+        createdAt: new Date(NOW.getTime() - 30 * 60 * 1000),
+      }),
+    ]
+    const result = computeVelocityFeature(
+      tx({ type: 'WITHDRAWAL', amount: 1000 }),
+      history,
+      cfg
+    )
+    expect(result.reasonCodes).toContain('VELOCITY_ROUND_TRIP')
+    expect(result.score).toBe(100)
+  })
+
+  it('does not flag a round-trip when the amount differs beyond tolerance', () => {
+    const history = [
+      hist({
+        type: 'DEPOSIT',
+        amount: 1000,
+        createdAt: new Date(NOW.getTime() - 30 * 60 * 1000),
+      }),
+    ]
+    const result = computeVelocityFeature(
+      tx({ type: 'WITHDRAWAL', amount: 400 }),
+      history,
+      cfg
+    )
+    expect(result.reasonCodes).not.toContain('VELOCITY_ROUND_TRIP')
+  })
+
+  it('does not flag a round-trip outside the round-trip window', () => {
+    const history = [
+      hist({
+        type: 'DEPOSIT',
+        amount: 1000,
+        createdAt: new Date(NOW.getTime() - 10 * DAY),
+      }),
+    ]
+    const result = computeVelocityFeature(
+      tx({ type: 'WITHDRAWAL', amount: 1000 }),
+      history,
+      cfg
+    )
+    expect(result.reasonCodes).not.toContain('VELOCITY_ROUND_TRIP')
+  })
+
+  it('is exempt for an agent-driven transaction regardless of history', () => {
+    const history = Array.from({ length: 20 }, (_, i) =>
+      hist({ createdAt: new Date(NOW.getTime() - (i + 1) * 60 * 1000) })
+    )
+    const result = computeVelocityFeature(
+      tx({ isAgentDriven: true }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+    expect(result.reasonCodes).toEqual(['AGENT_DRIVEN_EXEMPT'])
+  })
+
+  it('does not apply to non-money-movement transaction types', () => {
+    const result = computeVelocityFeature(tx({ type: 'YIELD_CLAIM' }), [], cfg)
+    expect(result.triggered).toBe(false)
+  })
+})
+
+// ── STRUCTURING ──────────────────────────────────────────────────────────
+
+describe('computeStructuringFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.structuring // threshold 10_000, band 10%, minOccurrences 3
+
+  it('is not triggered when the amount is not in the structuring band', () => {
+    const result = computeStructuringFeature(tx({ amount: 500 }), [], cfg)
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is not triggered for a single in-band transaction with no repeats', () => {
+    const result = computeStructuringFeature(tx({ amount: 9_500 }), [], cfg)
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered by repeated in-band transactions within the window', () => {
+    const history = [
+      hist({ amount: 9_400, createdAt: new Date(NOW.getTime() - 1 * DAY) }),
+      hist({ amount: 9_600, createdAt: new Date(NOW.getTime() - 2 * DAY) }),
+    ]
+    const result = computeStructuringFeature(
+      tx({ amount: 9_500 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.reasonCodes).toContain('STRUCTURING_SUB_THRESHOLD_PATTERN')
+  })
+
+  it('does not count occurrences outside the structuring window', () => {
+    const history = [
+      hist({ amount: 9_400, createdAt: new Date(NOW.getTime() - 60 * DAY) }),
+      hist({ amount: 9_600, createdAt: new Date(NOW.getTime() - 60 * DAY) }),
+    ]
+    const result = computeStructuringFeature(
+      tx({ amount: 9_500 }),
+      history,
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is exempt for an agent-driven transaction', () => {
+    const history = [hist({ amount: 9_400 }), hist({ amount: 9_600 })]
+    const result = computeStructuringFeature(
+      tx({ amount: 9_500, isAgentDriven: true }),
+      history,
+      cfg
+    )
+    expect(result.reasonCodes).toEqual(['AGENT_DRIVEN_EXEMPT'])
+  })
+})
+
+// ── NEW_DESTINATION ──────────────────────────────────────────────────────
+
+describe('computeNewDestinationFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.newDestination
+
+  it('is not triggered when there is no destination address', () => {
+    const result = computeNewDestinationFeature(
+      tx({ destinationAddress: null }),
+      account(),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is not triggered for a known destination', () => {
+    const result = computeNewDestinationFeature(
+      tx({ destinationAddress: 'GABC' }),
+      account({ knownDestinationAddresses: ['GABC'] }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered (moderately) for a new destination with a small amount', () => {
+    const result = computeNewDestinationFeature(
+      tx({ destinationAddress: 'GNEW', amount: 100 }),
+      account(),
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.score).toBeLessThan(100)
+    expect(result.reasonCodes).toContain('NEW_DESTINATION_NO_HISTORY')
+  })
+
+  it('saturates for a new destination with a large amount', () => {
+    const result = computeNewDestinationFeature(
+      tx({ destinationAddress: 'GNEW', amount: 1_000_000 }),
+      account(),
+      cfg
+    )
+    expect(result.score).toBe(100)
+  })
+
+  it('saturates and adds a reason code when the destination account is young', () => {
+    const result = computeNewDestinationFeature(
+      tx({ destinationAddress: 'GNEW', amount: 100 }),
+      account({ destinationAccountAgeMs: DAY }),
+      cfg
+    )
+    expect(result.score).toBe(100)
+    expect(result.reasonCodes).toContain('NEW_DESTINATION_YOUNG_ACCOUNT')
+  })
+})
+
+// ── ACCOUNT_AGE ──────────────────────────────────────────────────────────
+
+describe('computeAccountAgeFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.accountAge // 7d window
+
+  it('is not triggered for an account well outside the new-account window', () => {
+    const result = computeAccountAgeFeature(
+      tx(),
+      account({ accountCreatedAt: new Date(NOW.getTime() - 365 * DAY) }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('scores at (near) 100 for a brand-new account', () => {
+    const result = computeAccountAgeFeature(
+      tx(),
+      account({ accountCreatedAt: NOW }),
+      cfg
+    )
+    expect(result.score).toBe(100)
+    expect(result.reasonCodes).toContain('NEW_ACCOUNT')
+  })
+
+  it('decays linearly within the window', () => {
+    const result = computeAccountAgeFeature(
+      tx(),
+      account({ accountCreatedAt: new Date(NOW.getTime() - 3.5 * DAY) }),
+      cfg
+    )
+    expect(result.score).toBeCloseTo(50, 0)
+  })
+})
+
+// ── SUB_ACCOUNT_FANOUT ───────────────────────────────────────────────────
+
+describe('computeSubAccountFanOutFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.subAccountFanOut // childCount 5, concentration 5
+
+  it('is not triggered when the account has no sub-accounts', () => {
+    const result = computeSubAccountFanOutFeature(account(), cfg)
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is not triggered below the child-count threshold', () => {
+    const result = computeSubAccountFanOutFeature(
+      account({ subAccount: { childCount: 2, recentChildDepositCount: 2 } }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered by a mule-like fan-out pattern', () => {
+    const result = computeSubAccountFanOutFeature(
+      account({ subAccount: { childCount: 6, recentChildDepositCount: 6 } }),
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.reasonCodes).toContain('SUB_ACCOUNT_FANOUT_MULE_PATTERN')
+  })
+})
+
+// ── REFERRAL_GRAPH ───────────────────────────────────────────────────────
+
+describe('computeReferralGraphFeature', () => {
+  const cfg = DEFAULT_SCORING_CONFIG.referralGraph // 2_000 threshold
+
+  it('is not triggered for a non-referred user', () => {
+    const result = computeReferralGraphFeature(
+      tx({ type: 'WITHDRAWAL', amount: 5_000 }),
+      account({ referral: { isReferred: false, isFirstAction: true } }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it("is not triggered when it is not the referred user's first action", () => {
+    const result = computeReferralGraphFeature(
+      tx({ type: 'WITHDRAWAL', amount: 5_000 }),
+      account({ referral: { isReferred: true, isFirstAction: false } }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is not triggered for a deposit (only withdrawals count)', () => {
+    const result = computeReferralGraphFeature(
+      tx({ type: 'DEPOSIT', amount: 5_000 }),
+      account({ referral: { isReferred: true, isFirstAction: true } }),
+      cfg
+    )
+    expect(result.triggered).toBe(false)
+  })
+
+  it('is triggered for a referred user whose first action is a large withdrawal', () => {
+    const result = computeReferralGraphFeature(
+      tx({ type: 'WITHDRAWAL', amount: 5_000 }),
+      account({ referral: { isReferred: true, isFirstAction: true } }),
+      cfg
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.score).toBe(100)
+    expect(result.reasonCodes).toContain(
+      'REFERRAL_FIRST_ACTION_LARGE_WITHDRAWAL'
+    )
+  })
+})
+
+// ── scoreTransaction (combinator) ───────────────────────────────────────
+
+describe('scoreTransaction', () => {
+  it('is deterministic: identical input produces identical output', () => {
+    const context: TransactionContext = {
+      transaction: tx({ amount: 9_500 }),
+      account: account({
+        transactionHistory: [hist({ amount: 9_400 }), hist({ amount: 9_600 })],
+      }),
+    }
+    const a = scoreTransaction(context)
+    const b = scoreTransaction(context)
+    expect(a).toEqual(b)
+  })
+
+  it('carries the model version', () => {
+    const result = scoreTransaction({ transaction: tx(), account: account() })
+    expect(result.modelVersion).toBe(MODEL_VERSION)
+  })
+
+  it('the feature weights sum to 1.0', () => {
+    const total = Object.values(DEFAULT_SCORING_CONFIG.weights).reduce(
+      (sum, w) => sum + w,
+      0
+    )
+    expect(total).toBeCloseTo(1, 10)
+  })
+
+  it('totalScore is the rounded weighted sum of feature contributions, bounded 0-100', () => {
+    const result = scoreTransaction({
+      transaction: tx({ destinationAddress: 'GNEW', amount: 1_000_000 }),
+      account: account(),
+    })
+    const expected = Math.round(
+      result.features.reduce((sum, f) => sum + f.contribution, 0)
+    )
+    expect(result.totalScore).toBe(expected)
+    expect(result.totalScore).toBeGreaterThanOrEqual(0)
+    expect(result.totalScore).toBeLessThanOrEqual(100)
+  })
+
+  it('a quiet, unremarkable transaction scores near 0', () => {
+    const result = scoreTransaction({
+      transaction: tx({ amount: 100 }),
+      account: account({
+        transactionHistory: [100, 95, 105, 98, 102, 101].map((amount) =>
+          hist({ amount })
+        ),
+      }),
+    })
+    expect(result.totalScore).toBeLessThan(10)
+  })
+
+  it('flattens triggered reason codes from every feature', () => {
+    const result = scoreTransaction({
+      transaction: tx({ destinationAddress: 'GNEW', amount: 1_000_000 }),
+      account: account(),
+    })
+    expect(result.reasonCodes).toContain('NEW_DESTINATION_NO_HISTORY')
+    const newDest = feature(result, 'NEW_DESTINATION')
+    expect(
+      newDest.reasonCodes.every((c) => result.reasonCodes.includes(c))
+    ).toBe(true)
+  })
+
+  it('accepts config overrides without mutating the shared default config', () => {
+    const before = JSON.stringify(DEFAULT_SCORING_CONFIG)
+    scoreTransaction(
+      { transaction: tx(), account: account() },
+      { amount: { lowZ: 0.1 } }
+    )
+    expect(JSON.stringify(DEFAULT_SCORING_CONFIG)).toBe(before)
+  })
+
+  it('a config override changes scoring behavior', () => {
+    const history = [100, 95, 105, 98, 102, 101].map((amount) =>
+      hist({ amount })
+    )
+    const context: TransactionContext = {
+      transaction: tx({ amount: 102 }), // mild deviation, not enough to trigger default lowZ=2.5
+      account: account({ transactionHistory: history }),
+    }
+    const defaultResult = feature(scoreTransaction(context), 'AMOUNT_ANOMALY')
+    const sensitiveResult = feature(
+      scoreTransaction(context, { amount: { lowZ: 0.1, highZ: 1 } }),
+      'AMOUNT_ANOMALY'
+    )
+    expect(defaultResult.triggered).toBe(false)
+    expect(sensitiveResult.triggered).toBe(true)
+  })
+})
+
+// ── Agent-driven false-positive guard (issue's core edge case) ──────────
+
+describe('scoreTransaction — agent rebalance does not false-positive', () => {
+  it('an agent-driven rebalance with a rapid deposit/withdraw-like pattern scores low', () => {
+    // Deliberately construct the exact shape that WOULD trigger velocity,
+    // round-trip, and structuring if scored as user-driven: many rapid
+    // same-asset transactions, including an opposite-direction match just
+    // minutes before, all marked isAgentDriven. The transaction under test
+    // is itself agent-driven too (the agent's own rebalance leg).
+    const agentHistory: HistoricalTransaction[] = [
+      hist({
+        type: 'WITHDRAWAL',
+        amount: 9_500,
+        createdAt: new Date(NOW.getTime() - 5 * 60 * 1000),
+        isAgentDriven: true,
+      }),
+      ...Array.from({ length: 10 }, (_, i) =>
+        hist({
+          type: i % 2 === 0 ? 'DEPOSIT' : 'WITHDRAWAL',
+          amount: 9_500,
+          createdAt: new Date(NOW.getTime() - (i + 1) * 10 * 60 * 1000),
+          isAgentDriven: true,
+        })
+      ),
+    ]
+
+    const result = scoreTransaction({
+      transaction: tx({
+        type: 'DEPOSIT',
+        amount: 9_500,
+        isAgentDriven: true,
+      }),
+      account: account({ transactionHistory: agentHistory }),
+    })
+
+    const velocity = feature(result, 'VELOCITY')
+    const structuring = feature(result, 'STRUCTURING')
+
+    expect(velocity.triggered).toBe(false)
+    expect(velocity.reasonCodes).toEqual(['AGENT_DRIVEN_EXEMPT'])
+    expect(structuring.triggered).toBe(false)
+    expect(structuring.reasonCodes).toEqual(['AGENT_DRIVEN_EXEMPT'])
+    // Low overall — nothing about legitimate agent rebalancing should read as suspicious.
+    expect(result.totalScore).toBeLessThan(15)
+  })
+
+  it("agent-driven history does not inflate a later user-driven transaction's velocity score", () => {
+    // The account's agent has been rebalancing rapidly (10 legs in the last
+    // hour) but the user has made no manual transactions at all. The user's
+    // first real, manual deposit today must be judged on its own, not on the
+    // agent's unrelated activity sitting in the same history array.
+    const agentHistory: HistoricalTransaction[] = Array.from(
+      { length: 10 },
+      (_, i) =>
+        hist({
+          type: i % 2 === 0 ? 'DEPOSIT' : 'WITHDRAWAL',
+          amount: 500,
+          createdAt: new Date(NOW.getTime() - (i + 1) * 5 * 60 * 1000),
+          isAgentDriven: true,
+        })
+    )
+
+    const result = scoreTransaction({
+      transaction: tx({ type: 'DEPOSIT', amount: 100, isAgentDriven: false }),
+      account: account({ transactionHistory: agentHistory }),
+    })
+
+    const velocity = feature(result, 'VELOCITY')
+    expect(velocity.triggered).toBe(false)
+  })
+
+  it('by contrast, the same rapid pattern DOES trigger when it is user-driven', () => {
+    // Sanity check that the exemption is specific to isAgentDriven, not a
+    // blanket "velocity never fires" bug.
+    const userHistory: HistoricalTransaction[] = [
+      hist({
+        type: 'DEPOSIT',
+        amount: 9_500,
+        createdAt: new Date(NOW.getTime() - 30 * 60 * 1000),
+        isAgentDriven: false,
+      }),
+    ]
+
+    const result = scoreTransaction({
+      transaction: tx({
+        type: 'WITHDRAWAL',
+        amount: 9_500,
+        isAgentDriven: false,
+      }),
+      account: account({ transactionHistory: userHistory }),
+    })
+
+    const velocity = feature(result, 'VELOCITY')
+    expect(velocity.triggered).toBe(true)
+    expect(velocity.reasonCodes).toContain('VELOCITY_ROUND_TRIP')
+  })
+})


### PR DESCRIPTION
closes #321 

# Transaction Risk Scoring Engine — Phase 1

## Summary

This PR implements **Phase 1 of the transaction risk-scoring work**: a pure, deterministic, unit-tested transaction risk-scoring engine.

The implementation is intentionally scoped to the scoring engine only. It does **not** introduce database/schema changes, API routes, background jobs, persistence, or documentation changes. Those can be handled in subsequent phases.

## What Changed

### Transaction Risk Scoring Engine

Added `src/compliance/scoring.ts`, which provides `scoreTransaction()` and the supporting feature functions used to calculate a **0–100 suspicion score**.

The engine evaluates seven independent risk signals:

* **AMOUNT_ANOMALY** — detects unusually large transactions compared with the account's historical transaction amounts using a MAD-based modified z-score, with a mean absolute deviation fallback when MAD is zero.
* **VELOCITY** — evaluates transaction count/volume within a configurable time window and detects rapid opposite-direction round trips.
* **STRUCTURING** — detects repeated deposits or withdrawals occurring just below a configured threshold.
* **NEW_DESTINATION** — increases risk when funds are sent to a Stellar address with no previous history on the account, with additional elevation for young destination accounts.
* **ACCOUNT_AGE** — applies a linear risk ramp based on how recently the account was created.
* **SUB_ACCOUNT_FANOUT** — identifies parent accounts whose child accounts show concentrated deposit activity.
* **REFERRAL_GRAPH** — detects a referred user's first-ever action being a large withdrawal.

Each scoring result includes `MODEL_VERSION = "v1"` so that future scoring-model changes can be versioned without changing the interpretation of previously persisted scores.

## Configuration

All scoring weights, thresholds, and time windows are defined in `DEFAULT_SCORING_CONFIG`.

The configuration can be overridden per call using a deeply merged partial configuration, allowing future recalibration without changing the core scoring implementation.

The feature weights sum to `1.0`.

## Determinism

The scoring engine is fully deterministic.

It does not read the current system clock. All time-window calculations are anchored to the transaction's `createdAt` value.

Therefore, the same input produces the same score and reasons regardless of when the function is executed.

## Agent-Driven Transaction Protection

Agent-driven transactions receive special handling to prevent automated activity from generating false positives.

Transactions associated with an `AgentLog` entry where `isAgentDriven = true`:

* Are exempt from the velocity feature.
* Are exempt from the structuring feature.
* Produce the `AGENT_DRIVEN_EXEMPT` reason code.
* Are excluded from historical baselines used by the scoring features.

Tests also verify that the same rapid transaction pattern triggers risk when it is user-driven but is appropriately exempted when it is agent-driven.

## Tests

Added `tests/unit/compliance/scoring.test.ts` with comprehensive coverage of:

* Individual risk features
* Mathematical helpers
* Score aggregation
* Weight validation
* Configuration overrides
* Deterministic scoring
* Agent-driven transaction exemptions
* Historical baseline handling
* Edge cases

### Validation performed

* `npm run typecheck` — passed
* ESLint — passed
* Prettier — passed
* Dedicated scoring tests — **61/61 passed**
* Full unit test suite — **696/696 passed**

## Files Changed

* `src/compliance/scoring.ts`
* `tests/unit/compliance/scoring.test.ts`

No other application files were modified.

## Scope / Follow-Up Work

This PR intentionally implements **Phase 1 only**.

The following are outside the scope of this PR and can be addressed in later phases:

* Database/schema persistence for risk scores
* API endpoints
* Background scoring jobs
* Integration with transaction/withdrawal flows
* Additional persistence-layer data sources
* Documentation

One current limitation is that the withdrawal path currently sends to the user's own linked wallet address rather than accepting an arbitrary destination. The scoring engine therefore accepts destination-related data as optional inputs; wiring those inputs to a persistent data source can be handled in the persistence/integration phase.

## Review Notes

This implementation is designed as a pure scoring module with no database or network dependencies, making the core risk model independently testable and deterministic.

The PR is intentionally limited to the scoring engine and its tests to keep the Phase 1 change isolated and easy to review.
