### PR TITLE
feat(realtime): authenticated WebSocket streaming with resumable replay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,28 @@ MAX_REQUEST_SIZE=10mb
 # CORS Specific
 CORS_MAX_AGE=3600
 CORS_ALLOW_CREDENTIALS=true
+
+# ── Real-time WebSocket streaming (#316) ─────────────────────────────────────
+# See docs/WEBSOCKET_STREAMING.md. All optional — the defaults shown are what
+# the code uses when the variable is unset.
+WS_PATH=/api/v1/ws
+WS_HEARTBEAT_INTERVAL_MS=30000
+WS_IDLE_TIMEOUT_MS=90000
+WS_MAX_BUFFERED_EVENTS=256
+WS_MAX_BUFFERED_BYTES=1048576
+WS_MAX_CONNECTIONS_PER_USER=5
+WS_HANDSHAKE_MAX=30
+WS_HANDSHAKE_WINDOW_MS=60000
+WS_MESSAGE_MAX=50
+WS_MESSAGE_WINDOW_MS=10000
+WS_MAX_MESSAGE_BYTES=4096
+WS_REPLAY_MAX_EVENTS=1000
+WS_SESSION_RECHECK_MS=60000
+WS_COALESCE_WINDOW_MS=250
+WS_DRAIN_RETRY_AFTER_MS=2000
+# Cross-pod fan-out channel. Requires REDIS_URL; without it delivery is
+# pod-local and clients close the gap with `resume afterSeq`.
+WS_EVENT_CHANNEL=neurowealth:user-events
+# Durable stream retention — bounded by age AND by rows per user.
+RETENTION_USER_EVENTS_DAYS=7
+USER_EVENT_STREAM_MAX_PER_USER=5000

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -113,3 +113,60 @@ riskCeiling? }`** — the three keys `src/agent/loop.ts` actually reads.
     written here despite being out of scope for #322.** It was missing, which
     fails `scripts/check-migration-rollback.sh` on `main` and would have left
     this branch's CI red for an unrelated reason. Flagged in the PR description.
+
+---
+
+## Issue #316 — Authenticated Real-Time WebSocket Streaming
+
+1. **The durable stream is Postgres, not a Redis Stream.** `src/config/redis.ts`
+   degrades to a no-op when `REDIS_URL` is unset — the configuration most
+   environments and the whole test suite run — so a Redis-backed stream would
+   make `resume afterSeq` silently unavailable exactly where it is hardest to
+   notice, and would put durability on a store we treat elsewhere as a cache.
+   Redis stays in the design as the cross-pod *transport*. Justified in code on
+   `model UserEvent` in `prisma/schema.prisma`.
+
+2. **Stream retention defaults to 7 days and 5000 rows per user.** This table
+   exists to close a reconnect gap, not to be a second event log — `Transaction`
+   and `ProcessedEvent` remain the durable record. Both bounds are needed: age
+   alone lets one pathological account grow without limit inside the window.
+
+3. **`seq` is exposed to clients as a JSON `number`, not a string.** Postgres
+   returns `BIGINT` and Prisma maps it to `bigint`, which `JSON.stringify`
+   refuses. A per-user counter would need to pass 2^53 events before the
+   conversion could lose precision.
+
+4. **`subscribe` starts at "now"; only `resume` replays.** A client that wants
+   history asks for it. Making `subscribe` replay by default would turn every
+   fresh connection into a retention-sized read.
+
+5. **Coalescing is opt-in per subscription and lossy for `resume`.** Suppressed
+   events stay in the store but are not redelivered, because the client's
+   `afterSeq` has already moved past them. Default-off makes that the client's
+   trade, not the server's.
+
+6. **A revoked session is caught by polling, not by a push.** `WS_SESSION_RECHECK_MS`
+   (60s) re-verifies each live socket. Polling is the one mechanism that covers
+   every way a session can die — logout, expiry, deactivation, admin action —
+   without each of those code paths needing to know sockets exist. Logout
+   additionally closes sockets immediately on the pod handling it.
+
+7. **Delegated topic mapping: `VIEW` → portfolio/transactions/agent/alerts,
+   `MANAGE_STRATEGY` → strategies.** `DEPOSIT`/`WITHDRAW` add no topics of their
+   own — the confirmations they produce are already covered by `transactions`
+   under `VIEW`.
+
+8. **The webhook leg still receives the unredacted payload.** Webhook
+   subscriptions are operator-scoped and their endpoints are trusted servers;
+   an end user's browser is not. Only the socket payload is projected onto the
+   per-event-type allowlist.
+
+9. **`agent.rebalanced` from `src/stellar/events.ts` has no user stream.** The
+   contract event is protocol-wide with no user to address, so it publishes with
+   an empty user list and reaches the webhook channel alone. The per-user view
+   of a rebalance comes from `src/agent/loop.ts`, which knows whose positions
+   moved.
+
+10. **A `?token=` query parameter is deliberately unsupported.** URLs reach
+    access logs, proxy logs, and referrers, and the handshake token is a live
+    session. Browsers use the `Sec-WebSocket-Protocol: bearer, <jwt>` pair.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -13,6 +13,7 @@
 - **[PORTFOLIO_OPTIMIZATION.md](PORTFOLIO_OPTIMIZATION.md)** - Portfolio optimization & allocation suggestions: objective, λ mapping, estimation method, advisory invariant, limitations (#322)
 - **[PERFORMANCE_ATTRIBUTION.md](PERFORMANCE_ATTRIBUTION.md)** - Benchmark-relative Brinson attribution: allocation/selection effects, Cariño linking, benchmark definition, `vsBenchmark` on the marketplace (#320)
 - **[OUTBOX.md](OUTBOX.md)** - Durable outbox & prioritized on-chain transaction queue: state machine, idempotency, retry/fee-bump policy, priority ordering, admin API (#325)
+- **[WEBSOCKET_STREAMING.md](WEBSOCKET_STREAMING.md)** - Authenticated real-time WebSocket streaming: handshake auth, topics, seq/resume replay, gap handling, backpressure, sub-account scoping, multi-pod bridge (#316)
 
 ### For DevOps/Deployment
 

--- a/docs/WEBSOCKET_STREAMING.md
+++ b/docs/WEBSOCKET_STREAMING.md
@@ -1,0 +1,445 @@
+# Real-Time WebSocket Streaming (#316)
+
+Authenticated, per-user, sequence-numbered event streaming with resumable
+replay. Replaces polling `/api/portfolio`, `/api/transactions`, and
+`/api/analytics` for live views.
+
+Endpoint: **`GET /api/v1/ws`** (configurable via `WS_PATH`).
+Machine-readable subprotocol: `docs/openapi.yaml`, operation `openRealtimeStream`.
+
+---
+
+## 1. What this is, and what it is not
+
+The platform already produces an ordered stream of user-facing events —
+deposits, withdrawals, rebalances, alert triggers, strategy changes — and
+already fans them out to operator-configured endpoints through
+`src/services/webhookDispatcher.ts`. This feature exposes the same stream to the
+**end user**, over an authenticated socket, with no message loss across a
+reconnect.
+
+**Receive-only in v1.** The client→server side is a control channel:
+`subscribe`, `resume`, `unsubscribe`, `ping`. State-changing operations stay on
+the REST surface, which has the validation, rate limiting, idempotency, and
+audit trail a socket does not. A second, weaker path to move money is not a
+feature.
+
+---
+
+## 2. Connecting
+
+### Authentication
+
+The handshake runs the same checks as `src/middleware/authenticate.ts`:
+signature → live session row → expiry → active user. It runs **before** the
+protocol switch, so an unauthenticated peer receives an HTTP `401` and never
+becomes a WebSocket. There is no anonymous fallback.
+
+Two ways to present the token:
+
+```bash
+# Server-side clients
+wscat -c ws://localhost:3001/api/v1/ws -H "Authorization: Bearer $JWT"
+```
+
+```javascript
+// Browsers — a WebSocket cannot set headers, so the token rides the subprotocol
+const ws = new WebSocket('wss://api.example.com/api/v1/ws', ['bearer', jwt])
+```
+
+A `?token=` query parameter is **not** accepted. URLs land in access logs, proxy
+logs, and referrer headers, and this token is a live session.
+
+### Sub-account (delegated) connections
+
+A parent may bind the connection to a child's stream:
+
+```
+GET /api/v1/ws?actor=<childUserId>
+```
+
+The server looks up the `SubAccount` grant, requires `status = ACTIVE`, and
+derives the readable topics from its permissions. The client's opinion about its
+own scope is never consulted — the same enforcement the REST `actingAsUserId`
+routes apply.
+
+| Permission        | Topics unlocked                              |
+|-------------------|----------------------------------------------|
+| `VIEW`            | `portfolio`, `transactions`, `agent`, `alerts` |
+| `MANAGE_STRATEGY` | `strategies`                                 |
+
+`DEPOSIT` / `WITHDRAW` add no topics of their own — the confirmations they
+produce are already covered by `transactions` under `VIEW`.
+
+Authorisation is also re-resolved **at publish time**, from live grants, for
+every single event (see `resolveAuthorizedViewers` in
+`src/events/publisher.ts`). A grant revoked mid-connection stops delivery on the
+very next event, with no cache to invalidate and no reconnect required.
+
+### Revocation
+
+A session revoked while a socket is open closes it with code `4408`. Logout
+closes the user's sockets on the handling pod immediately; a periodic
+re-verification (`WS_SESSION_RECHECK_MS`, default 60s) is the backstop that
+covers every other way a session can die — expiry, account deactivation, admin
+action — and sockets held on other pods.
+
+---
+
+## 3. Topics
+
+`portfolio` · `transactions` · `agent` · `alerts` · `strategies`
+
+| Topic          | Carries                                                            | Source |
+|----------------|--------------------------------------------------------------------|--------|
+| `transactions` | deposit/withdraw/settlement confirmations, fiat orders, recurring deposits, terminal outbox failures | `src/stellar/events.ts`, `src/fiat/service.ts`, `src/controllers/transaction-controller.ts` |
+| `portfolio`    | value/position changes                                             | `src/agent/loop.ts` |
+| `agent`        | rebalance decisions                                                | `src/agent/loop.ts` |
+| `alerts`       | `alert_rule.triggered`                                             | `src/jobs/alertRules.ts` |
+| `strategies`   | publish / unpublish / material config change                       | `src/strategy/service.ts` |
+
+### Ordering contract
+
+* **Within a topic**: events are delivered in ascending `seq`.
+* **Across topics**: no ordering is guaranteed. All topics share one per-user
+  sequence, so if you need a cross-topic order, sort by `seq` — never by
+  arrival.
+* On-chain events inherit `ProcessedEvent`'s ledger ordering upstream of this
+  layer.
+
+---
+
+## 4. Message flow
+
+```
+client                                   server
+  │  ── upgrade (Bearer JWT) ──────────────▶│
+  │◀── hello { topics, currentSeq } ────────│
+  │  ── subscribe { topics } ──────────────▶│
+  │◀── subscribed { topics, currentSeq } ───│
+  │◀── event { seq: 41, … } ────────────────│
+  │◀── event { seq: 42, … } ────────────────│
+  ✗   connection drops
+  │  ── upgrade ───────────────────────────▶│
+  │◀── hello ───────────────────────────────│
+  │  ── resume { topics, afterSeq: 42 } ───▶│
+  │◀── replay { status: start, count: 3 } ──│
+  │◀── event { seq: 43 } … { seq: 45 } ─────│
+  │◀── replay { status: end } ──────────────│
+  │◀── subscribed  (now live) ──────────────│
+```
+
+`subscribe` starts at **now** — it does not replay history. History is what
+`resume` is for.
+
+### Client messages
+
+```jsonc
+{ "type": "subscribe",   "topics": ["portfolio", "transactions"], "coalesce": false }
+{ "type": "resume",      "topics": ["portfolio"], "afterSeq": 42 }
+{ "type": "unsubscribe", "topics": ["agent"] }
+{ "type": "ping" }
+```
+
+Schemas are strict: an unknown key or an unknown message type produces a
+`bad_request` error frame rather than being silently ignored, so a client using
+something this server does not implement finds out immediately.
+
+### Server frames
+
+| Frame        | When |
+|--------------|------|
+| `hello`      | First frame after a successful handshake |
+| `subscribed` | Acknowledges the active subscription set |
+| `event`      | One domain event, with `seq`, `topic`, `event`, `payload`, `emittedAt` |
+| `replay`     | `status: start` / `status: end` brackets around a resume replay |
+| `gap`        | The stream could not be served continuously — see §6 |
+| `error`      | `bad_request` · `forbidden` · `unauthorized` · `rate_limited` · `internal` |
+| `draining`   | Graceful shutdown; reconnect and resume |
+| `pong`       | Reply to an application-level `ping` |
+
+---
+
+## 5. Delivery guarantees
+
+**At-least-once, with a duplication window at reconnect.** A `resume` replays
+from the durable store while live events keep arriving; the live-switch prefers
+replaying an event twice over dropping it, because a hole would leave a client
+waiting forever for a `seq` that never comes.
+
+**Dedupe on `seq`.** It is monotonic and gapless per user, allocated by an
+atomic counter inside the same transaction that writes the event.
+
+```javascript
+let lastSeq = Number(localStorage.getItem('lastSeq') ?? 0)
+
+ws.onmessage = (raw) => {
+  const frame = JSON.parse(raw.data)
+  if (frame.type !== 'event') return handleControlFrame(frame)
+  if (frame.seq <= lastSeq) return          // duplicate from the replay window
+  lastSeq = frame.seq
+  localStorage.setItem('lastSeq', String(lastSeq))
+  apply(frame)
+}
+```
+
+---
+
+## 6. Gaps, and how to close them
+
+A `gap` frame means the stream could not be served continuously. It always
+carries enough to recover.
+
+```jsonc
+{
+  "type": "gap",
+  "reason": "retention",          // retention | backpressure | unknown_stream
+  "afterSeq": 12,                 // what you asked to resume after
+  "currentSeq": 481,              // newest seq that exists right now
+  "oldestAvailableSeq": 130,      // oldest still replayable (null if empty)
+  "snapshotRequired": true
+}
+```
+
+| `reason`         | Cause | Recovery |
+|------------------|-------|----------|
+| `retention`      | `afterSeq` is older than what is retained, or one replay hit its page limit with history still to come | If `snapshotRequired`, fetch a REST snapshot and `subscribe`; otherwise `resume` again from `currentSeq` in the frame |
+| `backpressure`   | Your client fell behind and delivery stopped | `resume` from `afterSeq` — nothing was lost, the durable stream still holds it |
+| `unknown_stream` | `afterSeq` is ahead of the server (restored from a stale cache, or the stream was reset) | Fetch a REST snapshot and `subscribe` |
+
+```javascript
+if (frame.type === 'gap') {
+  if (frame.snapshotRequired) {
+    await refetchFromRest()            // /api/v1/portfolio, /api/v1/transactions, …
+    lastSeq = frame.currentSeq
+    send({ type: 'subscribe', topics })
+  } else {
+    send({ type: 'resume', topics, afterSeq: frame.currentSeq })
+  }
+}
+```
+
+---
+
+## 7. Backpressure and event storms
+
+**A slow consumer never costs the server memory.** Past either bound —
+`WS_MAX_BUFFERED_EVENTS` in-process frames or `WS_MAX_BUFFERED_BYTES` unflushed
+socket bytes — the connection stops delivering, sends **one** `gap` frame with
+reason `backpressure` carrying the last seq it actually sent, and waits. This is
+drop-with-marker: the events are still in the durable stream, and your `resume`
+collects them.
+
+**Event storms** (a rebalance touching many positions) can be coalesced, per
+connection, opt-in:
+
+```json
+{ "type": "subscribe", "topics": ["portfolio"], "coalesce": true }
+```
+
+Within `WS_COALESCE_WINDOW_MS` (default 250ms), events sharing a
+`(topic, type)` collapse to the newest; frames still arrive in ascending `seq`,
+coalescing may drop but never reorder.
+
+> **Trade-off, stated plainly.** Suppressed events remain in the durable store
+> but will **not** be redelivered by a later `resume`, because your `afterSeq`
+> has already moved past them. Use coalescing for a dashboard that only renders
+> the latest state; do not use it for anything that must see every event.
+> Off by default — this is the client's call, not the server's.
+
+---
+
+## 8. Heartbeat and idle policy
+
+The server pings every `WS_HEARTBEAT_INTERVAL_MS` (default 30s). A connection
+that neither pongs nor sends a frame within `WS_IDLE_TIMEOUT_MS` (default 90s)
+is closed with code `4408`. Browser clients that cannot observe protocol pongs
+can send `{"type":"ping"}` and will receive a `pong`.
+
+### Reconnect policy
+
+Reconnect with exponential backoff and jitter, capped around 30s. Always
+`resume` with the highest `seq` you durably processed:
+
+```javascript
+let attempt = 0
+function reconnect() {
+  const delay = Math.min(30_000, 500 * 2 ** attempt++) * (0.5 + Math.random())
+  setTimeout(() => open().then(() => { attempt = 0 }), delay)
+}
+```
+
+On a `draining` frame, wait `retryAfterMs` before reconnecting — the pod is
+being replaced and an immediate retry lands on a socket that is also closing.
+
+### Close codes
+
+| Code | Meaning |
+|------|---------|
+| 1000 | Normal closure |
+| 1001 | Server draining (preceded by a `draining` frame) |
+| 4401 | Unauthenticated |
+| 4403 | Actor not permitted |
+| 4408 | Session revoked, or idle timeout |
+| 4429 | Message rate limit exceeded |
+
+---
+
+## 9. Privacy
+
+Frames go through the same allowlist discipline as REST responses. Payloads are
+projected onto a hand-written per-event-type allowlist
+(`mapUserEventPayloadToResponse` in `src/utils/api-formatters.ts`) **before**
+they are persisted, so a replay can never hand back a field the live path
+stripped.
+
+No `userId`, wallet address, phone, email, key, or internal column appears in a
+frame. An event type nobody has reviewed yields an empty payload rather than
+being passed through. The connection carries the JWT and nothing else; no secret
+ever travels over the socket.
+
+The webhook leg is unchanged and still receives the full payload including
+`userId` — an operator's endpoint is a trusted server, an end user's browser is
+not.
+
+---
+
+## 10. Architecture
+
+### Unified emission
+
+Every user-facing domain event now goes through one function:
+
+```typescript
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
+
+await publishUserEvent(
+  userId,                                    // or string[] for a multi-user occurrence
+  EVENT_TYPE_TOPIC['deposit.received'],
+  'deposit.received',
+  { txHash, amount, assetSymbol, userId }
+)
+```
+
+It redacts, persists (allocating `seq`), fans out to sockets locally and across
+pods, and dispatches the operator webhook. Adding a domain event therefore
+reaches both channels with no bespoke wiring.
+
+The webhook fires **once per domain occurrence** even when the occurrence
+touches many users, because webhook subscriptions in this codebase are
+operator-scoped, not user-scoped. Only the socket streams fan out per user.
+
+`publishUserEvent` never throws: every call site treats emission as
+fire-and-forget precisely because a notification problem must not roll back a
+deposit.
+
+### Durable store: Postgres, not Redis Streams
+
+`user_events` + `user_event_sequences`, in Postgres.
+
+Redis is **optional** in this deployment — `src/config/redis.ts` degrades to a
+no-op when `REDIS_URL` is unset, which is what most environments and the entire
+test suite actually run. A Redis-backed stream would therefore make `resume
+afterSeq` silently unavailable exactly where it is hardest to notice, and would
+put durability on a store we treat everywhere else as a cache. Postgres is
+already the source of truth for every other domain event, is already covered by
+the retention job, and gives a gapless per-user counter for free.
+
+`seq` is allocated by a single `INSERT … ON CONFLICT DO UPDATE … RETURNING` on
+the counter row, inside the same transaction as the event insert. Concurrent
+publishers for the same user serialise on that row lock: no duplicate, and no
+hole.
+
+### Retention
+
+Two bounds, both required:
+
+* **Age** — `RETENTION_USER_EVENTS_DAYS` (default 7). This is the one clients
+  reason about: offline longer than this means a `gap` and a REST snapshot.
+* **Per-user row cap** — `USER_EVENT_STREAM_MAX_PER_USER` (default 5000). Age
+  alone would let one pathological account grow without limit inside the window,
+  and the promise of a bounded stream is that no single user can do that.
+
+Both are swept by `cleanupUserEvents` in `src/jobs/dataRetention.ts`.
+
+### Multi-instance delivery
+
+Connections live on arbitrary pods; events are produced on arbitrary pods. Every
+publish is broadcast on one Redis channel (`WS_EVENT_CHANNEL`), and each pod
+delivers to whichever of that user's sockets it holds. An envelope carries the
+publishing pod's id so a pod does not redeliver its own emit.
+
+**Loss window.** Redis pub/sub is fire-and-forget, so live cross-pod delivery is
+**at-most-once**: an envelope published while a pod is restarting, partitioned,
+or slow simply does not reach that pod's sockets. The durable store closes that
+window, not the transport — the event was committed with its `seq` before it
+reached the bridge, so the client's next `resume afterSeq` collects it in order.
+
+**When Redis is down or unset**, the publish is never dropped silently: it still
+reaches this pod's own subscribers, the failure is counted on
+`ws_bridge_publish_total{outcome="local_only"|"error"}`, and an alert is raised
+through `alertingService` with a stable dedupe key (`ws:bridge:redis-publish-failed`)
+so an hour-long outage produces one alert, not one per event.
+
+### Graceful shutdown
+
+Sockets drain **before** `httpServer.close()`. An open WebSocket is a live HTTP
+connection, so closing the HTTP server first would block on them until the grace
+period expired and then cut them without warning. Instead each client receives a
+`draining` frame with the seq to resume after, then a close with code 1001 — a
+rolling deploy costs a reconnect, not a REST snapshot. The drain is awaited.
+
+---
+
+## 11. Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `WS_PATH` | `/api/v1/ws` | Upgrade endpoint path |
+| `WS_HEARTBEAT_INTERVAL_MS` | `30000` | Ping cadence |
+| `WS_IDLE_TIMEOUT_MS` | `90000` | Silence tolerated before close |
+| `WS_MAX_BUFFERED_EVENTS` | `256` | Per-connection frame bound |
+| `WS_MAX_BUFFERED_BYTES` | `1048576` | Unflushed socket bytes bound |
+| `WS_MAX_CONNECTIONS_PER_USER` | `5` | Sockets per user per pod |
+| `WS_HANDSHAKE_MAX` / `WS_HANDSHAKE_WINDOW_MS` | `30` / `60000` | Handshake flood guard, per IP |
+| `WS_MESSAGE_MAX` / `WS_MESSAGE_WINDOW_MS` | `50` / `10000` | Client message rate |
+| `WS_MAX_MESSAGE_BYTES` | `4096` | Largest client frame |
+| `WS_REPLAY_MAX_EVENTS` | `1000` | Events one `resume` may replay |
+| `WS_SESSION_RECHECK_MS` | `60000` | Live session re-verification |
+| `WS_COALESCE_WINDOW_MS` | `250` | Coalescing window (opt-in) |
+| `WS_DRAIN_RETRY_AFTER_MS` | `2000` | Advertised reconnect delay |
+| `WS_EVENT_CHANNEL` | `neurowealth:user-events` | Redis pub/sub channel |
+| `RETENTION_USER_EVENTS_DAYS` | `7` | Stream age bound |
+| `USER_EVENT_STREAM_MAX_PER_USER` | `5000` | Stream row bound per user |
+
+---
+
+## 12. Observability
+
+All on the existing Prometheus registry (`/metrics`):
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `ws_connections_active` | gauge | `mode` = `self` / `delegated` |
+| `ws_handshakes_total` | counter | `outcome` = `accepted` / `unauthorized` / `forbidden` / `rate_limited` / `too_many` |
+| `ws_messages_sent_total` | counter | `topic`, `path` = `live` / `replay` |
+| `ws_messages_received_total` | counter | `type` |
+| `ws_replay_events_total` | counter | — |
+| `ws_gaps_total` | counter | `reason` |
+| `ws_dropped_events_total` | counter | `reason` = `backpressure` / `coalesced` |
+| `ws_bridge_publish_total` | counter | `outcome` = `redis` / `local_only` / `error` |
+| `ws_publish_failures_total` | counter | — |
+
+Worth alerting on: a sustained non-zero rate of
+`ws_dropped_events_total{reason="backpressure"}` (clients or pods too slow),
+`ws_bridge_publish_total{outcome!="redis"}` in a multi-pod deployment (live
+delivery is degraded), and any `ws_publish_failures_total` (the durable stream
+is not accepting writes, so resume will not close gaps).
+
+---
+
+## 13. Out of scope for v1
+
+* Bidirectional trading messages — receive side is server→client only.
+* Compression and tracing beyond what the stack already provides.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -21,6 +21,12 @@ tags:
     description: Authentication and session management
   - name: Portfolio
     description: User portfolio management
+  - name: Realtime
+    description: |
+      Authenticated WebSocket streaming (#316). The handshake below is a real
+      HTTP request and is spec'd here so generated clients know how to open it;
+      everything after the 101 is the JSON subprotocol described in the
+      `WebSocket*` schemas and in docs/WEBSOCKET_STREAMING.md.
 
 # ─── Reusable components ──────────────────────────────────────────────────────
 components:
@@ -261,6 +267,295 @@ components:
           example: Unauthorized
       required:
         - error
+
+    # ── Real-time WebSocket subprotocol (#316) ───────────────────────────────
+    #
+    # These are not request/response bodies: they are the JSON frames exchanged
+    # over the socket opened by `GET /ws`. They live in the spec so client
+    # generators and reviewers have one authoritative shape per frame.
+
+    WebSocketTopic:
+      type: string
+      enum: [portfolio, transactions, agent, alerts, strategies]
+      description: |
+        Subscription, ordering, and permission unit.
+
+        **Ordering**: within a topic, events arrive in ascending `seq`. Across
+        topics there is NO ordering guarantee — all topics share one per-user
+        sequence, so use `seq` rather than arrival order. On-chain events
+        inherit ProcessedEvent's ledger ordering upstream.
+
+    WebSocketSubscribe:
+      type: object
+      description: Client → server. Start live delivery for the given topics.
+      required: [type, topics]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [subscribe]
+        topics:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/WebSocketTopic'
+        coalesce:
+          type: boolean
+          default: false
+          description: |
+            Opt into latest-wins coalescing of same-type bursts within a short
+            window (WS_COALESCE_WINDOW_MS). Suppressed events remain in the
+            durable stream but are NOT redelivered by a later `resume`, because
+            `afterSeq` has already moved past them. Off by default.
+
+    WebSocketResume:
+      type: object
+      description: |
+        Client → server. Replay everything after `afterSeq`, then switch to live.
+        Send this on every reconnect.
+      required: [type, topics, afterSeq]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [resume]
+        topics:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/WebSocketTopic'
+        afterSeq:
+          type: integer
+          minimum: 0
+          description: Last `seq` the client durably processed. 0 replays everything retained.
+        coalesce:
+          type: boolean
+          default: false
+
+    WebSocketUnsubscribe:
+      type: object
+      description: Client → server. Stop delivery for the given topics.
+      required: [type, topics]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [unsubscribe]
+        topics:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/WebSocketTopic'
+
+    WebSocketPing:
+      type: object
+      description: |
+        Client → server. Application-level keepalive, answered with `pong`. Only
+        needed by clients that cannot observe protocol-level pongs (browsers);
+        the server pings every `heartbeatIntervalMs` regardless.
+      required: [type]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [ping]
+
+    WebSocketClientMessage:
+      description: |
+        Every message a client may send. The receive side is a control channel
+        only — v1 is server→client for data. State-changing operations stay on
+        the REST surface, which has the validation, idempotency, and audit trail
+        a socket does not.
+      oneOf:
+        - $ref: '#/components/schemas/WebSocketSubscribe'
+        - $ref: '#/components/schemas/WebSocketResume'
+        - $ref: '#/components/schemas/WebSocketUnsubscribe'
+        - $ref: '#/components/schemas/WebSocketPing'
+
+    WebSocketHello:
+      type: object
+      description: Server → client. First frame after a successful handshake.
+      required: [type, actor, topics, currentSeq, heartbeatIntervalMs]
+      properties:
+        type:
+          type: string
+          enum: [hello]
+        actor:
+          type: string
+          enum: [self, delegated]
+          description: |
+            `delegated` when the connection was opened with `?actor=<userId>`
+            and an ACTIVE sub-account grant authorised it.
+        topics:
+          type: array
+          description: Topics this connection may subscribe to, derived server-side.
+          items:
+            $ref: '#/components/schemas/WebSocketTopic'
+        currentSeq:
+          type: integer
+          description: Newest `seq` on the bound stream right now.
+        heartbeatIntervalMs:
+          type: integer
+
+    WebSocketSubscribed:
+      type: object
+      description: Server → client. Acknowledges the active subscription set.
+      required: [type, topics, currentSeq, coalesce]
+      properties:
+        type:
+          type: string
+          enum: [subscribed]
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebSocketTopic'
+        currentSeq:
+          type: integer
+        coalesce:
+          type: boolean
+
+    WebSocketEvent:
+      type: object
+      description: |
+        Server → client. One domain event.
+
+        **Delivery is at-least-once.** A `resume` replays from the durable store
+        while live events keep arriving, and the live-switch prefers a duplicate
+        over a hole. Dedupe on `seq`, which is monotonic per user.
+
+        **Payloads are allowlisted per event type** by the same discipline as
+        REST responses (src/utils/api-formatters.ts). No `userId`, wallet
+        address, key, or internal field appears here.
+      required: [type, seq, topic, event, payload, emittedAt]
+      properties:
+        type:
+          type: string
+          enum: [event]
+        seq:
+          type: integer
+          description: Monotonic per-user sequence number. Track the highest you processed.
+        topic:
+          $ref: '#/components/schemas/WebSocketTopic'
+        event:
+          type: string
+          description: Domain event type, e.g. `deposit.received`.
+          example: deposit.received
+        payload:
+          type: object
+          additionalProperties: true
+        emittedAt:
+          type: string
+          format: date-time
+
+    WebSocketReplay:
+      type: object
+      description: Server → client. Brackets the replay served for a `resume`.
+      required: [type, status, fromSeq, toSeq, count]
+      properties:
+        type:
+          type: string
+          enum: [replay]
+        status:
+          type: string
+          enum: [start, end]
+        fromSeq:
+          type: integer
+        toSeq:
+          type: integer
+        count:
+          type: integer
+
+    WebSocketGap:
+      type: object
+      description: |
+        Server → client. The stream could not be served continuously.
+
+        * `retention` — the requested `afterSeq` is older than what is retained,
+          or a single replay hit its page limit with history still to come.
+        * `backpressure` — the client was too slow; delivery stopped at
+          `afterSeq`. Nothing is lost; `resume` from there.
+        * `unknown_stream` — the requested `afterSeq` is ahead of the server.
+
+        When `snapshotRequired` is true, replay cannot close the gap: fetch a
+        REST snapshot (`/portfolio`, `/transactions`, …) and then `subscribe`.
+      required: [type, reason, afterSeq, currentSeq, oldestAvailableSeq, snapshotRequired]
+      properties:
+        type:
+          type: string
+          enum: [gap]
+        reason:
+          type: string
+          enum: [retention, backpressure, unknown_stream]
+        afterSeq:
+          type: integer
+          nullable: true
+        currentSeq:
+          type: integer
+        oldestAvailableSeq:
+          type: integer
+          nullable: true
+        snapshotRequired:
+          type: boolean
+
+    WebSocketError:
+      type: object
+      description: |
+        Server → client. `forbidden` mirrors REST 403 semantics — a topic the
+        connection's grant does not cover. `unauthorized` precedes a close with
+        code 4408 when the session is revoked mid-connection.
+      required: [type, code, message]
+      properties:
+        type:
+          type: string
+          enum: [error]
+        code:
+          type: string
+          enum: [bad_request, forbidden, unauthorized, rate_limited, internal]
+        message:
+          type: string
+
+    WebSocketDraining:
+      type: object
+      description: |
+        Server → client. Sent before a graceful shutdown closes the socket with
+        code 1001. Reconnect after `retryAfterMs` and `resume` from
+        `resumeAfterSeq`.
+      required: [type, reason, resumeAfterSeq, retryAfterMs]
+      properties:
+        type:
+          type: string
+          enum: [draining]
+        reason:
+          type: string
+          enum: [server_shutdown]
+        resumeAfterSeq:
+          type: integer
+        retryAfterMs:
+          type: integer
+
+    WebSocketPong:
+      type: object
+      description: Server → client. Reply to an application-level `ping`.
+      required: [type, at]
+      properties:
+        type:
+          type: string
+          enum: [pong]
+        at:
+          type: string
+          format: date-time
+
+    WebSocketServerFrame:
+      description: Every frame the server may send.
+      oneOf:
+        - $ref: '#/components/schemas/WebSocketHello'
+        - $ref: '#/components/schemas/WebSocketSubscribed'
+        - $ref: '#/components/schemas/WebSocketEvent'
+        - $ref: '#/components/schemas/WebSocketReplay'
+        - $ref: '#/components/schemas/WebSocketGap'
+        - $ref: '#/components/schemas/WebSocketError'
+        - $ref: '#/components/schemas/WebSocketDraining'
+        - $ref: '#/components/schemas/WebSocketPong'
 
   responses:
     Unauthorized:
@@ -534,6 +829,134 @@ paths:
                     type: array
                     items:
                       type: object
+
+  # ── Real-time WebSocket stream (#316) ─────────────────────────────────────────
+
+  /ws:
+    get:
+      operationId: openRealtimeStream
+      summary: Open the authenticated real-time event stream
+      description: |
+        Upgrades to a WebSocket carrying this user's live, sequence-numbered
+        event stream. Not a REST endpoint: the only HTTP response a client
+        should ever see is a rejection — success is a `101 Switching Protocols`
+        followed by the JSON subprotocol below.
+
+        Full client contract, including reconnect policy and worked examples:
+        `docs/WEBSOCKET_STREAMING.md`.
+
+        ### Authentication
+        The same JWT + live-session check the REST middleware performs, run
+        BEFORE the protocol switch — an unauthenticated peer gets a 401 and
+        never becomes a WebSocket. There is no anonymous channel.
+
+        Send the token either as `Authorization: Bearer <jwt>` (server-side
+        clients) or as the subprotocol pair `Sec-WebSocket-Protocol: bearer,
+        <jwt>` (browsers, which cannot set headers on a WebSocket). A `?token=`
+        query parameter is deliberately NOT accepted: URLs reach access logs,
+        proxy logs, and referrers, and this token is a live session.
+
+        A session revoked while the socket is open closes it with code 4408 —
+        the server rechecks the session periodically rather than trusting the
+        handshake forever.
+
+        ### Message flow
+        1. Server sends `hello` with the topics you may read and `currentSeq`.
+        2. Client sends `subscribe` (live from now) or `resume` (replay first).
+        3. Server sends `event` frames; each carries a monotonic per-user `seq`.
+        4. On reconnect, client sends `resume` with the highest `seq` it
+           durably processed. Missed events replay, then live resumes.
+
+        ### Delivery guarantees
+        At-least-once, with a duplication window around a reconnect — dedupe on
+        `seq`. Within a topic, events are ordered; across topics they are not.
+
+        ### Heartbeat and idle policy
+        The server pings every `heartbeatIntervalMs` (default 30s). A connection
+        that neither pongs nor sends a frame for `WS_IDLE_TIMEOUT_MS` (default
+        90s) is closed with code 4408. Clients that cannot observe protocol
+        pongs may send `{"type":"ping"}` instead.
+
+        ### Backpressure
+        A slow consumer is never buffered without bound. Past the per-connection
+        bound the server stops delivering, sends one `gap` frame with reason
+        `backpressure`, and waits for a `resume`. Nothing is lost — the durable
+        stream still holds every event.
+
+        ### Limits
+        Handshakes are rate-limited per source IP (`429` on the upgrade), client
+        messages per connection (`rate_limited` error frame, then close 4429),
+        and each user may hold `WS_MAX_CONNECTIONS_PER_USER` sockets per pod.
+
+        ### Close codes
+        | Code | Meaning |
+        |------|---------|
+        | 1000 | Normal closure |
+        | 1001 | Server draining (preceded by a `draining` frame) |
+        | 4401 | Unauthenticated |
+        | 4403 | Actor not permitted |
+        | 4408 | Session revoked, or idle timeout |
+        | 4429 | Message rate limit exceeded |
+      tags: [Realtime]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: actor
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: |
+            Bind the connection to a sub-account's stream instead of your own.
+            The ACTIVE `SubAccount` grant is verified server-side and its
+            permissions decide the readable topics (`VIEW` → portfolio,
+            transactions, agent, alerts; `MANAGE_STRATEGY` → strategies).
+            Same enforcement as the REST `actingAsUserId` routes; the client's
+            opinion about its own scope is never consulted.
+        - name: Sec-WebSocket-Protocol
+          in: header
+          required: false
+          schema:
+            type: string
+            example: bearer, eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+          description: Browser alternative to the Authorization header.
+      requestBody:
+        required: false
+        description: |
+          Not an HTTP body — documents the frames the client sends over the
+          socket after the upgrade.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebSocketClientMessage'
+      responses:
+        '101':
+          description: |
+            Protocol switched. Every subsequent server frame is one of
+            `WebSocketServerFrame`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebSocketServerFrame'
+        '401':
+          description: Missing, malformed, expired, or revoked credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: No ACTIVE sub-account grant for the requested `actor`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '429':
+          description: Handshake rate limit, or too many concurrent connections.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
 
   # ── Health ────────────────────────────────────────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "swagger-ui-express": "^5.0.1",
         "twilio": "^6.0.2",
         "winston": "^3.19.0",
+        "ws": "^8.21.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -51,6 +52,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.10.6",
         "@types/swagger-ui-express": "^4.1.8",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0",
@@ -4063,6 +4065,16 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -9761,6 +9773,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "swagger-ui-express": "^5.0.1",
     "twilio": "^6.0.2",
     "winston": "^3.19.0",
+    "ws": "^8.21.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -98,6 +99,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.10.6",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^8.57.0",

--- a/prisma/migrations/20260825000000_add_user_event_stream/migration.sql
+++ b/prisma/migrations/20260825000000_add_user_event_stream/migration.sql
@@ -1,0 +1,53 @@
+-- Migration: add_user_event_stream (#316)
+-- Durable, sequence-numbered per-user event stream backing the authenticated
+-- WebSocket transport (/api/v1/ws) and its `resume afterSeq` replay.
+--
+-- Why Postgres rather than a Redis stream: REDIS_URL is optional (see
+-- src/config/redis.ts, which degrades to a no-op), so a Redis-only stream would
+-- make replay unavailable in the most common configuration. Redis remains the
+-- cross-pod transport only — never the store.
+
+-- Per-user monotonic counter. One row per user; the publisher increments it
+-- with INSERT … ON CONFLICT DO UPDATE … RETURNING so concurrent publishers
+-- serialise on the row lock and cannot mint duplicate or skipped sequences.
+CREATE TABLE "user_event_sequences" (
+    "userId"    TEXT NOT NULL,
+    "lastSeq"   BIGINT NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_event_sequences_pkey" PRIMARY KEY ("userId")
+);
+
+ALTER TABLE "user_event_sequences"
+    ADD CONSTRAINT "user_event_sequences_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- The stream itself. `payload` is stored already-redacted (see the per-type
+-- allowlists in src/utils/api-formatters.ts) so a replay can never hand a
+-- client a field the live path would have stripped.
+CREATE TABLE "user_events" (
+    "id"        TEXT NOT NULL,
+    "userId"    TEXT NOT NULL,
+    "seq"       BIGINT NOT NULL,
+    "topic"     TEXT NOT NULL,
+    "type"      TEXT NOT NULL,
+    "payload"   JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_events_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "user_events"
+    ADD CONSTRAINT "user_events_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Gaplessness is enforced by the counter, but the unique index is the backstop:
+-- a second writer that somehow reused a seq fails its INSERT rather than
+-- silently corrupting a replay.
+CREATE UNIQUE INDEX "user_events_userId_seq_key" ON "user_events"("userId", "seq");
+
+-- Replay reads are always "WHERE userId = ? AND seq > ? ORDER BY seq ASC LIMIT n".
+CREATE INDEX "user_events_userId_seq_idx" ON "user_events"("userId", "seq");
+
+-- Age-based retention sweep (src/jobs/dataRetention.ts).
+CREATE INDEX "user_events_createdAt_idx" ON "user_events"("createdAt");

--- a/prisma/migrations/20260825000000_add_user_event_stream/rollback.sql
+++ b/prisma/migrations/20260825000000_add_user_event_stream/rollback.sql
@@ -1,0 +1,18 @@
+-- rollback.sql — reverse of 20260825000000_add_user_event_stream/migration.sql
+--
+-- Drops the user_events stream and its per-user sequence counter.
+-- DATA LOSS: replay history for every live WebSocket client is destroyed. A
+-- client that reconnects after this runs receives a `gap` frame with
+-- currentSeq 0 and must re-fetch a REST snapshot — the documented,
+-- already-handled path, but expect a burst of snapshot requests.
+-- Safe to run multiple times (IF EXISTS guards).
+-- Run with: psql $DATABASE_URL -f prisma/migrations/20260825000000_add_user_event_stream/rollback.sql
+
+-- Drop indexes first (dropped implicitly with the table, listed explicitly for clarity)
+DROP INDEX IF EXISTS "user_events_createdAt_idx";
+DROP INDEX IF EXISTS "user_events_userId_seq_idx";
+DROP INDEX IF EXISTS "user_events_userId_seq_key";
+
+-- Drop the tables (cascade removes foreign-key constraints automatically)
+DROP TABLE IF EXISTS "user_events" CASCADE;
+DROP TABLE IF EXISTS "user_event_sequences" CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -223,6 +223,8 @@ model User {
   allocationSuggestions   AllocationSuggestion[]
   portfolioAttributions   PortfolioAttribution[]
   portfolioRiskAggregates PortfolioRiskAggregate[]
+  userEvents              UserEvent[]
+  userEventSequence       UserEventSequence?
 
   @@map("users")
 }
@@ -1214,4 +1216,66 @@ model PortfolioRiskAggregate {
   @@index([sortinoRatio])
   @@index([annualisedVolatility])
   @@map("portfolio_risk_aggregates")
+}
+
+/// One durable, sequence-numbered event on a user's real-time stream (#316).
+///
+/// DESIGN NOTE — why Postgres and not a Redis Stream.
+/// Redis is *optional* in this deployment: src/config/redis.ts degrades to a
+/// no-op when REDIS_URL is unset, which is the configuration most environments
+/// (and the whole test suite) actually run. A Redis-backed stream would
+/// therefore make `resume afterSeq` silently unavailable exactly where it is
+/// hardest to notice, and would put durability on a store we already treat as
+/// a cache. Postgres is the source of truth for every other domain event, is
+/// already covered by the retention job, and gives us the gapless per-user
+/// counter below for free. Redis stays in the design as the *transport* for the
+/// cross-pod fan-out (src/events/bridge.ts) — never as the store. Losing Redis
+/// costs live cross-pod delivery for the duration of the outage; it never costs
+/// replay, because replay reads this table.
+///
+/// Bounded two ways by src/jobs/dataRetention.ts: by age
+/// (RETENTION_USER_EVENTS_DAYS) and by per-user row count
+/// (USER_EVENT_STREAM_MAX_PER_USER). A resume older than what survives is
+/// answered with a `gap` frame carrying the newest available seq, never an
+/// unbounded replay.
+model UserEvent {
+  id        String   @id @default(uuid())
+  /// Stream owner. Delivery to a parent sub-account is authorised at publish
+  /// time (see src/events/publisher.ts) — never by rewriting this column.
+  userId    String
+  /// Monotonic, gapless, per-user. Allocated by the atomic upsert-increment on
+  /// UserEventSequence inside the same transaction as this row's INSERT.
+  seq       BigInt
+  /// One of src/events/types.ts USER_EVENT_TOPICS.
+  topic     String
+  /// Domain event type, e.g. 'deposit.received'. Mirrors the webhook event
+  /// name when one exists so both channels speak the same vocabulary.
+  type      String
+  /// Already redacted through the per-type allowlist in
+  /// src/utils/api-formatters.ts before it is stored — the socket must never
+  /// be the reason a field reaches a client, so the store holds only what a
+  /// client is allowed to see.
+  payload   Json
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, seq])
+  @@index([userId, seq])
+  @@index([createdAt])
+  @@map("user_events")
+}
+
+/// Per-user monotonic counter backing UserEvent.seq (#316).
+/// Incremented with a single `INSERT … ON CONFLICT DO UPDATE … RETURNING`, so
+/// concurrent publishers for the same user serialise on the row lock and can
+/// never mint a duplicate or leave a hole.
+model UserEventSequence {
+  userId    String   @id
+  lastSeq   BigInt   @default(0)
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("user_event_sequences")
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -14,7 +14,8 @@ import {
   getThresholds,
   logAgentAction,
 } from './router'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { captureAllUserBalances, cleanupOldSnapshots } from './snapshotter'
 import { resolveEffectiveConfig } from './effectiveStrategy'
 import {
@@ -236,14 +237,44 @@ async function rebalanceCheckJob(): Promise<void> {
           currentProtocol = result.toProtocol
           currentApy = result.improvedBy
           recordRebalanceTriggered()
-          dispatchWebhookEvent('agent.rebalanced', {
+
+          // #316: every user with a position in this batch had their money
+          // moved, so each gets the event on their own stream. The operator
+          // webhook still fires exactly once — webhook subscriptions are
+          // operator-scoped, not per-user, so fanning it out would duplicate it.
+          const affectedUserIds = Array.from(
+            new Set(protocolPositions.map((p: PositionWithUser) => p.userId))
+          )
+          const rebalancePayload = {
             fromProtocol: result.fromProtocol,
             toProtocol: result.toProtocol,
             amount: result.amount,
             improvedBy: result.improvedBy,
             txHash: result.txHash,
             timestamp: result.timestamp,
-          }).catch(() => {})
+          }
+
+          publishUserEvent(
+            affectedUserIds,
+            EVENT_TYPE_TOPIC['agent.rebalanced'],
+            'agent.rebalanced',
+            rebalancePayload
+          ).catch(() => {})
+
+          // Companion socket-only signal: a dashboard watching `portfolio`
+          // should refresh without also subscribing to agent internals. No
+          // webhook counterpart — an operator endpoint already got the
+          // rebalance above, and a second near-identical POST helps nobody.
+          publishUserEvent(
+            affectedUserIds,
+            EVENT_TYPE_TOPIC['portfolio.updated'],
+            'portfolio.updated',
+            {
+              protocolName: result.toProtocol,
+              positionsAffected: protocolPositions.length,
+              reason: 'rebalance',
+            }
+          ).catch(() => {})
         }
       }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -462,6 +462,58 @@ export const config = {
   shutdown: {
     drainTimeoutMs: parseInt(process.env.SHUTDOWN_DRAIN_TIMEOUT_MS || '30000'),
   },
+  /**
+   * Authenticated real-time WebSocket stream (#316) — see
+   * docs/WEBSOCKET_STREAMING.md for the client contract these bounds imply.
+   */
+  websocket: {
+    /** Mount path of the upgrade endpoint. */
+    path: process.env.WS_PATH || '/api/v1/ws',
+    /** Ping cadence. A peer that misses two consecutive pongs is closed. */
+    heartbeatIntervalMs: parseInt(
+      process.env.WS_HEARTBEAT_INTERVAL_MS || '30000'
+    ),
+    /** How long a socket may stay silent (no pong, no frame) before closing. */
+    idleTimeoutMs: parseInt(process.env.WS_IDLE_TIMEOUT_MS || '90000'),
+    /**
+     * Per-connection outbound buffer bound. Past this the connection is marked
+     * gapped and events are dropped with a resumable marker rather than queued
+     * — a slow consumer must cost its own liveness, never the pod's memory.
+     */
+    maxBufferedEvents: parseInt(process.env.WS_MAX_BUFFERED_EVENTS || '256'),
+    /** Socket-level backpressure bound (bytes still unflushed by the kernel). */
+    maxBufferedBytes: parseInt(
+      process.env.WS_MAX_BUFFERED_BYTES || String(1024 * 1024)
+    ),
+    /** Simultaneous connections one authenticated user may hold on one pod. */
+    maxConnectionsPerUser: parseInt(
+      process.env.WS_MAX_CONNECTIONS_PER_USER || '5'
+    ),
+    /** Handshake flood guard, per source IP. A connection flood is a DoS. */
+    handshakeRateLimit: {
+      windowMs: parseInt(process.env.WS_HANDSHAKE_WINDOW_MS || '60000'),
+      max: parseInt(process.env.WS_HANDSHAKE_MAX || '30'),
+    },
+    /** Client→server message rate. Exceeding it closes the socket. */
+    messageRateLimit: {
+      windowMs: parseInt(process.env.WS_MESSAGE_WINDOW_MS || '10000'),
+      max: parseInt(process.env.WS_MESSAGE_MAX || '50'),
+    },
+    /** Largest client frame accepted. Client messages are tiny control frames. */
+    maxMessageBytes: parseInt(process.env.WS_MAX_MESSAGE_BYTES || '4096'),
+    /** Events one `resume` may replay before the client must resume again. */
+    replayMaxEvents: parseInt(process.env.WS_REPLAY_MAX_EVENTS || '1000'),
+    /**
+     * How often a live connection re-verifies its session against the database,
+     * so a logout or a deactivated account kills the socket rather than waiting
+     * for it to disconnect on its own.
+     */
+    sessionRecheckMs: parseInt(process.env.WS_SESSION_RECHECK_MS || '60000'),
+    /** Coalescing window for clients that opt in at subscribe time. */
+    coalesceWindowMs: parseInt(process.env.WS_COALESCE_WINDOW_MS || '250'),
+    /** How long a draining client should wait before reconnecting. */
+    drainRetryAfterMs: parseInt(process.env.WS_DRAIN_RETRY_AFTER_MS || '2000'),
+  },
   retention: {
     processedEventsDays: parseInt(
       process.env.RETENTION_PROCESSED_EVENTS_DAYS || '90'
@@ -470,6 +522,20 @@ export const config = {
       process.env.RETENTION_DEAD_LETTER_EVENTS_DAYS || '30'
     ),
     agentLogsDays: parseInt(process.env.RETENTION_AGENT_LOGS_DAYS || '60'),
+    /**
+     * Real-time stream retention (#316). Short by design: this table exists to
+     * close a reconnect gap, not to be a second event log — ProcessedEvent and
+     * Transaction remain the durable record. A client offline longer than this
+     * gets a `gap` frame and re-fetches a REST snapshot.
+     */
+    userEventsDays: parseInt(process.env.RETENTION_USER_EVENTS_DAYS || '7'),
+    /**
+     * Per-user row cap, enforced alongside the age sweep. Age alone lets one
+     * pathological account grow without bound inside the window.
+     */
+    userEventsMaxPerUser: parseInt(
+      process.env.USER_EVENT_STREAM_MAX_PER_USER || '5000'
+    ),
     intervalMs: parseInt(process.env.RETENTION_INTERVAL_MS || '86400000'),
   },
   protocolRisk: {

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -86,3 +86,42 @@ export async function cacheDel(key: string): Promise<void> {
     })
   }
 }
+
+/**
+ * The shared client, or null when REDIS_URL is unset (#316).
+ *
+ * Exposed for callers that need Redis as a *transport* rather than a cache —
+ * today that is only the cross-pod event bridge. Callers MUST treat null as
+ * "Redis is not available" and degrade, exactly as the cache helpers above do.
+ */
+export function getRedisClient(): Redis | null {
+  return getClient()
+}
+
+/**
+ * Open a dedicated connection for SUBSCRIBE (#316).
+ *
+ * A Redis connection in subscriber mode cannot issue ordinary commands, so the
+ * shared client above must never be used for it — that would silently break
+ * every cacheGet in the process. Returns null when REDIS_URL is unset.
+ *
+ * The caller owns the returned client and must `quit()` it on shutdown.
+ */
+export function createRedisSubscriber(): Redis | null {
+  const url = process.env.REDIS_URL
+  if (!url) return null
+
+  const subscriber = new Redis(url, {
+    maxRetriesPerRequest: null, // a subscriber must keep retrying, not give up
+    lazyConnect: false,
+    enableOfflineQueue: true,
+  })
+
+  subscriber.on('error', (err) => {
+    logger.error('[redis] subscriber error', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+
+  return subscriber
+}

--- a/src/controllers/auth-controller.ts
+++ b/src/controllers/auth-controller.ts
@@ -9,6 +9,7 @@ import { logger } from '../utils/logger'
 import db from '../db'
 import { stellarVerification } from '../utils/stellar/stellar-verification'
 import { attributeSignup } from '../referral/service'
+import { closeUserSockets } from '../ws/server'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -278,6 +279,15 @@ export async function logout(req: Request, res: Response): Promise<void> {
   try {
     // Delete the session matched by access token (also nukes its refresh token hash)
     await db.session.deleteMany({ where: { token } })
+
+    // #316: a revoked session must kill the user's live sockets, not just block
+    // the next handshake. The per-connection recheck would catch this within
+    // WS_SESSION_RECHECK_MS anyway; doing it here closes the window now, on the
+    // pod handling the logout. Sockets on other pods still fall to the recheck.
+    if (req.userId) {
+      closeUserSockets(req.userId, 'Session revoked')
+    }
+
     logger.info(`[Auth] Session revoked for user ${req.userId}`)
     res.status(200).json({ message: 'Logged out successfully' })
   } catch (error) {

--- a/src/controllers/transaction-controller.ts
+++ b/src/controllers/transaction-controller.ts
@@ -4,7 +4,8 @@ import db from '../db'
 import { formatDepositReply, formatWithdrawReply } from '../whatsapp/formatters'
 import { sendNotFound, sendUnauthorized } from '../utils/errors'
 import { logger } from '../utils/logger'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { enqueueOutboxOp } from '../outbox/service'
 import { dispatchOne } from '../outbox/dispatcher'
 import { deriveIdempotencyKey } from '../outbox/idempotency'
@@ -158,14 +159,19 @@ export async function executeDeposit(
   })
 
   if (transaction.status === 'CONFIRMED') {
-    dispatchWebhookEvent('transaction.confirmed', {
-      txHash: transaction.txHash,
-      type: 'DEPOSIT',
-      status: transaction.status,
-      assetSymbol,
-      amount,
+    publishUserEvent(
       userId,
-    }).catch(() => {})
+      EVENT_TYPE_TOPIC['transaction.confirmed'],
+      'transaction.confirmed',
+      {
+        txHash: transaction.txHash,
+        type: 'DEPOSIT',
+        status: transaction.status,
+        assetSymbol,
+        amount,
+        userId,
+      }
+    ).catch(() => {})
   }
 
   return {
@@ -233,15 +239,20 @@ export async function processOnChainTransaction(
     })
 
     if (transaction.status === 'CONFIRMED') {
-      dispatchWebhookEvent('transaction.confirmed', {
-        txHash: transaction.txHash,
-        type,
-        status: transaction.status,
-        assetSymbol,
-        amount,
-        protocolName,
+      publishUserEvent(
         userId,
-      }).catch(() => {})
+        EVENT_TYPE_TOPIC['transaction.confirmed'],
+        'transaction.confirmed',
+        {
+          txHash: transaction.txHash,
+          type,
+          status: transaction.status,
+          assetSymbol,
+          amount,
+          protocolName,
+          userId,
+        }
+      ).catch(() => {})
     }
 
     return res.status(201).json({

--- a/src/events/bridge.ts
+++ b/src/events/bridge.ts
@@ -1,0 +1,171 @@
+/**
+ * Redis pub/sub bridge for multi-instance delivery (#316).
+ *
+ * When the API runs on more than one pod, a user's socket lives on exactly one
+ * of them while the event that concerns them may be produced on any. Every
+ * publish is therefore broadcast on a single Redis channel; each pod delivers
+ * it to whichever of that user's connections it happens to hold.
+ *
+ * ── Loss window, stated plainly ───────────────────────────────────────────────
+ * Redis pub/sub is fire-and-forget: an envelope published while a pod is
+ * restarting, partitioned, or slow is simply not delivered to that pod's
+ * sockets. So live delivery is AT-MOST-ONCE across pods.
+ *
+ * The durable store closes that window, not the transport. Every envelope was
+ * already committed to `user_events` with its seq before it reached this
+ * module, so a client that reconnects and sends `resume afterSeq` gets whatever
+ * it missed, in order. The contract the client sees is therefore at-least-once
+ * with possible duplicates around a reconnect — which is why every frame
+ * carries `seq` and clients dedupe on it.
+ *
+ * ── When Redis is down or unconfigured ────────────────────────────────────────
+ * The publish is never dropped silently. It always reaches this pod's own
+ * subscribers first (bounded in-process broadcast), the failure is counted on
+ * `ws_bridge_publish_total{outcome="local_only"|"error"}`, and an alert is
+ * raised through alertingService with a stable dedupe key so an hour-long
+ * outage produces one alert rather than one per event.
+ */
+
+import { randomUUID } from 'crypto'
+import type { Redis } from 'ioredis'
+import { createRedisSubscriber, getRedisClient } from '../config/redis'
+import { logger } from '../utils/logger'
+import { alertingService } from '../services/alerting'
+import { recordWsBridgePublish } from '../utils/metrics'
+import { deliverToLocalSubscribers } from './hub'
+import { isUserEventTopic, type UserEventEnvelope } from './types'
+
+const CHANNEL = process.env.WS_EVENT_CHANNEL || 'neurowealth:user-events'
+
+/**
+ * Identifies this process in every envelope so we can drop the Redis echo of
+ * our own publish — the local fan-out already happened synchronously.
+ */
+export const POD_ID = `${process.env.HOSTNAME || 'pod'}-${randomUUID().slice(0, 8)}`
+
+let subscriber: Redis | null = null
+let started = false
+
+/** Parse and validate an envelope off the wire. Returns null if unusable. */
+function parseEnvelope(raw: string): UserEventEnvelope | null {
+  try {
+    const parsed = JSON.parse(raw) as UserEventEnvelope
+    if (
+      typeof parsed?.streamUserId !== 'string' ||
+      typeof parsed?.seq !== 'number' ||
+      !Array.isArray(parsed?.authorizedViewers) ||
+      !isUserEventTopic(parsed?.topic)
+    ) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Start listening for envelopes published by other pods.
+ * No-op (and logged once) when REDIS_URL is unset — single-pod deployments and
+ * the test suite run entirely on the in-process hub.
+ */
+export async function startEventBridge(): Promise<void> {
+  if (started) return
+  started = true
+
+  subscriber = createRedisSubscriber()
+  if (!subscriber) {
+    logger.warn(
+      '[EventBridge] REDIS_URL not set — cross-pod event delivery disabled. ' +
+        'Single-instance deployments are unaffected; horizontally scaled ones ' +
+        'will only deliver events to sockets on the publishing pod.'
+    )
+    return
+  }
+
+  subscriber.on('message', (channel, raw) => {
+    if (channel !== CHANNEL) return
+
+    const envelope = parseEnvelope(raw)
+    if (!envelope) {
+      logger.warn('[EventBridge] Discarded unparseable envelope')
+      return
+    }
+
+    // Our own publish already fanned out locally; redelivering it here would
+    // hand every local socket a duplicate of every event.
+    if (envelope.originId === POD_ID) return
+
+    deliverToLocalSubscribers(envelope)
+  })
+
+  await subscriber.subscribe(CHANNEL)
+  logger.info(`[EventBridge] Subscribed to ${CHANNEL} as ${POD_ID}`)
+}
+
+/**
+ * Fan an envelope out: local subscribers synchronously, other pods via Redis.
+ * Returns the number of local deliveries.
+ */
+export async function broadcastEnvelope(
+  envelope: UserEventEnvelope
+): Promise<number> {
+  const localDeliveries = deliverToLocalSubscribers(envelope)
+
+  const redis = getRedisClient()
+  if (!redis) {
+    recordWsBridgePublish('local_only')
+    return localDeliveries
+  }
+
+  try {
+    await redis.publish(CHANNEL, JSON.stringify(envelope))
+    recordWsBridgePublish('redis')
+  } catch (error) {
+    recordWsBridgePublish('error')
+    logger.error(
+      '[EventBridge] Redis publish failed — delivered locally only',
+      {
+        streamUserId: envelope.streamUserId,
+        seq: envelope.seq,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    )
+
+    // Stable dedupe key: one alert per outage, not one per event.
+    alertingService
+      .emit(
+        {
+          title: 'Real-time event bridge degraded',
+          description:
+            'Redis publish failed, so events are reaching only the sockets on ' +
+            'the publishing pod. Clients on other pods will see the gap closed ' +
+            'by their next `resume afterSeq`, but live latency is broken until ' +
+            'Redis recovers.',
+          severity: 'warning',
+          component: 'event-bridge',
+          metadata: { channel: CHANNEL, podId: POD_ID },
+        },
+        'ws:bridge:redis-publish-failed'
+      )
+      .catch(() => {})
+  }
+
+  return localDeliveries
+}
+
+/** Close the subscriber connection. Safe to call when never started. */
+export async function stopEventBridge(): Promise<void> {
+  started = false
+  if (!subscriber) return
+  try {
+    await subscriber.unsubscribe(CHANNEL)
+    await subscriber.quit()
+  } catch (error) {
+    logger.warn('[EventBridge] Subscriber shutdown error', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    subscriber = null
+  }
+}

--- a/src/events/hub.ts
+++ b/src/events/hub.ts
@@ -1,0 +1,90 @@
+/**
+ * In-process fan-out registry for live WebSocket subscribers (#316).
+ *
+ * Deliberately knows nothing about `ws`, JWTs, or Prisma: it maps a stream
+ * owner's id to a set of callbacks. That keeps the publisher independent of the
+ * transport (the socket layer registers here; so could an SSE layer later) and
+ * keeps the socket layer's tests free of a Redis or database dependency.
+ *
+ * Authorisation is NOT decided here. The envelope arrives with the viewer set
+ * the publisher resolved; a subscriber is handed the event only if the identity
+ * it authenticated at handshake is in that set. See UserEventEnvelope.
+ */
+
+import { logger } from '../utils/logger'
+import type { UserEventEnvelope } from './types'
+
+export interface HubSubscriber {
+  /** Stream this subscriber is bound to (own userId, or a permitted child's). */
+  streamUserId: string
+  /** Identity that authenticated at handshake — matched against the viewer set. */
+  viewerUserId: string
+  deliver: (envelope: UserEventEnvelope) => void
+}
+
+const subscribersByStream = new Map<string, Set<HubSubscriber>>()
+
+/** Register a subscriber. Returns the unregister function. */
+export function subscribeToUserStream(subscriber: HubSubscriber): () => void {
+  let set = subscribersByStream.get(subscriber.streamUserId)
+  if (!set) {
+    set = new Set()
+    subscribersByStream.set(subscriber.streamUserId, set)
+  }
+  set.add(subscriber)
+
+  return () => {
+    const current = subscribersByStream.get(subscriber.streamUserId)
+    if (!current) return
+    current.delete(subscriber)
+    if (current.size === 0) subscribersByStream.delete(subscriber.streamUserId)
+  }
+}
+
+/**
+ * Deliver an envelope to every local subscriber of its stream that the
+ * publisher authorised.
+ *
+ * A throwing subscriber is logged and skipped: one wedged socket must never
+ * stop the fan-out to the others.
+ */
+export function deliverToLocalSubscribers(envelope: UserEventEnvelope): number {
+  const set = subscribersByStream.get(envelope.streamUserId)
+  if (!set || set.size === 0) return 0
+
+  const authorized = new Set(envelope.authorizedViewers)
+  let delivered = 0
+
+  for (const subscriber of set) {
+    if (!authorized.has(subscriber.viewerUserId)) continue
+    try {
+      subscriber.deliver(envelope)
+      delivered++
+    } catch (error) {
+      logger.warn('[EventHub] Subscriber delivery threw — skipping', {
+        streamUserId: envelope.streamUserId,
+        seq: envelope.seq,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return delivered
+}
+
+/** Every subscriber currently bound to a stream (used to close revoked sockets). */
+export function getLocalSubscribers(streamUserId: string): HubSubscriber[] {
+  return Array.from(subscribersByStream.get(streamUserId) ?? [])
+}
+
+/** Total live subscribers — the source for the ws_connections_active gauge. */
+export function countLocalSubscribers(): number {
+  let total = 0
+  for (const set of subscribersByStream.values()) total += set.size
+  return total
+}
+
+/** Test helper: forget every registration. */
+export function resetHub(): void {
+  subscribersByStream.clear()
+}

--- a/src/events/publisher.ts
+++ b/src/events/publisher.ts
@@ -1,0 +1,153 @@
+/**
+ * `publishUserEvent` — the one place a user-facing domain event is emitted (#316).
+ *
+ * Before this existed, every domain site called `dispatchWebhookEvent` directly
+ * and a real-time channel would have meant a second bespoke call next to each
+ * one, forever out of sync with the first. Now a site publishes once and both
+ * channels follow:
+ *
+ *   1. redact  — project the payload onto its per-type allowlist
+ *   2. persist — append to the user's durable stream, allocating `seq`
+ *   3. fan out — local sockets + other pods via the Redis bridge
+ *   4. webhook — the existing HMAC-signed operator dispatch, unchanged
+ *
+ * ── Why the webhook leg is unchanged ──────────────────────────────────────────
+ * Webhook subscriptions in this codebase are operator-scoped, not user-scoped:
+ * `dispatchWebhookEvent` fans out to every active subscription for the event
+ * regardless of which user it concerns. So it is called ONCE per domain
+ * occurrence even when the occurrence touches many users, and it receives the
+ * caller's ORIGINAL payload (including `userId`) — an operator's endpoint is a
+ * trusted server and has always needed to know whose event it is. Only the
+ * socket leg gets the redacted projection.
+ *
+ * ── Failure policy ────────────────────────────────────────────────────────────
+ * Never throws. Every existing call site treats event emission as
+ * fire-and-forget (`dispatchWebhookEvent(...).catch(() => {})`) precisely
+ * because a notification problem must not roll back a deposit. That property is
+ * preserved here: a store failure is logged, counted, and the webhook leg still
+ * runs.
+ */
+
+import db from '../db'
+import { logger } from '../utils/logger'
+import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import type { WebhookEvent } from '../validators/webhook-validators'
+import { mapUserEventPayloadToResponse } from '../utils/api-formatters'
+import { recordWsPublishFailure } from '../utils/metrics'
+import { appendUserEvent } from './store'
+import { broadcastEnvelope, POD_ID } from './bridge'
+import {
+  hasWebhookCounterpart,
+  type UserEventEnvelope,
+  type UserEventTopic,
+  type UserEventType,
+} from './types'
+
+export interface PublishOptions {
+  /**
+   * Suppress the webhook leg. Only for a site that has already dispatched the
+   * webhook for this same occurrence by another route — not a way to make an
+   * event "socket-only", which is what SOCKET_ONLY_EVENT_TYPES is for.
+   */
+  webhook?: boolean
+}
+
+/**
+ * Resolve who may see this user's events right now.
+ *
+ * Always the owner, plus any parent holding an ACTIVE sub-account grant with
+ * VIEW. Resolved HERE, at publish time, from live rows — not read off the
+ * subscriber, and not cached. A grant revoked between two events is absent from
+ * the second one's viewer set with nothing to invalidate, which is the whole
+ * reason this lives in the publisher rather than in the socket layer.
+ */
+async function resolveAuthorizedViewers(userId: string): Promise<string[]> {
+  try {
+    const grants = await db.subAccount.findMany({
+      where: {
+        childUserId: userId,
+        status: 'ACTIVE',
+        permissions: { has: 'VIEW' },
+      },
+      select: { parentUserId: true },
+    })
+    return [userId, ...grants.map((g) => g.parentUserId)]
+  } catch (error) {
+    // Fail closed: the owner still gets their own event, a parent does not.
+    logger.warn('[PublishUserEvent] Sub-account scope lookup failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return [userId]
+  }
+}
+
+/**
+ * Publish one domain event to one or more users' real-time streams, and — when
+ * the type has a webhook counterpart — to the operator webhook channel.
+ *
+ * @param userId  Stream owner, or several when one occurrence affects several
+ *                users (an agent rebalance across a batch). The webhook still
+ *                fires exactly once; only the socket streams fan out.
+ * @param topic   Subscription/ordering unit. Use EVENT_TYPE_TOPIC[type] unless
+ *                you have a specific reason not to.
+ * @param type    Domain event type, e.g. 'deposit.received'.
+ * @param payload The full domain payload. Redacted per-type for the socket;
+ *                passed through verbatim to the webhook dispatcher.
+ */
+export async function publishUserEvent(
+  userId: string | string[],
+  topic: UserEventTopic,
+  type: UserEventType,
+  payload: Record<string, unknown>,
+  options: PublishOptions = {}
+): Promise<void> {
+  const userIds = Array.from(
+    new Set(Array.isArray(userId) ? userId : [userId])
+  ).filter(Boolean)
+
+  const redacted = mapUserEventPayloadToResponse(type, payload)
+
+  for (const id of userIds) {
+    try {
+      const stored = await appendUserEvent({
+        userId: id,
+        topic,
+        type,
+        payload: redacted,
+      })
+
+      const envelope: UserEventEnvelope = {
+        streamUserId: id,
+        authorizedViewers: await resolveAuthorizedViewers(id),
+        seq: stored.seq,
+        topic,
+        type,
+        payload: stored.payload,
+        emittedAt: stored.emittedAt,
+        originId: POD_ID,
+      }
+
+      await broadcastEnvelope(envelope)
+    } catch (error) {
+      // A stream failure must not cost the webhook leg, and must not surface to
+      // the caller — see the failure policy in this file's header.
+      recordWsPublishFailure()
+      logger.error('[PublishUserEvent] Failed to publish to user stream', {
+        userId: id,
+        topic,
+        type,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const wantsWebhook = options.webhook ?? hasWebhookCounterpart(type)
+  if (!wantsWebhook) return
+
+  await dispatchWebhookEvent(type as WebhookEvent, payload).catch((error) => {
+    logger.warn('[PublishUserEvent] Webhook dispatch failed', {
+      type,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  })
+}

--- a/src/events/store.ts
+++ b/src/events/store.ts
@@ -1,0 +1,192 @@
+/**
+ * Durable per-user event stream (#316).
+ *
+ * See the DESIGN NOTE on `model UserEvent` in prisma/schema.prisma for why this
+ * is Postgres and not a Redis stream. In short: Redis is optional in this
+ * deployment, so a Redis-only stream would make `resume afterSeq` unavailable
+ * in the most common configuration, and would put durability on a store we
+ * treat everywhere else as a cache.
+ *
+ * `seq` values are exposed to the rest of the process as `number`. Postgres
+ * hands them back as `bigint` (Prisma maps BIGINT that way); a per-user counter
+ * would have to pass 2^53 events before that conversion could lose precision,
+ * which at the platform's busiest plausible rate is longer than the heat death
+ * of the product. Converting at this boundary keeps JSON.stringify working for
+ * every frame — bigint is not JSON-serialisable.
+ */
+
+import db from '../db'
+import { logger } from '../utils/logger'
+import type { UserEventTopic, UserEventType } from './types'
+
+/** One row of the durable stream, as the rest of the process sees it. */
+export interface StoredUserEvent {
+  seq: number
+  topic: UserEventTopic
+  type: UserEventType
+  payload: Record<string, unknown>
+  emittedAt: string
+}
+
+/** How many events a single replay may return. Bounds a hostile `afterSeq: 0`. */
+export const REPLAY_PAGE_LIMIT = Math.max(
+  1,
+  parseInt(process.env.WS_REPLAY_MAX_EVENTS || '1000', 10)
+)
+
+/**
+ * Append an event to a user's stream and return its allocated sequence number.
+ *
+ * The counter increment and the row INSERT run in one transaction. The
+ * increment is a single `INSERT … ON CONFLICT DO UPDATE … RETURNING`, so
+ * concurrent publishers for the same user serialise on that row's lock: no
+ * duplicate seq, and — because the number is allocated and consumed inside the
+ * same transaction — no hole either. A hole would be worse than a duplicate;
+ * a client waiting for the missing seq would stall forever.
+ *
+ * `payload` must already be redacted (see mapUserEventPayloadToResponse). The
+ * store is not a second chance to strip fields: a replay reads straight out of
+ * here, so whatever is written is what a client eventually sees.
+ */
+export async function appendUserEvent(params: {
+  userId: string
+  topic: UserEventTopic
+  type: UserEventType
+  payload: Record<string, unknown>
+}): Promise<StoredUserEvent> {
+  const { userId, topic, type, payload } = params
+
+  return db.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<Array<{ lastSeq: bigint }>>`
+      INSERT INTO "user_event_sequences" ("userId", "lastSeq", "updatedAt")
+      VALUES (${userId}, 1, NOW())
+      ON CONFLICT ("userId") DO UPDATE
+        SET "lastSeq" = "user_event_sequences"."lastSeq" + 1,
+            "updatedAt" = NOW()
+      RETURNING "lastSeq"
+    `
+
+    const seq = Number(rows[0].lastSeq)
+
+    const row = await tx.userEvent.create({
+      data: { userId, seq, topic, type, payload: payload as object },
+      select: {
+        seq: true,
+        topic: true,
+        type: true,
+        payload: true,
+        createdAt: true,
+      },
+    })
+
+    return {
+      seq: Number(row.seq),
+      topic: row.topic as UserEventTopic,
+      type: row.type as UserEventType,
+      payload: (row.payload ?? {}) as Record<string, unknown>,
+      emittedAt: row.createdAt.toISOString(),
+    }
+  })
+}
+
+/** Newest seq allocated for a user, or 0 when they have never had an event. */
+export async function getLatestSeq(userId: string): Promise<number> {
+  const row = await db.userEventSequence.findUnique({
+    where: { userId },
+    select: { lastSeq: true },
+  })
+  return row ? Number(row.lastSeq) : 0
+}
+
+/** Oldest seq still replayable, or null once retention has emptied the stream. */
+export async function getOldestAvailableSeq(
+  userId: string
+): Promise<number | null> {
+  const row = await db.userEvent.findFirst({
+    where: { userId },
+    orderBy: { seq: 'asc' },
+    select: { seq: true },
+  })
+  return row ? Number(row.seq) : null
+}
+
+/**
+ * Read up to `limit` events after `afterSeq`, oldest first, restricted to
+ * `topics`.
+ *
+ * Topic filtering happens in SQL rather than in the caller so a client
+ * subscribed to one quiet topic cannot make the server page through another
+ * topic's storm to find it.
+ */
+export async function readAfterSeq(params: {
+  userId: string
+  afterSeq: number
+  topics: UserEventTopic[]
+  limit?: number
+}): Promise<StoredUserEvent[]> {
+  const { userId, afterSeq, topics } = params
+  const limit = Math.min(params.limit ?? REPLAY_PAGE_LIMIT, REPLAY_PAGE_LIMIT)
+
+  if (topics.length === 0) return []
+
+  const rows = await db.userEvent.findMany({
+    where: { userId, seq: { gt: afterSeq }, topic: { in: topics } },
+    orderBy: { seq: 'asc' },
+    take: limit,
+    select: {
+      seq: true,
+      topic: true,
+      type: true,
+      payload: true,
+      createdAt: true,
+    },
+  })
+
+  return rows.map((row) => ({
+    seq: Number(row.seq),
+    topic: row.topic as UserEventTopic,
+    type: row.type as UserEventType,
+    payload: (row.payload ?? {}) as Record<string, unknown>,
+    emittedAt: row.createdAt.toISOString(),
+  }))
+}
+
+/**
+ * Trim any user whose stream exceeds `maxPerUser` rows, keeping the newest.
+ *
+ * Complements the age-based sweep in src/jobs/dataRetention.ts: age alone lets
+ * one pathological account grow without bound inside the retention window, and
+ * the whole point of a bounded stream is that no single user can do that.
+ * Returns the number of rows deleted.
+ */
+export async function trimUserEventStreams(
+  maxPerUser: number
+): Promise<number> {
+  if (maxPerUser <= 0) return 0
+
+  try {
+    // One statement: for every user over the cap, delete everything below the
+    // seq of their `maxPerUser`-th newest event. Doing this per-user in JS
+    // would be a query per account on a table that only ever grows.
+    const result = await db.$executeRaw`
+      DELETE FROM "user_events" ue
+      USING (
+        SELECT "userId", "seq" AS cutoff
+        FROM (
+          SELECT "userId",
+                 "seq",
+                 ROW_NUMBER() OVER (PARTITION BY "userId" ORDER BY "seq" DESC) AS rn
+          FROM "user_events"
+        ) ranked
+        WHERE ranked.rn = ${maxPerUser}
+      ) keep
+      WHERE ue."userId" = keep."userId" AND ue."seq" < keep.cutoff
+    `
+    return result
+  } catch (error) {
+    logger.error('[UserEventStore] Stream trim failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return 0
+  }
+}

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared vocabulary for the authenticated real-time stream (#316).
+ *
+ * Every user-facing domain event flows through `publishUserEvent` (see
+ * ./publisher.ts) and lands in exactly one topic. Topics are the unit of
+ * subscription, of ordering, and of permission — keep them coarse.
+ */
+
+import type { WebhookEvent } from '../validators/webhook-validators'
+
+// ── Topics ────────────────────────────────────────────────────────────────────
+
+export const USER_EVENT_TOPICS = [
+  'portfolio',
+  'transactions',
+  'agent',
+  'alerts',
+  'strategies',
+] as const
+
+export type UserEventTopic = (typeof USER_EVENT_TOPICS)[number]
+
+export function isUserEventTopic(value: unknown): value is UserEventTopic {
+  return (
+    typeof value === 'string' &&
+    (USER_EVENT_TOPICS as readonly string[]).includes(value)
+  )
+}
+
+// ── Event types ───────────────────────────────────────────────────────────────
+
+/**
+ * Socket-only event types — real-time signals with no webhook counterpart.
+ * Kept deliberately separate from WEBHOOK_EVENTS so adding one here can never
+ * change what an operator's configured webhook receives.
+ */
+export const SOCKET_ONLY_EVENT_TYPES = [
+  /** Emitted alongside agent.rebalanced: this user's positions moved. */
+  'portfolio.updated',
+] as const
+
+export type SocketOnlyEventType = (typeof SOCKET_ONLY_EVENT_TYPES)[number]
+
+/** Anything publishable on a user stream: a webhook event or a socket-only one. */
+export type UserEventType = WebhookEvent | SocketOnlyEventType
+
+/**
+ * Canonical topic for every event type. Exhaustive over both unions, so a new
+ * webhook event fails the build here until someone decides where it belongs —
+ * which is the whole point of routing through one table rather than wiring each
+ * emit site by hand.
+ */
+export const EVENT_TYPE_TOPIC: Record<UserEventType, UserEventTopic> = {
+  'transaction.confirmed': 'transactions',
+  'deposit.received': 'transactions',
+  'withdraw.completed': 'transactions',
+  'fiat.order.settled': 'transactions',
+  'fiat.order.failed': 'transactions',
+  'fiat.order.rate_mismatch': 'transactions',
+  'recurring_deposit.executed': 'transactions',
+  'recurring_deposit.failed': 'transactions',
+  'outbox.op_failed': 'transactions',
+  'agent.rebalanced': 'agent',
+  'alert_rule.triggered': 'alerts',
+  'strategy.updated': 'strategies',
+  'strategy.unpublished': 'strategies',
+  'portfolio.updated': 'portfolio',
+}
+
+const SOCKET_ONLY = new Set<string>(SOCKET_ONLY_EVENT_TYPES)
+
+/** True when this type also has an operator-facing webhook counterpart. */
+export function hasWebhookCounterpart(type: UserEventType): boolean {
+  return !SOCKET_ONLY.has(type)
+}
+
+// ── Wire frames (server → client) ─────────────────────────────────────────────
+
+/** One delivered domain event. `seq` is monotonic within the user's stream. */
+export interface EventFrame {
+  type: 'event'
+  seq: number
+  topic: UserEventTopic
+  event: UserEventType
+  payload: Record<string, unknown>
+  emittedAt: string
+}
+
+/**
+ * Sent instead of a replay the server cannot honour, and after a
+ * backpressure drop. `snapshotRequired` tells the client the cheap path
+ * (replay) is gone and it should re-fetch a REST snapshot before resubscribing.
+ */
+export interface GapFrame {
+  type: 'gap'
+  reason: 'retention' | 'backpressure' | 'unknown_stream'
+  /** The seq the client asked to resume after, when it asked. */
+  afterSeq: number | null
+  /** Newest seq that exists for this user right now. */
+  currentSeq: number
+  /** Oldest seq still replayable, or null when the stream is empty. */
+  oldestAvailableSeq: number | null
+  snapshotRequired: boolean
+}
+
+export interface SubscribedFrame {
+  type: 'subscribed'
+  topics: UserEventTopic[]
+  currentSeq: number
+  /** Echoed so a client can confirm the server honoured its coalesce request. */
+  coalesce: boolean
+}
+
+export interface ReplayFrame {
+  type: 'replay'
+  status: 'start' | 'end'
+  fromSeq: number
+  toSeq: number
+  count: number
+}
+
+export interface ErrorFrame {
+  type: 'error'
+  code:
+    'bad_request' | 'forbidden' | 'unauthorized' | 'rate_limited' | 'internal'
+  message: string
+}
+
+/** Sent before the socket closes during graceful shutdown. */
+export interface DrainingFrame {
+  type: 'draining'
+  reason: 'server_shutdown'
+  /** Resume from here on the next connection. */
+  resumeAfterSeq: number
+  retryAfterMs: number
+}
+
+/** Reply to an application-level `ping`. */
+export interface PongFrame {
+  type: 'pong'
+  at: string
+}
+
+export interface HelloFrame {
+  type: 'hello'
+  /** The stream this connection is bound to: self, or a permitted child. */
+  actor: 'self' | 'delegated'
+  topics: UserEventTopic[]
+  currentSeq: number
+  heartbeatIntervalMs: number
+}
+
+export type ServerFrame =
+  | HelloFrame
+  | SubscribedFrame
+  | ReplayFrame
+  | EventFrame
+  | GapFrame
+  | ErrorFrame
+  | DrainingFrame
+  | PongFrame
+
+// ── Internal envelope (publisher → fan-out, including across pods) ────────────
+
+/**
+ * What travels from `publishUserEvent` to every connection holder, locally and
+ * over the Redis bridge.
+ *
+ * `authorizedViewers` is resolved by the PUBLISHER, from the live SubAccount
+ * grants, at the moment of publish. The socket layer only ever intersects it
+ * with the viewer identity it authenticated at handshake — it never re-derives
+ * permission and never trusts anything the subscriber said. A grant revoked a
+ * second ago is therefore absent from the next event's viewer set without any
+ * cache to invalidate.
+ */
+export interface UserEventEnvelope {
+  streamUserId: string
+  authorizedViewers: string[]
+  seq: number
+  topic: UserEventTopic
+  type: UserEventType
+  /** Already redacted — see mapUserEventPayloadToResponse. */
+  payload: Record<string, unknown>
+  emittedAt: string
+  /** Pod that published it; used to suppress the Redis echo of our own emit. */
+  originId: string
+}

--- a/src/fiat/service.ts
+++ b/src/fiat/service.ts
@@ -39,7 +39,8 @@
  */
 import db from '../db'
 import { logger } from '../utils/logger'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { alertingService } from '../services/alerting'
 import {
   getDefaultProvider,
@@ -550,14 +551,19 @@ export async function processProviderWebhook(
   // Emit outbound webhook for terminal failure/refund so subscribers react.
   if (updated.status === 'FAILED' || updated.status === 'REFUNDED') {
     recordFiatOrder(providerName, updated.status)
-    dispatchWebhookEvent('fiat.order.failed', {
-      orderId: updated.id,
-      provider: providerName,
-      direction: updated.direction,
-      status: updated.status,
-      failureReason: updated.failureReason,
-      userId: updated.userId,
-    }).catch(() => {})
+    publishUserEvent(
+      updated.userId,
+      EVENT_TYPE_TOPIC['fiat.order.failed'],
+      'fiat.order.failed',
+      {
+        orderId: updated.id,
+        provider: providerName,
+        direction: updated.direction,
+        status: updated.status,
+        failureReason: updated.failureReason,
+        userId: updated.userId,
+      }
+    ).catch(() => {})
   }
 
   // If the provider handed us a tx hash, try an immediate reconciliation pass
@@ -652,14 +658,19 @@ export async function reconcileSingleOrder(
 
   recordFiatOrder(order.provider, 'SETTLED')
 
-  dispatchWebhookEvent('fiat.order.settled', {
-    orderId: settled.id,
-    provider: settled.provider,
-    direction: settled.direction,
-    status: 'SETTLED',
-    txHash,
-    userId: settled.userId,
-  }).catch(() => {})
+  publishUserEvent(
+    settled.userId,
+    EVENT_TYPE_TOPIC['fiat.order.settled'],
+    'fiat.order.settled',
+    {
+      orderId: settled.id,
+      provider: settled.provider,
+      direction: settled.direction,
+      status: 'SETTLED',
+      txHash,
+      userId: settled.userId,
+    }
+  ).catch(() => {})
 
   if (driftPct !== null) {
     recordFiatRateDrift(order.provider, order.direction, Math.abs(driftPct))
@@ -689,15 +700,20 @@ export async function reconcileSingleOrder(
         )
         .catch(() => {})
 
-      dispatchWebhookEvent('fiat.order.rate_mismatch', {
-        orderId: order.id,
-        provider: order.provider,
-        direction: order.direction,
-        quotedCryptoAmount,
-        settledCryptoAmount,
-        driftPct,
-        userId: order.userId,
-      }).catch(() => {})
+      publishUserEvent(
+        order.userId,
+        EVENT_TYPE_TOPIC['fiat.order.rate_mismatch'],
+        'fiat.order.rate_mismatch',
+        {
+          orderId: order.id,
+          provider: order.provider,
+          direction: order.direction,
+          quotedCryptoAmount,
+          settledCryptoAmount,
+          driftPct,
+          userId: order.userId,
+        }
+      ).catch(() => {})
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ import { scheduleOutboxDispatcher } from './outbox/dispatcher'
 import { scheduleProtocolRiskScoring } from './jobs/protocolRiskScoring'
 import { schedulePortfolioRiskJob } from './jobs/portfolioRisk'
 import { startEventListener, stopEventListener } from './stellar/events'
+import { startEventBridge, stopEventBridge } from './events/bridge'
+import { attachWebSocketServer, closeWebSocketServer } from './ws/server'
 import { validateStellarNetworkReady } from './config/readiness'
 import healthRouter from './routes/health'
 import agentRouter from './routes/agent'
@@ -414,6 +416,16 @@ async function gracefulShutdown(signal: string): Promise<void> {
     process.exit(0)
   }
 
+  // #316: WebSocket sockets must drain BEFORE httpServer.close(). An open
+  // WebSocket is a live HTTP connection, so closing the HTTP server first would
+  // simply block on them until the grace period expired and then cut them
+  // without warning. Draining first gives each client a `draining` frame
+  // carrying the seq to resume after, so a rolling deploy costs a reconnect
+  // rather than a REST snapshot. Awaited — connection cleanup is not optional.
+  logger.info('[Shutdown] Draining WebSocket connections...')
+  await closeWebSocketServer()
+  await stopEventBridge()
+
   logger.info('[Shutdown] Closing HTTP server (no new requests accepted)')
   httpServer.close(async () => {
     logger.info('[Shutdown] HTTP server closed')
@@ -554,6 +566,24 @@ async function main(): Promise<void> {
   httpServer = app.listen(config.port, () => {
     logger.info(`[Startup] HTTP server listening on port ${config.port} ✓`)
     logger.info('[Startup] All systems operational — ready to serve requests')
+  })
+
+  // #316: authenticated real-time stream. Attached to the same HTTP server, so
+  // it inherits the TLS termination, proxy configuration, and port the REST
+  // surface already has. Started after listen() because it hooks the server's
+  // 'upgrade' event, and the bridge is started alongside it so cross-pod
+  // envelopes have somewhere to land the moment a socket connects.
+  attachWebSocketServer(httpServer)
+  await startEventBridge().catch((error) => {
+    // A bridge failure degrades multi-pod delivery to pod-local delivery; it is
+    // not a reason to refuse to serve traffic. Clients close the resulting gap
+    // with `resume afterSeq`.
+    logger.error(
+      '[Startup] Event bridge failed to start — continuing with pod-local delivery only',
+      {
+        error: error instanceof Error ? error.message : String(error),
+      }
+    )
   })
 
   process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))

--- a/src/jobs/alertRules.ts
+++ b/src/jobs/alertRules.ts
@@ -6,7 +6,8 @@ import {
 } from '../utils/correlation'
 import { recordJobSuccess, recordJobFailure } from '../utils/job-metrics'
 import { config } from '../config/env'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { sendWhatsAppMessage } from '../utils/twilio-client'
 import { formatAlertTriggeredReply } from '../whatsapp/formatters'
 import {
@@ -24,7 +25,9 @@ import {
  * On each tick this job loads ACTIVE rules, computes the current value for each
  * rule's metric, and fires a notification when the comparator condition holds
  * and the rule is outside its cooldown window. Fires go out over the webhook
- * (HMAC-signed, via the existing dispatchWebhookEvent) and/or WhatsApp channels.
+ * (HMAC-signed, via publishUserEvent's webhook leg) and/or WhatsApp channels.
+ * Every trigger also lands on the user's real-time stream (#316), which is not
+ * something they have to configure.
  *
  * Design decisions (see issue #289):
  *
@@ -47,7 +50,7 @@ import {
  *    row is auto-deactivated (isActive=false) with a clear log line rather than
  *    evaluated against stale/missing data.
  *
- *  • Failed webhook delivery: we reuse dispatchWebhookEvent as-is. Its internal
+ *  • Failed webhook delivery: publishUserEvent reuses the same dispatcher. Its internal
  *    3-attempt backoff is the only retry; there is no separate sweep for alert
  *    deliveries. Rationale documented in docs/ALERTS.md — the next tick re-
  *    evaluates the live condition, so a transient delivery failure self-heals
@@ -200,10 +203,17 @@ async function deliverAlert(
   const wantsWhatsApp =
     rule.deliveryChannel === 'WHATSAPP' || rule.deliveryChannel === 'BOTH'
 
-  if (wantsWebhook) {
-    // HMAC-signed via the existing dispatcher; no new unsigned path.
-    await dispatchWebhookEvent('alert_rule.triggered', data)
-  }
+  // #316: the alert always reaches the user's real-time stream — that is the
+  // channel they did not have to configure. The webhook leg stays opt-in via
+  // the rule's deliveryChannel, and is still HMAC-signed by the same
+  // dispatcher; no new unsigned path.
+  await publishUserEvent(
+    rule.userId,
+    EVENT_TYPE_TOPIC['alert_rule.triggered'],
+    'alert_rule.triggered',
+    data,
+    { webhook: wantsWebhook }
+  )
 
   if (wantsWhatsApp) {
     const user = await db.user.findUnique({

--- a/src/jobs/dataRetention.ts
+++ b/src/jobs/dataRetention.ts
@@ -12,6 +12,7 @@ import {
   aggregatePayloadHash,
   GENESIS_AUDIT_HASH,
 } from '../audit/chain'
+import { trimUserEventStreams } from '../events/store'
 
 function cutoffDate(retentionDays: number): Date {
   const d = new Date()
@@ -263,6 +264,70 @@ export async function cleanupAgentLogs(): Promise<void> {
 }
 
 /**
+ * Prune the real-time user event stream (#316).
+ *
+ * Two bounds, both required. Age (RETENTION_USER_EVENTS_DAYS, default 7) is the
+ * one clients reason about: a client offline longer than this gets a `gap`
+ * frame and re-fetches a REST snapshot. The per-user row cap
+ * (USER_EVENT_STREAM_MAX_PER_USER) is the one that protects the pod: age alone
+ * lets a single pathological account grow without limit inside the window, and
+ * the whole promise of this table is that no user can do that.
+ *
+ * Deliberately NOT anchored into the audit chain like processed_events: these
+ * rows are a redacted, short-lived projection of events whose authoritative
+ * records (Transaction, ProcessedEvent, AgentLog) are anchored already. Hashing
+ * them again would anchor a copy, not evidence.
+ */
+export async function cleanupUserEvents(): Promise<void> {
+  const correlationId = generateCorrelationId()
+  return runWithCorrelationIdAsync(correlationId, async () => {
+    const start = Date.now()
+    const jobName = 'retention_user_events'
+
+    try {
+      const cutoff = cutoffDate(config.retention.userEventsDays)
+      const expired = await db.userEvent.deleteMany({
+        where: { createdAt: { lt: cutoff } },
+      })
+      const trimmed = await trimUserEventStreams(
+        config.retention.userEventsMaxPerUser
+      )
+
+      const durationMs = Date.now() - start
+      const duration = durationMs / 1000
+      const rowsDeleted = expired.count + trimmed
+
+      logBackgroundJob(jobName, 'success', duration, correlationId, {
+        rowsDeleted,
+        expiredByAge: expired.count,
+        trimmedByCap: trimmed,
+        retentionDays: config.retention.userEventsDays,
+        maxPerUser: config.retention.userEventsMaxPerUser,
+      })
+
+      if (rowsDeleted > 0) {
+        recordRetentionDeletes('user_events', rowsDeleted)
+      }
+      recordBackgroundJob(jobName, 'success', duration)
+      recordJobSuccess(jobName, durationMs)
+    } catch (error) {
+      const durationMs = Date.now() - start
+      const duration = durationMs / 1000
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error'
+
+      logBackgroundJob(jobName, 'failed', duration, correlationId, {
+        error: errorMessage,
+        retentionDays: config.retention.userEventsDays,
+      })
+
+      recordBackgroundJob(jobName, 'failed', duration)
+      recordJobFailure(jobName, durationMs)
+    }
+  })
+}
+
+/**
  * Run all retention jobs sequentially.
  */
 export async function runAllRetentionJobs(): Promise<void> {
@@ -280,6 +345,7 @@ export async function runAllRetentionJobs(): Promise<void> {
       await cleanupProcessedEvents()
       await cleanupDeadLetterEvents()
       await cleanupAgentLogs()
+      await cleanupUserEvents()
 
       const duration = (Date.now() - startTime) / 1000
       logBackgroundJob(jobName, 'success', duration, correlationId)
@@ -308,7 +374,9 @@ export function scheduleDataRetention(): NodeJS.Timeout {
     `[DataRetention] Retention jobs scheduled every ${config.retention.intervalMs / 3600000}h` +
       ` (processed_events=${config.retention.processedEventsDays}d,` +
       ` dlq=${config.retention.deadLetterEventsDays}d,` +
-      ` agent_logs=${config.retention.agentLogsDays}d)`
+      ` agent_logs=${config.retention.agentLogsDays}d,` +
+      ` user_events=${config.retention.userEventsDays}d/` +
+      `${config.retention.userEventsMaxPerUser} per user)`
   )
   return handle
 }

--- a/src/jobs/recurringDeposits.ts
+++ b/src/jobs/recurringDeposits.ts
@@ -8,7 +8,8 @@ import { config } from '../config/env'
 import { recordBackgroundJob } from '../utils/metrics'
 import { recordJobSuccess, recordJobFailure } from '../utils/job-metrics'
 import { executeDeposit } from '../controllers/transaction-controller'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { addCadence } from '../utils/cadence'
 import type { RecurringDepositPlan } from '@prisma/client'
 
@@ -105,14 +106,19 @@ async function executePlan(plan: RecurringDepositPlan): Promise<void> {
         txHash: result.transaction.txHash,
       })
 
-      dispatchWebhookEvent('recurring_deposit.executed', {
-        planId: plan.id,
-        userId: plan.userId,
-        amount: Number(plan.amount),
-        assetSymbol: plan.assetSymbol,
-        cadence: plan.cadence,
-        txHash: result.transaction.txHash,
-      }).catch(() => {})
+      publishUserEvent(
+        plan.userId,
+        EVENT_TYPE_TOPIC['recurring_deposit.executed'],
+        'recurring_deposit.executed',
+        {
+          planId: plan.id,
+          userId: plan.userId,
+          amount: Number(plan.amount),
+          assetSymbol: plan.assetSymbol,
+          cadence: plan.cadence,
+          txHash: result.transaction.txHash,
+        }
+      ).catch(() => {})
     } else {
       await failPlan(plan, 'transaction_failed')
     }
@@ -147,14 +153,19 @@ async function failPlan(
     reason,
   })
 
-  dispatchWebhookEvent('recurring_deposit.failed', {
-    planId: plan.id,
-    userId: plan.userId,
-    amount: Number(plan.amount),
-    assetSymbol: plan.assetSymbol,
-    cadence: plan.cadence,
-    reason,
-  }).catch(() => {})
+  publishUserEvent(
+    plan.userId,
+    EVENT_TYPE_TOPIC['recurring_deposit.failed'],
+    'recurring_deposit.failed',
+    {
+      planId: plan.id,
+      userId: plan.userId,
+      amount: Number(plan.amount),
+      assetSymbol: plan.assetSymbol,
+      cadence: plan.cadence,
+      reason,
+    }
+  ).catch(() => {})
 }
 
 /**

--- a/src/outbox/dispatcher.ts
+++ b/src/outbox/dispatcher.ts
@@ -21,7 +21,8 @@
 import { logger } from '../utils/logger'
 import { config } from '../config/env'
 import { alertingService } from '../services/alerting'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { TransactionResult } from '../stellar/types'
 import { getSignerLock } from './signerLock'
 import { resolveSignerPublicKey, executeOutboxPayload } from './executors'
@@ -92,13 +93,18 @@ async function onTerminalFailure(
       logger.error('[Outbox] Failed to emit terminal-failure alert', { err })
     )
 
-  await dispatchWebhookEvent('outbox.op_failed', {
-    opId: op.id,
-    kind: op.kind,
-    userId: op.userId,
-    attempts: op.attempts,
-    error: errorMessage,
-  }).catch(() => {})
+  await publishUserEvent(
+    op.userId,
+    EVENT_TYPE_TOPIC['outbox.op_failed'],
+    'outbox.op_failed',
+    {
+      opId: op.id,
+      kind: op.kind,
+      userId: op.userId,
+      attempts: op.attempts,
+      error: errorMessage,
+    }
+  ).catch(() => {})
 }
 
 /**

--- a/src/stellar/events.ts
+++ b/src/stellar/events.ts
@@ -32,7 +32,8 @@ import {
   updateLastProcessedLedger,
   recordDbOperation,
 } from '../utils/metrics'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { checkAndActivateOnDeposit } from '../referral/service'
 import { reconcileOutboxOpByTxHash } from '../outbox/service'
 import {
@@ -230,7 +231,7 @@ async function handleDepositEvent(
   depositData: DepositEvent,
   event: ContractEvent,
   tx: any = db
-): Promise<void> {
+): Promise<string> {
   const user = (await timedDbOperation(() =>
     tx.user.findUnique({ where: { walletAddress: depositData.user } })
   )) as any
@@ -334,6 +335,10 @@ async function handleDepositEvent(
     transaction.confirmedAt ?? new Date(),
     tx
   )
+
+  // Returned so handleEvent can address the real-time stream to the right
+  // user without repeating the walletAddress lookup this function already did.
+  return user.id
 }
 
 /**
@@ -343,7 +348,7 @@ async function handleWithdrawEvent(
   withdrawData: WithdrawEvent,
   event: ContractEvent,
   tx: any = db
-): Promise<void> {
+): Promise<string> {
   const user = (await timedDbOperation(() =>
     tx.user.findUnique({ where: { walletAddress: withdrawData.user } })
   )) as any
@@ -426,6 +431,8 @@ async function handleWithdrawEvent(
     transaction.confirmedAt ?? new Date(),
     tx
   )
+
+  return user.id
 }
 
 /**
@@ -500,22 +507,33 @@ export async function handleEvent(
         case 'deposit': {
           const depositData = parseDepositEvent(event)
           DepositEventSchema.parse(depositData)
-          await handleDepositEvent(depositData, event, tx)
-          dispatchWebhookEvent('deposit.received', {
-            txHash: event.txHash,
-            ...depositData,
-          }).catch(() => {})
+          const depositUserId = await handleDepositEvent(depositData, event, tx)
+          // #316: one call now feeds both the operator webhook and the
+          // depositor's live socket. Fire-and-forget, as before — a
+          // notification problem must never roll back a confirmed deposit.
+          publishUserEvent(
+            depositUserId,
+            EVENT_TYPE_TOPIC['deposit.received'],
+            'deposit.received',
+            { txHash: event.txHash, ...depositData }
+          ).catch(() => {})
           break
         }
 
         case 'withdraw': {
           const withdrawData = parseWithdrawEvent(event)
           WithdrawEventSchema.parse(withdrawData)
-          await handleWithdrawEvent(withdrawData, event, tx)
-          dispatchWebhookEvent('withdraw.completed', {
-            txHash: event.txHash,
-            ...withdrawData,
-          }).catch(() => {})
+          const withdrawUserId = await handleWithdrawEvent(
+            withdrawData,
+            event,
+            tx
+          )
+          publishUserEvent(
+            withdrawUserId,
+            EVENT_TYPE_TOPIC['withdraw.completed'],
+            'withdraw.completed',
+            { txHash: event.txHash, ...withdrawData }
+          ).catch(() => {})
           break
         }
 
@@ -523,10 +541,17 @@ export async function handleEvent(
           const rebalanceData = parseRebalanceEvent(event)
           RebalanceEventSchema.parse(rebalanceData)
           await handleRebalanceEvent(rebalanceData, event, tx)
-          dispatchWebhookEvent('agent.rebalanced', {
-            txHash: event.txHash,
-            ...rebalanceData,
-          }).catch(() => {})
+          // Contract-level rebalance events are protocol-wide, not user-scoped:
+          // there is no user to address a stream frame to, so this one stays on
+          // the operator webhook channel alone. The per-user view of a
+          // rebalance is emitted by the agent loop, which knows whose positions
+          // moved. Passing an empty user list keeps the single emit path.
+          publishUserEvent(
+            [],
+            EVENT_TYPE_TOPIC['agent.rebalanced'],
+            'agent.rebalanced',
+            { txHash: event.txHash, ...rebalanceData }
+          ).catch(() => {})
           break
         }
         default:

--- a/src/strategy/service.ts
+++ b/src/strategy/service.ts
@@ -24,7 +24,8 @@
 import { Prisma } from '@prisma/client'
 import db from '../db'
 import { logger } from '../utils/logger'
-import { dispatchWebhookEvent } from '../services/webhookDispatcher'
+import { publishUserEvent } from '../events/publisher'
+import { EVENT_TYPE_TOPIC } from '../events/types'
 import { sendWhatsAppMessage } from '../utils/twilio-client'
 import {
   formatStrategyUpdatedReply,
@@ -529,7 +530,7 @@ export async function loadActiveFollowsForUsers(
  * Runs OUTSIDE the transaction that changed the strategy and never rethrows:
  * a Twilio outage or a dead webhook endpoint must not roll back a publish or
  * leave a follower's snapshot half-written. Same fire-and-forget convention as
- * dispatchWebhookEvent(...).catch(() => {}) in agent/loop.ts.
+ * publishUserEvent(...).catch(() => {}) in agent/loop.ts.
  *
  * A follower with no phone on file is warned and skipped, never thrown —
  * matching src/jobs/alertRules.ts.
@@ -558,8 +559,16 @@ async function notifyFollowers(
             : {}),
         }
 
-        await dispatchWebhookEvent(event, data).catch((error) => {
-          logger.warn('[Strategy] Webhook dispatch failed', {
+        // #316: one call reaches this follower's live socket AND the operator
+        // webhook channel. Still anonymised — the payload names the strategy
+        // and the follower, never the publisher.
+        await publishUserEvent(
+          follower.followerUserId,
+          EVENT_TYPE_TOPIC[event],
+          event,
+          data
+        ).catch((error) => {
+          logger.warn('[Strategy] Event publish failed', {
             event,
             strategyId,
             error: error instanceof Error ? error.message : 'Unknown error',

--- a/src/utils/api-formatters.ts
+++ b/src/utils/api-formatters.ts
@@ -159,3 +159,129 @@ export const mapAllocationSuggestionToResponse = (suggestion: any) => ({
   reason: suggestion.reason ?? null,
   computedAt: suggestion.computedAt.toISOString(),
 })
+
+/**
+ * Real-time stream payload allowlists (#316) — the socket's equivalent of the
+ * REST mappers above, and held to the same rule.
+ *
+ * A WebSocket frame is a response body. It gets the same discipline: a
+ * hand-written allowlist per event type, never a spread, never a denylist. The
+ * emit sites pass the same object they hand `dispatchWebhookEvent`, and those
+ * objects carry `userId` (an operator's webhook endpoint is a trusted server;
+ * an end user's browser is not). Anything not named here is dropped before the
+ * payload is persisted to `user_events`, so a replay cannot leak what the live
+ * path stripped.
+ *
+ * Adding a key here is the moment to ask: would I put this in a REST response
+ * for this user? If not, it does not belong on their socket either.
+ */
+const USER_EVENT_PAYLOAD_ALLOWLIST: Record<string, readonly string[]> = {
+  'transaction.confirmed': [
+    'txHash',
+    'type',
+    'status',
+    'assetSymbol',
+    'amount',
+    'protocolName',
+  ],
+  // `user` (the wallet address) is deliberately absent: the client already
+  // knows its own wallet, and a delegated parent connection must not learn the
+  // child's address from a stream frame.
+  'deposit.received': [
+    'txHash',
+    'amount',
+    'shares',
+    'assetSymbol',
+    'protocolName',
+    'network',
+  ],
+  'withdraw.completed': [
+    'txHash',
+    'amount',
+    'shares',
+    'assetSymbol',
+    'protocolName',
+    'network',
+  ],
+  'agent.rebalanced': [
+    'txHash',
+    'fromProtocol',
+    'toProtocol',
+    'amount',
+    'improvedBy',
+    'timestamp',
+  ],
+  'fiat.order.settled': [
+    'orderId',
+    'provider',
+    'direction',
+    'status',
+    'txHash',
+  ],
+  'fiat.order.failed': [
+    'orderId',
+    'provider',
+    'direction',
+    'status',
+    'failureReason',
+  ],
+  'fiat.order.rate_mismatch': [
+    'orderId',
+    'provider',
+    'direction',
+    'quotedCryptoAmount',
+    'settledCryptoAmount',
+    'driftPct',
+  ],
+  'recurring_deposit.executed': [
+    'planId',
+    'amount',
+    'assetSymbol',
+    'cadence',
+    'txHash',
+  ],
+  'recurring_deposit.failed': [
+    'planId',
+    'amount',
+    'assetSymbol',
+    'cadence',
+    'reason',
+  ],
+  'alert_rule.triggered': [
+    'ruleId',
+    'metric',
+    'protocolName',
+    'comparator',
+    'threshold',
+    'observedValue',
+    'triggeredAt',
+  ],
+  // `followerUserId` is dropped: the frame is already scoped to that follower.
+  'strategy.updated': ['strategyId', 'label', 'configVersion'],
+  'strategy.unpublished': ['strategyId', 'label'],
+  // `error` is the user's own op failure text, already sent to their webhooks.
+  'outbox.op_failed': ['opId', 'kind', 'attempts', 'error'],
+  'portfolio.updated': ['protocolName', 'positionsAffected', 'reason'],
+}
+
+/**
+ * Project a domain payload onto the allowlist for its event type.
+ *
+ * An unknown event type yields `{}` rather than the original object: a type
+ * nobody has reviewed is a type whose fields nobody has reviewed. Values are
+ * copied as-is (they are already JSON-safe primitives at every emit site);
+ * `undefined` values are omitted so the stored JSON stays clean.
+ */
+export const mapUserEventPayloadToResponse = (
+  eventType: string,
+  payload: Record<string, unknown>
+): Record<string, unknown> => {
+  const allowed = USER_EVENT_PAYLOAD_ALLOWLIST[eventType]
+  if (!allowed) return {}
+
+  const out: Record<string, unknown> = {}
+  for (const key of allowed) {
+    if (payload[key] !== undefined) out[key] = payload[key]
+  }
+  return out
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -643,6 +643,119 @@ export function updateOutboxStuckSubmitted(count: number): void {
   outboxStuckSubmitted.set(count)
 }
 
+// ── Real-time WebSocket streaming metrics (#316) ─────────────────────────────
+
+export const wsConnectionsActive = new client.Gauge({
+  name: 'ws_connections_active',
+  help: 'Currently open authenticated WebSocket connections',
+  labelNames: ['mode'] as const, // mode: self|delegated
+  registers: [register],
+})
+
+export const wsHandshakesTotal = new client.Counter({
+  name: 'ws_handshakes_total',
+  help: 'WebSocket handshake attempts by outcome',
+  labelNames: ['outcome'] as const, // outcome: accepted|unauthorized|forbidden|rate_limited|too_many
+  registers: [register],
+})
+
+export const wsMessagesSentTotal = new client.Counter({
+  name: 'ws_messages_sent_total',
+  help: 'Frames pushed to clients, by topic and delivery path',
+  labelNames: ['topic', 'path'] as const, // path: live|replay
+  registers: [register],
+})
+
+export const wsMessagesReceivedTotal = new client.Counter({
+  name: 'ws_messages_received_total',
+  help: 'Client messages received, by message type',
+  labelNames: ['type'] as const,
+  registers: [register],
+})
+
+export const wsReplayEventsTotal = new client.Counter({
+  name: 'ws_replay_events_total',
+  help: 'Events replayed from the durable stream on resume',
+  registers: [register],
+})
+
+export const wsGapsTotal = new client.Counter({
+  name: 'ws_gaps_total',
+  help: 'Gap frames emitted, by reason (retention|backpressure|unknown_stream)',
+  labelNames: ['reason'] as const,
+  registers: [register],
+})
+
+export const wsDroppedEventsTotal = new client.Counter({
+  name: 'ws_dropped_events_total',
+  help: 'Events dropped rather than delivered, by reason (backpressure|coalesced)',
+  labelNames: ['reason'] as const,
+  registers: [register],
+})
+
+export const wsBridgePublishTotal = new client.Counter({
+  name: 'ws_bridge_publish_total',
+  help: 'Cross-pod event publishes, by transport outcome',
+  labelNames: ['outcome'] as const, // outcome: redis|local_only|error
+  registers: [register],
+})
+
+export const wsPublishFailuresTotal = new client.Counter({
+  name: 'ws_publish_failures_total',
+  help: 'publishUserEvent calls that failed to persist to the durable stream',
+  registers: [register],
+})
+
+export function setWsConnectionsActive(
+  mode: 'self' | 'delegated',
+  count: number
+): void {
+  wsConnectionsActive.set({ mode }, count)
+}
+
+export function recordWsHandshake(
+  outcome:
+    'accepted' | 'unauthorized' | 'forbidden' | 'rate_limited' | 'too_many'
+): void {
+  wsHandshakesTotal.inc({ outcome })
+}
+
+export function recordWsMessageSent(
+  topic: string,
+  path: 'live' | 'replay'
+): void {
+  wsMessagesSentTotal.inc({ topic, path })
+}
+
+export function recordWsMessageReceived(type: string): void {
+  wsMessagesReceivedTotal.inc({ type })
+}
+
+export function recordWsReplay(count: number): void {
+  if (count > 0) wsReplayEventsTotal.inc(count)
+}
+
+export function recordWsGap(reason: string): void {
+  wsGapsTotal.inc({ reason })
+}
+
+export function recordWsDroppedEvents(
+  reason: 'backpressure' | 'coalesced',
+  count = 1
+): void {
+  wsDroppedEventsTotal.inc({ reason }, count)
+}
+
+export function recordWsBridgePublish(
+  outcome: 'redis' | 'local_only' | 'error'
+): void {
+  wsBridgePublishTotal.inc({ outcome })
+}
+
+export function recordWsPublishFailure(): void {
+  wsPublishFailuresTotal.inc()
+}
+
 /**
  * Get metrics for Prometheus scraping
  */

--- a/src/ws/auth.ts
+++ b/src/ws/auth.ts
@@ -1,0 +1,227 @@
+/**
+ * WebSocket handshake authentication and topic scoping (#316).
+ *
+ * Runs the SAME checks as src/middleware/authenticate.ts — signature, live
+ * session row, expiry, active user — rather than a socket-flavoured variant of
+ * them, because "the WebSocket auth path" is exactly the sort of place a second
+ * set of rules rots. There is no anonymous fallback: a handshake that does not
+ * authenticate is closed before a single byte of user data is written.
+ *
+ * ── Where the token comes from ────────────────────────────────────────────────
+ * `Authorization: Bearer <jwt>` for server-side clients, or the
+ * `Sec-WebSocket-Protocol: bearer, <jwt>` subprotocol pair for browsers, which
+ * cannot set headers on a WebSocket. A `?token=` query parameter is deliberately
+ * NOT accepted: URLs land in access logs, proxy logs, and referrers, and this
+ * token is a live session.
+ */
+
+import type { IncomingMessage } from 'node:http'
+import { SubAccountPermission } from '@prisma/client'
+import { JwtAdapter } from '../config'
+import db from '../db'
+import { logger } from '../utils/logger'
+import { USER_EVENT_TOPICS, type UserEventTopic } from '../events/types'
+
+export interface AuthenticatedHandshake {
+  /** Identity that authenticated — always the token holder. */
+  viewerUserId: string
+  /** Stream to bind to: the viewer's own, or a permitted child's. */
+  streamUserId: string
+  sessionId: string
+  token: string
+  /** Topics this connection is allowed to subscribe to. */
+  allowedTopics: UserEventTopic[]
+  delegated: boolean
+}
+
+export type HandshakeFailure =
+  | { ok: false; code: 4401; reason: 'unauthorized'; message: string }
+  | { ok: false; code: 4403; reason: 'forbidden'; message: string }
+
+export type HandshakeResult =
+  { ok: true; auth: AuthenticatedHandshake } | HandshakeFailure
+
+/**
+ * Topics a parent may see on a child's stream, per sub-account permission.
+ *
+ * VIEW is read-only visibility, so it opens the read-only topics. Strategy
+ * changes are a management concern and ride on MANAGE_STRATEGY — the same split
+ * the REST routes enforce. DEPOSIT/WITHDRAW grant the ability to move money on
+ * the child's behalf, and the resulting confirmations are already covered by
+ * `transactions` under VIEW, so they add no topics of their own.
+ */
+const TOPICS_BY_PERMISSION: Partial<
+  Record<SubAccountPermission, UserEventTopic[]>
+> = {
+  VIEW: ['portfolio', 'transactions', 'agent', 'alerts'],
+  MANAGE_STRATEGY: ['strategies'],
+}
+
+const unauthorized = (message: string): HandshakeFailure => ({
+  ok: false,
+  code: 4401,
+  reason: 'unauthorized',
+  message,
+})
+
+const forbidden = (message: string): HandshakeFailure => ({
+  ok: false,
+  code: 4403,
+  reason: 'forbidden',
+  message,
+})
+
+/**
+ * Extract the bearer token from the Authorization header or the
+ * `Sec-WebSocket-Protocol` pair. Returns null when neither carries one.
+ */
+export function extractHandshakeToken(req: IncomingMessage): string | null {
+  const header = req.headers.authorization
+  if (header?.startsWith('Bearer ')) {
+    const token = header.slice(7).trim()
+    if (token.length > 0) return token
+  }
+
+  const protocols = req.headers['sec-websocket-protocol']
+  if (typeof protocols === 'string') {
+    const parts = protocols.split(',').map((p) => p.trim())
+    const marker = parts.findIndex((p) => p === 'bearer')
+    if (marker !== -1 && parts[marker + 1]) return parts[marker + 1]
+  }
+
+  return null
+}
+
+/** Read the optional `?actor=<userId>` scoping parameter off the upgrade URL. */
+export function extractActorParam(req: IncomingMessage): string | null {
+  try {
+    const url = new URL(req.url ?? '/', 'http://placeholder')
+    const actor = url.searchParams.get('actor')?.trim()
+    return actor && actor.length > 0 ? actor : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Verify the session behind a token, exactly as requireAuth does.
+ * Reused by the periodic recheck on live connections, which is why it is
+ * separate from the handshake itself.
+ */
+export async function verifySessionToken(
+  token: string
+): Promise<
+  | { ok: true; userId: string; sessionId: string }
+  | { ok: false; message: string }
+> {
+  const payload = await JwtAdapter.validateToken<{ id: string }>(token)
+  if (!payload) return { ok: false, message: 'Invalid token' }
+
+  const session = await db.session.findUnique({
+    where: { token },
+    include: { user: { select: { id: true, isActive: true } } },
+  })
+
+  if (!session) return { ok: false, message: 'Session not found' }
+  if (session.expiresAt < new Date())
+    return { ok: false, message: 'Session expired' }
+  if (!session.user.isActive)
+    return { ok: false, message: 'User account is inactive' }
+
+  return { ok: true, userId: session.user.id, sessionId: session.id }
+}
+
+/**
+ * Authenticate an upgrade request and resolve the stream it may read.
+ *
+ * For a delegated connection (`?actor=` naming someone other than the token
+ * holder) the sub-account grant is looked up server-side and the topic set is
+ * derived from its permissions — the client's opinion about what it may read is
+ * never consulted, only its opinion about what it wants.
+ */
+export async function authenticateHandshake(
+  req: IncomingMessage
+): Promise<HandshakeResult> {
+  const token = extractHandshakeToken(req)
+  if (!token) {
+    return unauthorized('Missing bearer token')
+  }
+
+  let session: Awaited<ReturnType<typeof verifySessionToken>>
+  try {
+    session = await verifySessionToken(token)
+  } catch (error) {
+    logger.error('[WS] Handshake verification error', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return unauthorized('Authentication failed')
+  }
+
+  if (!session.ok) return unauthorized(session.message)
+
+  const viewerUserId = session.userId
+  const actor = extractActorParam(req)
+
+  if (!actor || actor === viewerUserId) {
+    return {
+      ok: true,
+      auth: {
+        viewerUserId,
+        streamUserId: viewerUserId,
+        sessionId: session.sessionId,
+        token,
+        allowedTopics: [...USER_EVENT_TOPICS],
+        delegated: false,
+      },
+    }
+  }
+
+  // Delegated: the same ACTIVE-grant rule requireSubAccountPermission applies.
+  let grant
+  try {
+    grant = await db.subAccount.findUnique({
+      where: {
+        parentUserId_childUserId: {
+          parentUserId: viewerUserId,
+          childUserId: actor,
+        },
+      },
+      select: { permissions: true, status: true },
+    })
+  } catch (error) {
+    logger.error('[WS] Sub-account lookup failed during handshake', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return forbidden('Forbidden')
+  }
+
+  if (!grant || grant.status !== 'ACTIVE') {
+    return forbidden('No active sub-account grant for the requested actor')
+  }
+
+  const allowedTopics = Array.from(
+    new Set(grant.permissions.flatMap((p) => TOPICS_BY_PERMISSION[p] ?? []))
+  ) as UserEventTopic[]
+
+  if (allowedTopics.length === 0) {
+    return forbidden('Sub-account grant carries no readable topics')
+  }
+
+  logger.info('[WS] Delegated stream access granted', {
+    parentUserId: viewerUserId,
+    childUserId: actor,
+    topics: allowedTopics,
+  })
+
+  return {
+    ok: true,
+    auth: {
+      viewerUserId,
+      streamUserId: actor,
+      sessionId: session.sessionId,
+      token,
+      allowedTopics,
+      delegated: true,
+    },
+  }
+}

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -1,0 +1,670 @@
+/**
+ * One authenticated WebSocket connection: subscription state, replay, and
+ * backpressure (#316).
+ *
+ * ── Ordering contract ─────────────────────────────────────────────────────────
+ * Within a topic, events are delivered in ascending `seq`. Across topics there
+ * is NO ordering guarantee — they share one per-user sequence, so a client that
+ * needs a cross-topic order must use `seq` itself, not arrival order. On-chain
+ * events inherit ProcessedEvent's ledger ordering upstream of this layer.
+ *
+ * ── Delivery contract ─────────────────────────────────────────────────────────
+ * At-least-once with a duplication window at reconnect: `resume afterSeq`
+ * replays from the durable store while live events keep arriving, and the
+ * live-switch prefers replaying an event twice over dropping it. Clients dedupe
+ * on `seq`, which is monotonic per user.
+ *
+ * ── Backpressure ──────────────────────────────────────────────────────────────
+ * A slow consumer is never queued without bound. Past either bound
+ * (WS_MAX_BUFFERED_EVENTS in-process frames, WS_MAX_BUFFERED_BYTES unflushed
+ * socket bytes) the connection enters the `gapped` state: it stops delivering,
+ * emits one `gap` frame carrying the seq to resume after, and waits. Nothing is
+ * lost — the durable stream still holds every event, and the client's next
+ * `resume` collects them.
+ */
+
+import type { WebSocket } from 'ws'
+import { config } from '../config/env'
+import { logger } from '../utils/logger'
+import {
+  recordWsDroppedEvents,
+  recordWsGap,
+  recordWsMessageReceived,
+  recordWsMessageSent,
+  recordWsReplay,
+} from '../utils/metrics'
+import { subscribeToUserStream } from '../events/hub'
+import {
+  getLatestSeq,
+  getOldestAvailableSeq,
+  readAfterSeq,
+} from '../events/store'
+import type {
+  ErrorFrame,
+  ServerFrame,
+  UserEventEnvelope,
+  UserEventTopic,
+} from '../events/types'
+import { clientMessageSchema, type ClientMessage } from './protocol'
+import { verifySessionToken, type AuthenticatedHandshake } from './auth'
+
+/** Close codes. 1000/1001 are RFC 6455; 44xx are this application's. */
+export const WS_CLOSE = {
+  NORMAL: 1000,
+  GOING_AWAY: 1001,
+  UNAUTHORIZED: 4401,
+  FORBIDDEN: 4403,
+  AUTH_REVOKED: 4408,
+  RATE_LIMITED: 4429,
+  IDLE_TIMEOUT: 4408,
+} as const
+
+type ConnectionState = 'idle' | 'live' | 'replaying' | 'gapped'
+
+interface CoalesceSlot {
+  envelope: UserEventEnvelope
+  suppressed: number
+}
+
+export class StreamConnection {
+  private readonly ws: WebSocket
+  private readonly auth: AuthenticatedHandshake
+  private readonly onClosed: (connection: StreamConnection) => void
+
+  private topics = new Set<UserEventTopic>()
+  private state: ConnectionState = 'idle'
+  private lastSentSeq = 0
+  private coalesce = false
+  private closed = false
+
+  /** Live events captured while a replay is in flight, flushed on live-switch. */
+  private liveBuffer: UserEventEnvelope[] = []
+  /** Latest-wins slots when the client opted into coalescing. */
+  private coalesceSlots = new Map<string, CoalesceSlot>()
+  private coalesceTimer: NodeJS.Timeout | null = null
+
+  private messageWindowStart = Date.now()
+  private messageCount = 0
+
+  private heartbeatTimer: NodeJS.Timeout | null = null
+  private sessionTimer: NodeJS.Timeout | null = null
+  private lastSeenAt = Date.now()
+  private unsubscribeHub: (() => void) | null = null
+
+  constructor(params: {
+    ws: WebSocket
+    auth: AuthenticatedHandshake
+    onClosed: (connection: StreamConnection) => void
+  }) {
+    this.ws = params.ws
+    this.auth = params.auth
+    this.onClosed = params.onClosed
+  }
+
+  get delegated(): boolean {
+    return this.auth.delegated
+  }
+
+  get viewerUserId(): string {
+    return this.auth.viewerUserId
+  }
+
+  get streamUserId(): string {
+    return this.auth.streamUserId
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  /** Wire up listeners, register with the hub, and greet the client. */
+  async start(): Promise<void> {
+    this.unsubscribeHub = subscribeToUserStream({
+      streamUserId: this.auth.streamUserId,
+      viewerUserId: this.auth.viewerUserId,
+      deliver: (envelope) => this.deliver(envelope),
+    })
+
+    this.ws.on('message', (data) => {
+      void this.handleMessage(data)
+    })
+    this.ws.on('pong', () => {
+      this.lastSeenAt = Date.now()
+    })
+    this.ws.on('error', (error) => {
+      logger.warn('[WS] Socket error', {
+        streamUserId: this.auth.streamUserId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
+    this.ws.on('close', () => this.cleanup())
+
+    this.startHeartbeat()
+    this.startSessionRecheck()
+
+    const currentSeq = await this.currentSeqSafely()
+    this.send({
+      type: 'hello',
+      actor: this.auth.delegated ? 'delegated' : 'self',
+      topics: this.auth.allowedTopics,
+      currentSeq,
+      heartbeatIntervalMs: config.websocket.heartbeatIntervalMs,
+    })
+  }
+
+  /**
+   * Announce shutdown and close. The client is told the seq to resume after, so
+   * a rolling deploy costs a reconnect rather than a REST snapshot.
+   */
+  drain(): void {
+    if (this.closed) return
+    this.send({
+      type: 'draining',
+      reason: 'server_shutdown',
+      resumeAfterSeq: this.lastSentSeq,
+      retryAfterMs: config.websocket.drainRetryAfterMs,
+    })
+    this.close(WS_CLOSE.GOING_AWAY, 'Server shutting down')
+  }
+
+  close(code: number, reason: string): void {
+    if (this.closed) return
+    try {
+      this.ws.close(code, reason)
+    } catch {
+      try {
+        this.ws.terminate()
+      } catch {
+        /* socket already gone */
+      }
+    }
+  }
+
+  private cleanup(): void {
+    if (this.closed) return
+    this.closed = true
+
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
+    if (this.sessionTimer) clearInterval(this.sessionTimer)
+    if (this.coalesceTimer) clearTimeout(this.coalesceTimer)
+    this.heartbeatTimer = null
+    this.sessionTimer = null
+    this.coalesceTimer = null
+
+    this.unsubscribeHub?.()
+    this.unsubscribeHub = null
+    this.liveBuffer = []
+    this.coalesceSlots.clear()
+
+    this.onClosed(this)
+  }
+
+  // ── Timers ─────────────────────────────────────────────────────────────────
+
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      if (Date.now() - this.lastSeenAt > config.websocket.idleTimeoutMs) {
+        logger.info('[WS] Closing idle connection', {
+          streamUserId: this.auth.streamUserId,
+        })
+        this.close(WS_CLOSE.IDLE_TIMEOUT, 'Idle timeout')
+        return
+      }
+      try {
+        this.ws.ping()
+      } catch {
+        this.close(WS_CLOSE.GOING_AWAY, 'Ping failed')
+      }
+    }, config.websocket.heartbeatIntervalMs)
+  }
+
+  /**
+   * A revoked session must kill the live socket, not merely block the next
+   * handshake. Polling the session row is the one mechanism that covers every
+   * way a session dies — logout, expiry, account deactivation, admin action —
+   * without each of those code paths having to know sockets exist.
+   */
+  private startSessionRecheck(): void {
+    this.sessionTimer = setInterval(() => {
+      void (async () => {
+        try {
+          const result = await verifySessionToken(this.auth.token)
+          if (!result.ok) {
+            logger.info('[WS] Session no longer valid — closing socket', {
+              streamUserId: this.auth.streamUserId,
+              reason: result.message,
+            })
+            this.sendError('unauthorized', result.message)
+            this.close(WS_CLOSE.AUTH_REVOKED, 'Session revoked')
+          }
+        } catch (error) {
+          // A transient database blip must not disconnect a healthy client.
+          logger.warn('[WS] Session recheck failed — keeping connection', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      })()
+    }, config.websocket.sessionRecheckMs)
+  }
+
+  // ── Inbound ────────────────────────────────────────────────────────────────
+
+  private async handleMessage(data: unknown): Promise<void> {
+    this.lastSeenAt = Date.now()
+
+    if (!this.withinMessageRate()) {
+      recordWsMessageReceived('rate_limited')
+      this.sendError('rate_limited', 'Message rate limit exceeded')
+      this.close(WS_CLOSE.RATE_LIMITED, 'Message rate limit exceeded')
+      return
+    }
+
+    const raw = Buffer.isBuffer(data) ? data : Buffer.from(String(data))
+    if (raw.byteLength > config.websocket.maxMessageBytes) {
+      this.sendError('bad_request', 'Message too large')
+      return
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw.toString('utf8'))
+    } catch {
+      recordWsMessageReceived('malformed')
+      this.sendError('bad_request', 'Message must be JSON')
+      return
+    }
+
+    const result = clientMessageSchema.safeParse(parsed)
+    if (!result.success) {
+      recordWsMessageReceived('invalid')
+      this.sendError(
+        'bad_request',
+        result.error.issues[0]?.message ?? 'Invalid message'
+      )
+      return
+    }
+
+    const message: ClientMessage = result.data
+    recordWsMessageReceived(message.type)
+
+    switch (message.type) {
+      case 'ping':
+        this.send({ type: 'pong', at: new Date().toISOString() })
+        return
+      case 'subscribe':
+        await this.handleSubscribe(message.topics, message.coalesce ?? false)
+        return
+      case 'resume':
+        await this.handleResume(
+          message.topics,
+          message.afterSeq,
+          message.coalesce ?? false
+        )
+        return
+      case 'unsubscribe':
+        for (const topic of message.topics) this.topics.delete(topic)
+        this.send({
+          type: 'subscribed',
+          topics: Array.from(this.topics),
+          currentSeq: await this.currentSeqSafely(),
+          coalesce: this.coalesce,
+        })
+        return
+    }
+  }
+
+  private withinMessageRate(): boolean {
+    const now = Date.now()
+    const { windowMs, max } = config.websocket.messageRateLimit
+    if (now - this.messageWindowStart >= windowMs) {
+      this.messageWindowStart = now
+      this.messageCount = 0
+    }
+    this.messageCount++
+    return this.messageCount <= max
+  }
+
+  /**
+   * Apply a requested topic set against what the handshake authorised.
+   * Returns null after emitting a 'forbidden' error frame — the socket
+   * equivalent of the REST 403, and equally non-negotiable: the allowed set
+   * came from the sub-account grant, never from the client.
+   */
+  private applyTopics(requested: UserEventTopic[]): UserEventTopic[] | null {
+    const allowed = new Set(this.auth.allowedTopics)
+    const denied = requested.filter((topic) => !allowed.has(topic))
+
+    if (denied.length > 0) {
+      this.sendError(
+        'forbidden',
+        `Not permitted to subscribe to: ${denied.join(', ')}`
+      )
+      return null
+    }
+
+    this.topics = new Set(requested)
+    return requested
+  }
+
+  private async handleSubscribe(
+    requested: UserEventTopic[],
+    coalesce: boolean
+  ): Promise<void> {
+    const topics = this.applyTopics(requested)
+    if (!topics) return
+
+    this.coalesce = coalesce
+    this.state = 'live'
+
+    const currentSeq = await this.currentSeqSafely()
+    // A fresh subscribe starts at "now": the client asked for live events, not
+    // for history. History is what `resume` is for.
+    this.lastSentSeq = currentSeq
+
+    this.send({ type: 'subscribed', topics, currentSeq, coalesce })
+  }
+
+  /**
+   * Replay everything after `afterSeq`, then switch to live with no gap.
+   *
+   * Live events arriving during the replay are buffered rather than dropped or
+   * sent out of order; the flush skips anything the replay already covered. The
+   * remaining risk is a duplicate, never a hole — see the delivery contract.
+   */
+  private async handleResume(
+    requested: UserEventTopic[],
+    afterSeq: number,
+    coalesce: boolean
+  ): Promise<void> {
+    const topics = this.applyTopics(requested)
+    if (!topics) return
+
+    this.coalesce = coalesce
+    this.state = 'replaying'
+    this.liveBuffer = []
+
+    let currentSeq = 0
+    let oldest: number | null = null
+    try {
+      currentSeq = await getLatestSeq(this.auth.streamUserId)
+      oldest = await getOldestAvailableSeq(this.auth.streamUserId)
+    } catch (error) {
+      logger.error('[WS] Resume lookup failed', {
+        streamUserId: this.auth.streamUserId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      this.sendError('internal', 'Could not read the event stream')
+      this.state = 'live'
+      return
+    }
+
+    // Ahead of the server: the client's cursor cannot exist here. Treat it as
+    // an unknown stream rather than replaying nothing and pretending all is well.
+    if (afterSeq > currentSeq) {
+      this.emitGap('unknown_stream', afterSeq, currentSeq, oldest, true)
+      this.lastSentSeq = currentSeq
+      this.finishReplay(topics, currentSeq, coalesce)
+      return
+    }
+
+    // Behind retention: the cheap path is gone, say so rather than serving a
+    // silently truncated replay.
+    if (oldest !== null && afterSeq + 1 < oldest) {
+      this.emitGap('retention', afterSeq, currentSeq, oldest, true)
+      this.lastSentSeq = currentSeq
+      this.finishReplay(topics, currentSeq, coalesce)
+      return
+    }
+
+    let replayed = 0
+    let cursor = afterSeq
+    try {
+      const events = await readAfterSeq({
+        userId: this.auth.streamUserId,
+        afterSeq,
+        topics,
+        limit: config.websocket.replayMaxEvents,
+      })
+
+      this.send({
+        type: 'replay',
+        status: 'start',
+        fromSeq: afterSeq + 1,
+        toSeq: currentSeq,
+        count: events.length,
+      })
+
+      for (const event of events) {
+        this.send({
+          type: 'event',
+          seq: event.seq,
+          topic: event.topic,
+          event: event.type,
+          payload: event.payload,
+          emittedAt: event.emittedAt,
+        })
+        recordWsMessageSent(event.topic, 'replay')
+        cursor = event.seq
+        replayed++
+      }
+
+      recordWsReplay(replayed)
+
+      this.send({
+        type: 'replay',
+        status: 'end',
+        fromSeq: afterSeq + 1,
+        toSeq: cursor,
+        count: replayed,
+      })
+    } catch (error) {
+      logger.error('[WS] Replay failed', {
+        streamUserId: this.auth.streamUserId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      this.sendError('internal', 'Replay failed')
+      this.state = 'live'
+      return
+    }
+
+    this.lastSentSeq = cursor
+
+    // The page limit was hit: more history remains. Tell the client to resume
+    // again from where we stopped instead of quietly starting the live stream
+    // on top of a hole.
+    if (replayed === config.websocket.replayMaxEvents && cursor < currentSeq) {
+      this.emitGap('retention', cursor, currentSeq, oldest, false)
+    }
+
+    this.finishReplay(topics, currentSeq, coalesce)
+  }
+
+  /** Flush anything buffered during the replay, then go live. */
+  private finishReplay(
+    topics: UserEventTopic[],
+    currentSeq: number,
+    coalesce: boolean
+  ): void {
+    this.state = 'live'
+    const buffered = this.liveBuffer
+    this.liveBuffer = []
+
+    for (const envelope of buffered) {
+      if (envelope.seq <= this.lastSentSeq) continue
+      this.sendEvent(envelope)
+    }
+
+    this.send({ type: 'subscribed', topics, currentSeq, coalesce })
+  }
+
+  // ── Outbound ───────────────────────────────────────────────────────────────
+
+  /** Hub callback. Authorisation was already decided by the publisher. */
+  private deliver(envelope: UserEventEnvelope): void {
+    if (this.closed) return
+    if (!this.topics.has(envelope.topic)) return
+
+    // Already gapped: the client owes us a `resume`. Counting the drop is the
+    // point — silently discarding here is how a "why is my UI stale" bug hides.
+    if (this.state === 'gapped') {
+      recordWsDroppedEvents('backpressure')
+      return
+    }
+
+    if (this.state === 'replaying') {
+      if (this.liveBuffer.length >= config.websocket.maxBufferedEvents) {
+        this.enterGap('backpressure')
+        return
+      }
+      this.liveBuffer.push(envelope)
+      return
+    }
+
+    if (this.coalesce) {
+      this.queueCoalesced(envelope)
+      return
+    }
+
+    this.sendEvent(envelope)
+  }
+
+  /**
+   * Latest-wins within a short window, for clients that opted in.
+   *
+   * A rebalance touching many positions produces a burst of same-type events;
+   * a dashboard only ever renders the last one. Suppressed events stay in the
+   * durable store, but a later `resume afterSeq` will NOT redeliver them —
+   * afterSeq has already moved past them. That is the trade the client made by
+   * asking for coalescing, and it is documented in
+   * docs/WEBSOCKET_STREAMING.md.
+   */
+  private queueCoalesced(envelope: UserEventEnvelope): void {
+    const key = `${envelope.topic}:${envelope.type}`
+    const existing = this.coalesceSlots.get(key)
+
+    if (existing) {
+      // Keep the newest; the older one is superseded, not lost from the store.
+      const newer =
+        envelope.seq > existing.envelope.seq ? envelope : existing.envelope
+      this.coalesceSlots.set(key, {
+        envelope: newer,
+        suppressed: existing.suppressed + 1,
+      })
+    } else if (this.coalesceSlots.size >= config.websocket.maxBufferedEvents) {
+      // More distinct (topic,type) pairs in flight than the buffer allows —
+      // the bound applies to coalescing too.
+      this.enterGap('backpressure')
+      return
+    } else {
+      this.coalesceSlots.set(key, { envelope, suppressed: 0 })
+    }
+
+    if (!this.coalesceTimer) {
+      this.coalesceTimer = setTimeout(
+        () => this.flushCoalesced(),
+        config.websocket.coalesceWindowMs
+      )
+    }
+  }
+
+  private flushCoalesced(): void {
+    this.coalesceTimer = null
+    const slots = Array.from(this.coalesceSlots.values())
+    this.coalesceSlots.clear()
+
+    // Ascending seq: coalescing may drop events, it must never reorder them.
+    slots.sort((a, b) => a.envelope.seq - b.envelope.seq)
+
+    for (const slot of slots) {
+      if (slot.suppressed > 0) {
+        recordWsDroppedEvents('coalesced', slot.suppressed)
+      }
+      this.sendEvent(slot.envelope)
+    }
+  }
+
+  private sendEvent(envelope: UserEventEnvelope): void {
+    if (this.closed) return
+
+    if (this.ws.bufferedAmount > config.websocket.maxBufferedBytes) {
+      this.enterGap('backpressure')
+      return
+    }
+
+    this.send({
+      type: 'event',
+      seq: envelope.seq,
+      topic: envelope.topic,
+      event: envelope.type,
+      payload: envelope.payload,
+      emittedAt: envelope.emittedAt,
+    })
+    recordWsMessageSent(envelope.topic, 'live')
+
+    if (envelope.seq > this.lastSentSeq) this.lastSentSeq = envelope.seq
+  }
+
+  /**
+   * Stop delivering and hand the client a resumable marker.
+   * Nothing is lost: the durable stream still has every event past
+   * `lastSentSeq`, and the client's `resume` collects them.
+   */
+  private enterGap(reason: 'backpressure'): void {
+    if (this.state === 'gapped') return
+    this.state = 'gapped'
+    this.liveBuffer = []
+    this.coalesceSlots.clear()
+
+    logger.warn('[WS] Connection gapped — slow consumer', {
+      streamUserId: this.auth.streamUserId,
+      lastSentSeq: this.lastSentSeq,
+      bufferedAmount: this.ws.bufferedAmount,
+    })
+
+    this.emitGap(reason, this.lastSentSeq, this.lastSentSeq, null, false)
+  }
+
+  private emitGap(
+    reason: 'retention' | 'backpressure' | 'unknown_stream',
+    afterSeq: number | null,
+    currentSeq: number,
+    oldestAvailableSeq: number | null,
+    snapshotRequired: boolean
+  ): void {
+    recordWsGap(reason)
+    this.send({
+      type: 'gap',
+      reason,
+      afterSeq,
+      currentSeq,
+      oldestAvailableSeq,
+      snapshotRequired,
+    })
+  }
+
+  private sendError(code: ErrorFrame['code'], message: string): void {
+    this.send({ type: 'error', code, message })
+  }
+
+  private send(frame: ServerFrame): void {
+    if (this.closed) return
+    try {
+      this.ws.send(JSON.stringify(frame))
+    } catch (error) {
+      logger.warn('[WS] Frame send failed', {
+        streamUserId: this.auth.streamUserId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  private async currentSeqSafely(): Promise<number> {
+    try {
+      return await getLatestSeq(this.auth.streamUserId)
+    } catch (error) {
+      logger.warn('[WS] Could not read current seq', {
+        streamUserId: this.auth.streamUserId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return this.lastSentSeq
+    }
+  }
+}

--- a/src/ws/protocol.ts
+++ b/src/ws/protocol.ts
@@ -1,0 +1,68 @@
+/**
+ * Client → server message schemas for the real-time stream (#316).
+ *
+ * The receive side of this socket is a tiny control channel — subscribe,
+ * resume, ping — and nothing else. Trading and any other state-changing
+ * operation stays on the authenticated REST surface where it already has
+ * validation, rate limiting, idempotency, and an audit trail; a second, weaker
+ * path to move money is not a feature. `.strict()` on every schema means an
+ * unknown key is a 'bad_request' error frame rather than something quietly
+ * ignored, so a client using a message this server does not implement finds out
+ * immediately.
+ */
+
+import { z } from 'zod'
+import { USER_EVENT_TOPICS } from '../events/types'
+
+const topicSchema = z.enum(USER_EVENT_TOPICS)
+
+const topicsSchema = z
+  .array(topicSchema)
+  .min(1, 'At least one topic is required')
+  .max(USER_EVENT_TOPICS.length)
+
+export const subscribeMessageSchema = z
+  .object({
+    type: z.literal('subscribe'),
+    topics: topicsSchema,
+    /**
+     * Opt-in event coalescing (see docs/WEBSOCKET_STREAMING.md). Off by
+     * default because it trades exact per-seq delivery for burst tolerance,
+     * and that is the client's call to make, not the server's.
+     */
+    coalesce: z.boolean().optional(),
+  })
+  .strict()
+
+export const resumeMessageSchema = z
+  .object({
+    type: z.literal('resume'),
+    topics: topicsSchema,
+    /** Last seq the client durably processed. 0 means "everything retained". */
+    afterSeq: z.number().int().min(0),
+    coalesce: z.boolean().optional(),
+  })
+  .strict()
+
+export const unsubscribeMessageSchema = z
+  .object({
+    type: z.literal('unsubscribe'),
+    topics: topicsSchema,
+  })
+  .strict()
+
+/** Application-level keepalive, for clients that cannot observe protocol pongs. */
+export const pingMessageSchema = z
+  .object({
+    type: z.literal('ping'),
+  })
+  .strict()
+
+export const clientMessageSchema = z.discriminatedUnion('type', [
+  subscribeMessageSchema,
+  resumeMessageSchema,
+  unsubscribeMessageSchema,
+  pingMessageSchema,
+])
+
+export type ClientMessage = z.infer<typeof clientMessageSchema>

--- a/src/ws/server.ts
+++ b/src/ws/server.ts
@@ -1,0 +1,271 @@
+/**
+ * Authenticated WebSocket server for the real-time stream (#316).
+ *
+ * Mounted on the existing HTTP server with `noServer: true` and a manual
+ * `upgrade` handler, so authentication happens BEFORE the protocol switch: an
+ * unauthenticated peer gets an HTTP 401 and never becomes a WebSocket at all.
+ * Accepting the upgrade first and closing afterwards would mean every rejected
+ * probe still cost a full socket — and would hand an unauthenticated caller a
+ * live connection, however briefly.
+ *
+ * Only paths matching the configured WS path are claimed; any other upgrade
+ * request is left alone for whatever else may be listening.
+ */
+
+import type { Server as HttpServer, IncomingMessage } from 'node:http'
+import type { Duplex } from 'node:stream'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { config } from '../config/env'
+import { logger } from '../utils/logger'
+import { recordWsHandshake, setWsConnectionsActive } from '../utils/metrics'
+import { getLocalSubscribers } from '../events/hub'
+import { authenticateHandshake } from './auth'
+import { StreamConnection, WS_CLOSE } from './connection'
+
+let wss: WebSocketServer | null = null
+let upgradeHandler:
+  ((req: IncomingMessage, socket: Duplex, head: Buffer) => void) | null = null
+let boundServer: HttpServer | null = null
+
+const connections = new Set<StreamConnection>()
+
+// ── Handshake flood guard ─────────────────────────────────────────────────────
+//
+// Same philosophy as src/middleware/rateLimiter.ts — fixed window, per source —
+// but in-process and keyed on the raw socket address, because there is no
+// Express request here and the check must run before any work is done. A
+// connection flood is a denial-of-service vector even when every handshake
+// fails authentication.
+
+const handshakeWindows = new Map<string, { start: number; count: number }>()
+
+function withinHandshakeRate(ip: string): boolean {
+  const { windowMs, max } = config.websocket.handshakeRateLimit
+  const now = Date.now()
+  const window = handshakeWindows.get(ip)
+
+  if (!window || now - window.start >= windowMs) {
+    handshakeWindows.set(ip, { start: now, count: 1 })
+    return true
+  }
+
+  window.count++
+  return window.count <= max
+}
+
+/** Drop stale rate-limit windows so the map cannot grow with unique IPs. */
+function pruneHandshakeWindows(): void {
+  const cutoff = Date.now() - config.websocket.handshakeRateLimit.windowMs
+  for (const [ip, window] of handshakeWindows) {
+    if (window.start < cutoff) handshakeWindows.delete(ip)
+  }
+}
+
+function clientIp(req: IncomingMessage): string {
+  // Behind the same proxies the REST surface sits behind; TRUST_PROXY governs
+  // whether X-Forwarded-For is meaningful, so honour the first hop when present.
+  const forwarded = req.headers['x-forwarded-for']
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim()
+  }
+  return req.socket.remoteAddress ?? 'unknown'
+}
+
+function rejectUpgrade(socket: Duplex, status: number, message: string): void {
+  const body = JSON.stringify({ error: message })
+  socket.write(
+    `HTTP/1.1 ${status} ${message}\r\n` +
+      'Connection: close\r\n' +
+      'Content-Type: application/json\r\n' +
+      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      '\r\n' +
+      body
+  )
+  socket.destroy()
+}
+
+function refreshConnectionGauges(): void {
+  let self = 0
+  let delegated = 0
+  for (const connection of connections) {
+    if (connection.delegated) delegated++
+    else self++
+  }
+  setWsConnectionsActive('self', self)
+  setWsConnectionsActive('delegated', delegated)
+}
+
+function countConnectionsFor(viewerUserId: string): number {
+  let count = 0
+  for (const connection of connections) {
+    if (connection.viewerUserId === viewerUserId) count++
+  }
+  return count
+}
+
+/**
+ * Attach the WebSocket endpoint to a running HTTP server.
+ * Idempotent: calling it twice returns the existing server.
+ */
+export function attachWebSocketServer(server: HttpServer): WebSocketServer {
+  if (wss) return wss
+
+  wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: config.websocket.maxMessageBytes,
+  })
+  boundServer = server
+
+  upgradeHandler = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+    let pathname: string
+    try {
+      pathname = new URL(req.url ?? '/', 'http://placeholder').pathname
+    } catch {
+      return
+    }
+
+    // Not ours — leave the socket for another upgrade listener.
+    if (pathname !== config.websocket.path) return
+
+    pruneHandshakeWindows()
+
+    if (!withinHandshakeRate(clientIp(req))) {
+      recordWsHandshake('rate_limited')
+      rejectUpgrade(socket, 429, 'Too Many Requests')
+      return
+    }
+
+    void (async () => {
+      const result = await authenticateHandshake(req)
+
+      if (!result.ok) {
+        recordWsHandshake(
+          result.reason === 'forbidden' ? 'forbidden' : 'unauthorized'
+        )
+        rejectUpgrade(
+          socket,
+          result.reason === 'forbidden' ? 403 : 401,
+          result.message
+        )
+        return
+      }
+
+      if (
+        countConnectionsFor(result.auth.viewerUserId) >=
+        config.websocket.maxConnectionsPerUser
+      ) {
+        recordWsHandshake('too_many')
+        rejectUpgrade(socket, 429, 'Too many concurrent connections')
+        return
+      }
+
+      wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+        recordWsHandshake('accepted')
+        const connection = new StreamConnection({
+          ws,
+          auth: result.auth,
+          onClosed: (closed) => {
+            connections.delete(closed)
+            refreshConnectionGauges()
+          },
+        })
+        connections.add(connection)
+        refreshConnectionGauges()
+
+        connection.start().catch((error) => {
+          logger.error('[WS] Connection start failed', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+          connection.close(WS_CLOSE.NORMAL, 'Initialisation failed')
+        })
+      })
+    })()
+  }
+
+  server.on('upgrade', upgradeHandler)
+  logger.info(`[WS] WebSocket endpoint mounted at ${config.websocket.path}`)
+
+  return wss
+}
+
+/**
+ * Close every socket with a draining frame, then shut the server down.
+ *
+ * Awaited by the graceful-shutdown sequence BEFORE `httpServer.close()`: an
+ * open WebSocket is a live HTTP connection, so closing the HTTP server first
+ * would simply block on these sockets until the drain timeout fired and then
+ * cut them without warning.
+ */
+export async function closeWebSocketServer(
+  timeoutMs = config.websocket.drainRetryAfterMs * 5
+): Promise<void> {
+  if (!wss) return
+
+  if (boundServer && upgradeHandler) {
+    // Stop claiming new upgrades immediately — draining sockets while still
+    // accepting fresh ones never terminates.
+    boundServer.off('upgrade', upgradeHandler)
+  }
+
+  const draining = Array.from(connections)
+  logger.info(`[WS] Draining ${draining.length} connection(s)`)
+  for (const connection of draining) connection.drain()
+
+  const server = wss
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      logger.warn('[WS] Drain timeout — terminating remaining sockets')
+      for (const client of server.clients) client.terminate()
+      resolve()
+    }, timeoutMs)
+
+    server.close(() => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+
+  connections.clear()
+  handshakeWindows.clear()
+  refreshConnectionGauges()
+  wss = null
+  boundServer = null
+  upgradeHandler = null
+  logger.info('[WS] WebSocket server closed')
+}
+
+/**
+ * Force-close every socket bound to a user's stream.
+ *
+ * The per-connection session recheck already catches revocation within
+ * WS_SESSION_RECHECK_MS; this is the immediate path for code that knows a
+ * session died right now (logout, account deactivation) and does not want to
+ * wait out that interval. Local to this pod — the recheck remains the backstop
+ * for sockets held elsewhere.
+ */
+export function closeUserSockets(streamUserId: string, reason: string): number {
+  const subscribers = getLocalSubscribers(streamUserId)
+  let closed = 0
+
+  for (const connection of connections) {
+    if (connection.streamUserId !== streamUserId) continue
+    connection.close(WS_CLOSE.AUTH_REVOKED, reason)
+    closed++
+  }
+
+  if (closed > 0) {
+    logger.info('[WS] Force-closed sockets for user', {
+      streamUserId,
+      closed,
+      knownSubscribers: subscribers.length,
+      reason,
+    })
+  }
+
+  return closed
+}
+
+/** Live connection count — used by tests and the readiness surface. */
+export function getConnectionCount(): number {
+  return connections.size
+}

--- a/tests/integration/websocket.integration.test.ts
+++ b/tests/integration/websocket.integration.test.ts
@@ -1,0 +1,662 @@
+/**
+ * #316 — end-to-end WebSocket streaming, driven by a real socket client.
+ *
+ * A real `ws` client connects to a real WebSocketServer attached to a real HTTP
+ * server, and drives the full sequence the acceptance criteria name:
+ *
+ *     handshake → subscribe → live event → disconnect → resume replay → gap
+ *
+ * Only Postgres is substituted, by an in-memory store that implements the exact
+ * queries src/events/store.ts and src/ws/auth.ts issue. Everything else runs
+ * for real: the JWT is genuinely signed and verified, the handshake genuinely
+ * looks up a session, the publisher genuinely redacts, allocates a seq, and
+ * fans out through the hub, and the connection genuinely replays from the
+ * store. Mocking the socket layer would leave the interesting half untested.
+ */
+
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import WebSocket from 'ws'
+
+// ── In-memory Postgres substitute ─────────────────────────────────────────────
+//
+// Declared before the src imports because jest.mock is hoisted above them.
+
+interface StoredRow {
+  userId: string
+  seq: number
+  topic: string
+  type: string
+  payload: Record<string, unknown>
+  createdAt: Date
+}
+
+const CHILD_USER = 'child-user-1'
+const PARENT_USER = 'parent-user-1'
+const OTHER_USER = 'other-user-1'
+
+const store = {
+  rows: [] as StoredRow[],
+  seqs: new Map<string, number>(),
+  sessions: new Map<
+    string,
+    { userId: string; isActive: boolean; expiresAt: Date }
+  >(),
+  grants: new Map<string, { permissions: string[]; status: string }>(),
+  reset(): void {
+    store.rows = []
+    store.seqs.clear()
+    store.sessions.clear()
+    store.grants.clear()
+  },
+}
+
+const mockDb: any = {
+  $transaction: async (fn: (tx: any) => Promise<unknown>) => fn(mockDb),
+  // src/events/store.ts allocates the seq with a tagged-template
+  // INSERT … ON CONFLICT DO UPDATE … RETURNING. values[0] is the userId.
+  $queryRaw: async (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    const userId = values[0] as string
+    const next = (store.seqs.get(userId) ?? 0) + 1
+    store.seqs.set(userId, next)
+    return [{ lastSeq: BigInt(next) }]
+  },
+  userEvent: {
+    create: async ({ data }: any) => {
+      const row: StoredRow = { ...data, createdAt: new Date() }
+      store.rows.push(row)
+      return row
+    },
+    findMany: async ({ where, take }: any) => {
+      const topics: string[] = where.topic?.in ?? []
+      return store.rows
+        .filter(
+          (r) =>
+            r.userId === where.userId &&
+            r.seq > where.seq.gt &&
+            (topics.length === 0 || topics.includes(r.topic))
+        )
+        .sort((a, b) => a.seq - b.seq)
+        .slice(0, take)
+    },
+    findFirst: async ({ where }: any) => {
+      const matching = store.rows
+        .filter((r) => r.userId === where.userId)
+        .sort((a, b) => a.seq - b.seq)
+      return matching[0] ?? null
+    },
+    deleteMany: async () => ({ count: 0 }),
+  },
+  userEventSequence: {
+    findUnique: async ({ where }: any) => {
+      const last = store.seqs.get(where.userId)
+      return last === undefined ? null : { lastSeq: BigInt(last) }
+    },
+  },
+  session: {
+    findUnique: async ({ where }: any) => {
+      const session = store.sessions.get(where.token)
+      if (!session) return null
+      return {
+        id: `session-${session.userId}`,
+        userId: session.userId,
+        expiresAt: session.expiresAt,
+        user: { id: session.userId, isActive: session.isActive },
+      }
+    },
+  },
+  subAccount: {
+    findUnique: async ({ where }: any) => {
+      const { parentUserId, childUserId } = where.parentUserId_childUserId
+      return store.grants.get(`${parentUserId}:${childUserId}`) ?? null
+    },
+    findMany: async ({ where }: any) => {
+      const parents: Array<{ parentUserId: string }> = []
+      for (const [key, grant] of store.grants) {
+        const [parentUserId, childUserId] = key.split(':')
+        if (
+          childUserId === where.childUserId &&
+          grant.status === 'ACTIVE' &&
+          grant.permissions.includes('VIEW')
+        ) {
+          parents.push({ parentUserId })
+        }
+      }
+      return parents
+    },
+  },
+  webhookSubscription: { findMany: async () => [] },
+}
+
+jest.mock('../../src/db', () => ({ __esModule: true, default: mockDb }))
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logBackgroundJob: jest.fn(),
+}))
+
+import { JwtAdapter } from '../../src/config'
+import { config } from '../../src/config/env'
+import { publishUserEvent } from '../../src/events/publisher'
+import { resetHub } from '../../src/events/hub'
+import {
+  attachWebSocketServer,
+  closeWebSocketServer,
+  getConnectionCount,
+} from '../../src/ws/server'
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+let server: http.Server
+let port: number
+
+/** Collects frames so a test can await the one it cares about. */
+class FrameCollector {
+  readonly frames: any[] = []
+  constructor(private readonly ws: WebSocket) {
+    ws.on('message', (raw) => this.frames.push(JSON.parse(raw.toString())))
+  }
+
+  /** Resolve once a frame matching `predicate` arrives (or has already). */
+  async waitFor(
+    predicate: (frame: any) => boolean,
+    timeoutMs = 3000
+  ): Promise<any> {
+    const existing = this.frames.find(predicate)
+    if (existing) return existing
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.ws.off('message', onMessage)
+        reject(
+          new Error(
+            `Timed out waiting for frame. Saw: ${JSON.stringify(
+              this.frames.map((f) => f.type)
+            )}`
+          )
+        )
+      }, timeoutMs)
+
+      const onMessage = (raw: WebSocket.RawData) => {
+        const frame = JSON.parse(raw.toString())
+        if (!predicate(frame)) return
+        clearTimeout(timer)
+        this.ws.off('message', onMessage)
+        resolve(frame)
+      }
+
+      this.ws.on('message', onMessage)
+    })
+  }
+}
+
+async function issueToken(userId: string): Promise<string> {
+  const token = (await JwtAdapter.generateToken({ id: userId }))!
+  store.sessions.set(token, {
+    userId,
+    isActive: true,
+    expiresAt: new Date(Date.now() + 3_600_000),
+  })
+  return token
+}
+
+function connect(
+  token: string | null,
+  query = ''
+): { ws: WebSocket; frames: FrameCollector } {
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}${config.websocket.path}${query}`,
+    { headers }
+  )
+  return { ws, frames: new FrameCollector(ws) }
+}
+
+function open(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve())
+    ws.once('error', reject)
+  })
+}
+
+const sockets: WebSocket[] = []
+
+function track(ws: WebSocket): WebSocket {
+  sockets.push(ws)
+  return ws
+}
+
+beforeAll(async () => {
+  server = http.createServer()
+  attachWebSocketServer(server)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  port = (server.address() as AddressInfo).port
+})
+
+afterAll(async () => {
+  await closeWebSocketServer(500)
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+})
+
+beforeEach(() => {
+  store.reset()
+})
+
+afterEach(async () => {
+  for (const ws of sockets.splice(0)) {
+    ws.removeAllListeners()
+    ws.terminate()
+  }
+  // Give the server's close handlers a tick to deregister the connections.
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  resetHub()
+})
+
+// ── Handshake ─────────────────────────────────────────────────────────────────
+
+describe('WebSocket handshake', () => {
+  it('rejects an unauthenticated upgrade with 401 before any data is sent', async () => {
+    const { ws } = connect(null)
+    track(ws)
+
+    const error = await new Promise<Error>((resolve) =>
+      ws.once('error', resolve)
+    )
+    expect(error.message).toMatch(/401/)
+    expect(getConnectionCount()).toBe(0)
+  })
+
+  it('rejects a token whose session was revoked', async () => {
+    const token = await issueToken(CHILD_USER)
+    store.sessions.delete(token) // logout between issuing and connecting
+
+    const { ws } = connect(token)
+    track(ws)
+
+    const error = await new Promise<Error>((resolve) =>
+      ws.once('error', resolve)
+    )
+    expect(error.message).toMatch(/401/)
+  })
+
+  it('accepts an authenticated upgrade and greets with hello', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+
+    const hello = await frames.waitFor((f) => f.type === 'hello')
+    expect(hello).toMatchObject({ actor: 'self', currentSeq: 0 })
+    expect(hello.topics).toEqual(
+      expect.arrayContaining(['portfolio', 'transactions', 'strategies'])
+    )
+  })
+})
+
+// ── Subscribe and live delivery ───────────────────────────────────────────────
+
+describe('subscribe and live delivery', () => {
+  it('delivers a published event to a subscribed client, redacted', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['transactions'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-1',
+      amount: '25',
+      assetSymbol: 'USDC',
+      protocolName: 'Blend',
+      network: 'testnet',
+      user: 'GWALLET',
+      userId: CHILD_USER,
+    })
+
+    const event = await frames.waitFor((f) => f.type === 'event')
+    expect(event).toMatchObject({
+      seq: 1,
+      topic: 'transactions',
+      event: 'deposit.received',
+    })
+    expect(event.payload).toMatchObject({ txHash: 'tx-1', amount: '25' })
+    // The wire must not carry identity just because it is a socket.
+    expect(event.payload).not.toHaveProperty('userId')
+    expect(event.payload).not.toHaveProperty('user')
+  })
+
+  it('does not deliver another user’s events', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['transactions'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    await publishUserEvent(OTHER_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-other',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(frames.frames.filter((f) => f.type === 'event')).toHaveLength(0)
+  })
+
+  it('withholds events on topics the client did not subscribe to', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['alerts'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-1',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(frames.frames.filter((f) => f.type === 'event')).toHaveLength(0)
+  })
+
+  it('answers a malformed message with an error frame, not a disconnect', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send('not json')
+    const error = await frames.waitFor((f) => f.type === 'error')
+    expect(error.code).toBe('bad_request')
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+  })
+})
+
+// ── Resume and replay ─────────────────────────────────────────────────────────
+
+describe('resume replay', () => {
+  it('replays everything missed while disconnected, in order, then goes live', async () => {
+    const token = await issueToken(CHILD_USER)
+
+    // Three events happen while the client is away.
+    for (const txHash of ['tx-1', 'tx-2', 'tx-3']) {
+      await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+        txHash,
+      })
+    }
+
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(
+      JSON.stringify({
+        type: 'resume',
+        topics: ['transactions'],
+        afterSeq: 1, // the client already processed tx-1
+      })
+    )
+
+    await frames.waitFor((f) => f.type === 'replay' && f.status === 'end')
+
+    const replayed = frames.frames.filter((f) => f.type === 'event')
+    expect(replayed.map((f) => f.seq)).toEqual([2, 3])
+    expect(replayed.map((f) => f.payload.txHash)).toEqual(['tx-2', 'tx-3'])
+
+    // …and the switch to live leaves no hole.
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-4',
+    })
+    const live = await frames.waitFor((f) => f.type === 'event' && f.seq === 4)
+    expect(live.payload.txHash).toBe('tx-4')
+  })
+
+  it('replays nothing when the client is already current', async () => {
+    const token = await issueToken(CHILD_USER)
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-1',
+    })
+
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(
+      JSON.stringify({
+        type: 'resume',
+        topics: ['transactions'],
+        afterSeq: 1,
+      })
+    )
+
+    const end = await frames.waitFor(
+      (f) => f.type === 'replay' && f.status === 'end'
+    )
+    expect(end.count).toBe(0)
+    expect(frames.frames.filter((f) => f.type === 'event')).toHaveLength(0)
+  })
+
+  it('restricts a replay to the requested topics', async () => {
+    const token = await issueToken(CHILD_USER)
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-1',
+    })
+    await publishUserEvent(CHILD_USER, 'alerts', 'alert_rule.triggered', {
+      ruleId: 'rule-1',
+    })
+
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(JSON.stringify({ type: 'resume', topics: ['alerts'], afterSeq: 0 }))
+    await frames.waitFor((f) => f.type === 'replay' && f.status === 'end')
+
+    const events = frames.frames.filter((f) => f.type === 'event')
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ seq: 2, topic: 'alerts' })
+  })
+})
+
+// ── Gap semantics ─────────────────────────────────────────────────────────────
+
+describe('gap frames', () => {
+  it('answers a stale afterSeq with a gap carrying the newest available seq', async () => {
+    const token = await issueToken(CHILD_USER)
+
+    // Simulate retention having evicted seq 1–5: the counter is at 8, but the
+    // oldest surviving row is 6.
+    store.seqs.set(CHILD_USER, 8)
+    for (const seq of [6, 7, 8]) {
+      store.rows.push({
+        userId: CHILD_USER,
+        seq,
+        topic: 'transactions',
+        type: 'deposit.received',
+        payload: { txHash: `tx-${seq}` },
+        createdAt: new Date(),
+      })
+    }
+
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(
+      JSON.stringify({
+        type: 'resume',
+        topics: ['transactions'],
+        afterSeq: 2, // older than what survives
+      })
+    )
+
+    const gap = await frames.waitFor((f) => f.type === 'gap')
+    expect(gap).toMatchObject({
+      reason: 'retention',
+      afterSeq: 2,
+      currentSeq: 8,
+      oldestAvailableSeq: 6,
+      snapshotRequired: true,
+    })
+    // No truncated replay was served alongside it.
+    expect(frames.frames.filter((f) => f.type === 'event')).toHaveLength(0)
+  })
+
+  it('answers an afterSeq ahead of the server with an unknown_stream gap', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(
+      JSON.stringify({
+        type: 'resume',
+        topics: ['transactions'],
+        afterSeq: 99,
+      })
+    )
+
+    const gap = await frames.waitFor((f) => f.type === 'gap')
+    expect(gap).toMatchObject({
+      reason: 'unknown_stream',
+      currentSeq: 0,
+      snapshotRequired: true,
+    })
+  })
+})
+
+// ── Sub-account scoping ───────────────────────────────────────────────────────
+
+describe('sub-account delegated streams', () => {
+  it('delivers a child’s events to a permitted parent', async () => {
+    const parentToken = await issueToken(PARENT_USER)
+    store.grants.set(`${PARENT_USER}:${CHILD_USER}`, {
+      permissions: ['VIEW'],
+      status: 'ACTIVE',
+    })
+
+    const { ws, frames } = connect(parentToken, `?actor=${CHILD_USER}`)
+    track(ws)
+    await open(ws)
+
+    const hello = await frames.waitFor((f) => f.type === 'hello')
+    expect(hello.actor).toBe('delegated')
+
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['transactions'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-child',
+    })
+
+    const event = await frames.waitFor((f) => f.type === 'event')
+    expect(event.payload.txHash).toBe('tx-child')
+  })
+
+  it('rejects a delegated handshake with no grant', async () => {
+    const parentToken = await issueToken(PARENT_USER)
+    const { ws } = connect(parentToken, `?actor=${CHILD_USER}`)
+    track(ws)
+
+    const error = await new Promise<Error>((resolve) =>
+      ws.once('error', resolve)
+    )
+    expect(error.message).toMatch(/403/)
+  })
+
+  it('refuses a topic outside the grant with a forbidden error frame', async () => {
+    const parentToken = await issueToken(PARENT_USER)
+    store.grants.set(`${PARENT_USER}:${CHILD_USER}`, {
+      permissions: ['VIEW'], // no MANAGE_STRATEGY
+      status: 'ACTIVE',
+    })
+
+    const { ws, frames } = connect(parentToken, `?actor=${CHILD_USER}`)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['strategies'] }))
+
+    const error = await frames.waitFor((f) => f.type === 'error')
+    expect(error).toMatchObject({ code: 'forbidden' })
+    expect(error.message).toMatch(/strategies/)
+  })
+
+  it('stops delivering the moment the grant is revoked, without a reconnect', async () => {
+    const parentToken = await issueToken(PARENT_USER)
+    store.grants.set(`${PARENT_USER}:${CHILD_USER}`, {
+      permissions: ['VIEW'],
+      status: 'ACTIVE',
+    })
+
+    const { ws, frames } = connect(parentToken, `?actor=${CHILD_USER}`)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['transactions'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    // Revoked after the handshake — the publisher re-resolves viewers per event,
+    // so the very next publish is already out of reach.
+    store.grants.set(`${PARENT_USER}:${CHILD_USER}`, {
+      permissions: ['VIEW'],
+      status: 'REVOKED',
+    })
+
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-after-revoke',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(frames.frames.filter((f) => f.type === 'event')).toHaveLength(0)
+  })
+})
+
+// ── Graceful shutdown ─────────────────────────────────────────────────────────
+
+describe('graceful shutdown', () => {
+  it('sends a draining frame with a resumable seq before closing', async () => {
+    const token = await issueToken(CHILD_USER)
+    const { ws, frames } = connect(token)
+    track(ws)
+    await open(ws)
+    await frames.waitFor((f) => f.type === 'hello')
+    ws.send(JSON.stringify({ type: 'subscribe', topics: ['transactions'] }))
+    await frames.waitFor((f) => f.type === 'subscribed')
+
+    await publishUserEvent(CHILD_USER, 'transactions', 'deposit.received', {
+      txHash: 'tx-1',
+    })
+    await frames.waitFor((f) => f.type === 'event')
+
+    const closed = new Promise<number>((resolve) =>
+      ws.once('close', (code) => resolve(code))
+    )
+
+    await closeWebSocketServer(500)
+
+    const draining = await frames.waitFor((f) => f.type === 'draining')
+    expect(draining).toMatchObject({
+      reason: 'server_shutdown',
+      resumeAfterSeq: 1,
+    })
+    expect(await closed).toBe(1001)
+
+    // Re-attach for the remaining tests in the file.
+    attachWebSocketServer(server)
+  })
+})

--- a/tests/unit/events/hub.test.ts
+++ b/tests/unit/events/hub.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #316 — in-process fan-out registry.
+ *
+ * The one rule worth a test: a subscriber is handed an event only when the
+ * viewer identity it authenticated with is in the set the PUBLISHER authorised.
+ * The hub never decides permission for itself.
+ */
+
+import {
+  countLocalSubscribers,
+  deliverToLocalSubscribers,
+  resetHub,
+  subscribeToUserStream,
+} from '../../../src/events/hub'
+import type { UserEventEnvelope } from '../../../src/events/types'
+
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+function envelope(
+  overrides: Partial<UserEventEnvelope> = {}
+): UserEventEnvelope {
+  return {
+    streamUserId: 'child-1',
+    authorizedViewers: ['child-1'],
+    seq: 1,
+    topic: 'portfolio',
+    type: 'portfolio.updated',
+    payload: {},
+    emittedAt: '2026-08-25T00:00:00.000Z',
+    originId: 'pod-1',
+    ...overrides,
+  }
+}
+
+afterEach(() => resetHub())
+
+describe('event hub', () => {
+  it('delivers to the stream owner', () => {
+    const deliver = jest.fn()
+    subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'child-1',
+      deliver,
+    })
+
+    expect(deliverToLocalSubscribers(envelope())).toBe(1)
+    expect(deliver).toHaveBeenCalledTimes(1)
+  })
+
+  it('withholds from a viewer the publisher did not authorise', () => {
+    const deliver = jest.fn()
+    subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'parent-1',
+      deliver,
+    })
+
+    // Grant revoked between handshake and publish: the viewer set says no.
+    expect(deliverToLocalSubscribers(envelope())).toBe(0)
+    expect(deliver).not.toHaveBeenCalled()
+  })
+
+  it('delivers to a permitted parent on the child stream', () => {
+    const deliver = jest.fn()
+    subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'parent-1',
+      deliver,
+    })
+
+    const count = deliverToLocalSubscribers(
+      envelope({ authorizedViewers: ['child-1', 'parent-1'] })
+    )
+    expect(count).toBe(1)
+  })
+
+  it('keeps fanning out when one subscriber throws', () => {
+    const good = jest.fn()
+    subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'child-1',
+      deliver: () => {
+        throw new Error('wedged socket')
+      },
+    })
+    subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'child-1',
+      deliver: good,
+    })
+
+    expect(deliverToLocalSubscribers(envelope())).toBe(1)
+    expect(good).toHaveBeenCalledTimes(1)
+  })
+
+  it('unregisters cleanly', () => {
+    const unsubscribe = subscribeToUserStream({
+      streamUserId: 'child-1',
+      viewerUserId: 'child-1',
+      deliver: jest.fn(),
+    })
+    expect(countLocalSubscribers()).toBe(1)
+    unsubscribe()
+    expect(countLocalSubscribers()).toBe(0)
+    expect(deliverToLocalSubscribers(envelope())).toBe(0)
+  })
+})

--- a/tests/unit/events/publisher.test.ts
+++ b/tests/unit/events/publisher.test.ts
@@ -1,0 +1,192 @@
+/**
+ * #316 — publishUserEvent, the single emit path for user-facing domain events.
+ *
+ * The assertions that matter here are the ones the acceptance criteria turn on:
+ *   * one call reaches BOTH the durable stream and the webhook dispatcher
+ *   * the socket payload is redacted; the webhook payload is not
+ *   * sub-account viewers are resolved by the PUBLISHER from live grants
+ *   * a stream failure never costs the webhook leg and never throws
+ */
+
+// Config env validation runs at import time; supply the required vars before
+// any src import loads src/config/env (same pattern as the other unit tests).
+process.env.NODE_ENV = 'test'
+process.env.STELLAR_NETWORK = 'testnet'
+process.env.STELLAR_RPC_URL = 'https://soroban-testnet.stellar.org'
+process.env.STELLAR_AGENT_SECRET_KEY = 'S' + 'A'.repeat(55)
+process.env.VAULT_CONTRACT_ID = 'C' + 'A'.repeat(55)
+process.env.USDC_TOKEN_ADDRESS = 'C' + 'B'.repeat(55)
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.JWT_SEED = '0'.repeat(64)
+process.env.WALLET_ENCRYPTION_KEY = '0'.repeat(64)
+process.env.TWILIO_AUTH_TOKEN = '0'.repeat(32)
+
+import { publishUserEvent } from '../../../src/events/publisher'
+import { appendUserEvent } from '../../../src/events/store'
+import { broadcastEnvelope } from '../../../src/events/bridge'
+import { dispatchWebhookEvent } from '../../../src/services/webhookDispatcher'
+import db from '../../../src/db'
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/events/store', () => ({
+  appendUserEvent: jest.fn(),
+}))
+jest.mock('../../../src/events/bridge', () => ({
+  broadcastEnvelope: jest.fn().mockResolvedValue(0),
+  POD_ID: 'test-pod',
+}))
+jest.mock('../../../src/services/webhookDispatcher', () => ({
+  dispatchWebhookEvent: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+const mockDb = db as any
+const mockAppend = appendUserEvent as jest.Mock
+const mockBroadcast = broadcastEnvelope as jest.Mock
+const mockWebhook = dispatchWebhookEvent as jest.Mock
+
+const USER = 'user-1'
+const PARENT = 'parent-1'
+
+beforeEach(() => {
+  mockDb.subAccount = { findMany: jest.fn().mockResolvedValue([]) }
+  let seq = 0
+  mockAppend.mockImplementation(async (params: any) => ({
+    seq: ++seq,
+    topic: params.topic,
+    type: params.type,
+    payload: params.payload,
+    emittedAt: '2026-08-25T00:00:00.000Z',
+  }))
+})
+
+describe('publishUserEvent', () => {
+  it('persists a redacted payload but hands the webhook the original', async () => {
+    await publishUserEvent(USER, 'transactions', 'deposit.received', {
+      txHash: 'abc',
+      amount: '10',
+      assetSymbol: 'USDC',
+      protocolName: 'Blend',
+      network: 'testnet',
+      shares: '9',
+      // Identity fields an operator's server may see and a browser may not.
+      user: 'GWALLETADDRESS',
+      userId: USER,
+    })
+
+    const stored = mockAppend.mock.calls[0][0]
+    expect(stored.payload).toEqual({
+      txHash: 'abc',
+      amount: '10',
+      shares: '9',
+      assetSymbol: 'USDC',
+      protocolName: 'Blend',
+      network: 'testnet',
+    })
+    expect(stored.payload).not.toHaveProperty('userId')
+    expect(stored.payload).not.toHaveProperty('user')
+
+    // The webhook leg is unchanged — an operator endpoint has always needed to
+    // know whose event it is.
+    expect(mockWebhook).toHaveBeenCalledWith(
+      'deposit.received',
+      expect.objectContaining({ userId: USER, user: 'GWALLETADDRESS' })
+    )
+  })
+
+  it('authorises a parent with an ACTIVE VIEW grant at publish time', async () => {
+    mockDb.subAccount.findMany.mockResolvedValue([{ parentUserId: PARENT }])
+
+    await publishUserEvent(USER, 'alerts', 'alert_rule.triggered', {
+      ruleId: 'rule-1',
+      userId: USER,
+      metric: 'PROTOCOL_APY',
+      observedValue: 4,
+    })
+
+    expect(mockDb.subAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          childUserId: USER,
+          status: 'ACTIVE',
+          permissions: { has: 'VIEW' },
+        }),
+      })
+    )
+    expect(mockBroadcast.mock.calls[0][0].authorizedViewers).toEqual([
+      USER,
+      PARENT,
+    ])
+  })
+
+  it('fails closed to the owner alone when the grant lookup errors', async () => {
+    mockDb.subAccount.findMany.mockRejectedValue(new Error('db down'))
+
+    await publishUserEvent(USER, 'alerts', 'alert_rule.triggered', {
+      ruleId: 'rule-1',
+    })
+
+    expect(mockBroadcast.mock.calls[0][0].authorizedViewers).toEqual([USER])
+  })
+
+  it('fans out to every affected user but dispatches the webhook once', async () => {
+    await publishUserEvent(
+      ['user-a', 'user-b', 'user-a'],
+      'agent',
+      'agent.rebalanced',
+      { fromProtocol: 'Blend', toProtocol: 'Luma', amount: '5' }
+    )
+
+    // Deduplicated — the same user in the batch twice is still one stream write.
+    expect(mockAppend).toHaveBeenCalledTimes(2)
+    expect(mockWebhook).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits socket-only types without touching the webhook channel', async () => {
+    await publishUserEvent(USER, 'portfolio', 'portfolio.updated', {
+      protocolName: 'Blend',
+      positionsAffected: 3,
+      reason: 'rebalance',
+    })
+
+    expect(mockAppend).toHaveBeenCalledTimes(1)
+    expect(mockWebhook).not.toHaveBeenCalled()
+  })
+
+  it('honours an explicit webhook:false without skipping the stream', async () => {
+    await publishUserEvent(
+      USER,
+      'alerts',
+      'alert_rule.triggered',
+      { ruleId: 'rule-1' },
+      { webhook: false }
+    )
+
+    expect(mockAppend).toHaveBeenCalledTimes(1)
+    expect(mockWebhook).not.toHaveBeenCalled()
+  })
+
+  it('never throws, and still dispatches the webhook, when the store fails', async () => {
+    mockAppend.mockRejectedValue(new Error('stream unavailable'))
+
+    await expect(
+      publishUserEvent(USER, 'transactions', 'transaction.confirmed', {
+        txHash: 'abc',
+        status: 'CONFIRMED',
+      })
+    ).resolves.toBeUndefined()
+
+    expect(mockWebhook).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops an unknown event type to an empty payload rather than passing it through', async () => {
+    await publishUserEvent(USER, 'portfolio', 'never.reviewed' as any, {
+      secret: 'leak-me',
+    })
+
+    expect(mockAppend.mock.calls[0][0].payload).toEqual({})
+  })
+})

--- a/tests/unit/jobs/alertRules.test.ts
+++ b/tests/unit/jobs/alertRules.test.ts
@@ -15,15 +15,17 @@ process.env.TWILIO_ACCOUNT_SID = 'AC' + '0'.repeat(32)
 
 import { runAlertRules } from '../../../src/jobs/alertRules'
 import db from '../../../src/db'
-import { dispatchWebhookEvent } from '../../../src/services/webhookDispatcher'
+import { publishUserEvent } from '../../../src/events/publisher'
 import { sendWhatsAppMessage } from '../../../src/utils/twilio-client'
 
 jest.mock('../../../src/db', () => ({
   __esModule: true,
   default: {},
 }))
-jest.mock('../../../src/services/webhookDispatcher', () => ({
-  dispatchWebhookEvent: jest.fn().mockResolvedValue(undefined),
+// #316: alert delivery now goes through the unified publisher, which fans out
+// to the user's real-time stream and (when the rule opts in) the webhook leg.
+jest.mock('../../../src/events/publisher', () => ({
+  publishUserEvent: jest.fn().mockResolvedValue(undefined),
 }))
 jest.mock('../../../src/utils/twilio-client', () => ({
   sendWhatsAppMessage: jest.fn().mockResolvedValue('sid-1'),
@@ -38,7 +40,7 @@ jest.mock('../../../src/utils/job-metrics', () => ({
 }))
 
 const mockDb = db as any
-const mockDispatch = dispatchWebhookEvent as jest.Mock
+const mockPublish = publishUserEvent as jest.Mock
 const mockSendWhatsApp = sendWhatsAppMessage as jest.Mock
 
 /** Build a fresh alertRule mock with sensible default resolved values. */
@@ -87,13 +89,18 @@ describe('runAlertRules', () => {
         data: { lastFiredAt: NOW },
       })
     )
-    expect(mockDispatch).toHaveBeenCalledWith(
+    expect(mockPublish).toHaveBeenCalledWith(
+      'user-1',
+      'alerts',
       'alert_rule.triggered',
       expect.objectContaining({
         ruleId: 'rule-1',
         observedValue: 4,
         threshold: 5,
-      })
+      }),
+      // WEBHOOK/BOTH rules keep the webhook leg; WHATSAPP-only rules publish to
+      // the socket alone.
+      { webhook: true }
     )
   })
 
@@ -116,7 +123,7 @@ describe('runAlertRules', () => {
     await runAlertRules(NOW)
 
     expect(mockDb.alertRule.updateMany).not.toHaveBeenCalled()
-    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockPublish).not.toHaveBeenCalled()
   })
 
   it('auto-deactivates a PROTOCOL_APY rule whose protocol has no rate data', async () => {
@@ -141,7 +148,7 @@ describe('runAlertRules', () => {
       where: { id: 'rule-1' },
       data: { isActive: false },
     })
-    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockPublish).not.toHaveBeenCalled()
   })
 
   it('does not deliver when the fire-claim matches 0 rows (deleted/deactivated mid-tick)', async () => {
@@ -164,7 +171,7 @@ describe('runAlertRules', () => {
 
     await runAlertRules(NOW)
 
-    expect(mockDispatch).not.toHaveBeenCalled()
+    expect(mockPublish).not.toHaveBeenCalled()
     expect(mockSendWhatsApp).not.toHaveBeenCalled()
   })
 
@@ -186,7 +193,7 @@ describe('runAlertRules', () => {
 
     await runAlertRules(NOW)
 
-    expect(mockDispatch).toHaveBeenCalledTimes(1)
+    expect(mockPublish).toHaveBeenCalledTimes(1)
     expect(mockSendWhatsApp).toHaveBeenCalledWith(
       expect.objectContaining({ to: 'whatsapp:+15551230000' })
     )
@@ -230,7 +237,7 @@ describe('runAlertRules', () => {
       },
     ])
     mockDb.position.findMany.mockResolvedValue([{ currentValue: 500 }])
-    mockDispatch.mockRejectedValueOnce(new Error('delivery boom'))
+    mockPublish.mockRejectedValueOnce(new Error('delivery boom'))
 
     await runAlertRules(NOW)
 

--- a/tests/unit/ws/auth.test.ts
+++ b/tests/unit/ws/auth.test.ts
@@ -1,0 +1,223 @@
+/**
+ * #316 — WebSocket handshake authentication and topic scoping.
+ *
+ * Covers the security-relevant half of the handshake: where a token may come
+ * from, that an invalid session is rejected before the protocol switch, and
+ * that a delegated (`?actor=`) connection gets the topic set its sub-account
+ * grant allows — not the one it asked for.
+ */
+
+process.env.NODE_ENV = 'test'
+process.env.STELLAR_NETWORK = 'testnet'
+process.env.STELLAR_RPC_URL = 'https://soroban-testnet.stellar.org'
+process.env.STELLAR_AGENT_SECRET_KEY = 'S' + 'A'.repeat(55)
+process.env.VAULT_CONTRACT_ID = 'C' + 'A'.repeat(55)
+process.env.USDC_TOKEN_ADDRESS = 'C' + 'B'.repeat(55)
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.JWT_SEED = '0'.repeat(64)
+process.env.WALLET_ENCRYPTION_KEY = '0'.repeat(64)
+process.env.TWILIO_AUTH_TOKEN = '0'.repeat(32)
+
+import type { IncomingMessage } from 'node:http'
+import {
+  authenticateHandshake,
+  extractActorParam,
+  extractHandshakeToken,
+} from '../../../src/ws/auth'
+import { JwtAdapter } from '../../../src/config'
+import db from '../../../src/db'
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+const mockDb = db as any
+const CHILD = 'child-1'
+const PARENT = 'parent-1'
+
+function req(
+  headers: Record<string, string>,
+  url = '/api/v1/ws'
+): IncomingMessage {
+  return { headers, url } as unknown as IncomingMessage
+}
+
+function activeSession(userId: string) {
+  return {
+    id: 'session-1',
+    expiresAt: new Date(Date.now() + 60_000),
+    user: { id: userId, isActive: true },
+  }
+}
+
+beforeEach(() => {
+  jest
+    .spyOn(JwtAdapter, 'validateToken')
+    .mockResolvedValue({ id: PARENT } as never)
+  mockDb.session = { findUnique: jest.fn() }
+  mockDb.subAccount = { findUnique: jest.fn() }
+})
+
+describe('extractHandshakeToken', () => {
+  it('reads an Authorization bearer header', () => {
+    expect(extractHandshakeToken(req({ authorization: 'Bearer tok' }))).toBe(
+      'tok'
+    )
+  })
+
+  it('reads the Sec-WebSocket-Protocol bearer pair browsers must use', () => {
+    expect(
+      extractHandshakeToken(req({ 'sec-websocket-protocol': 'bearer, tok' }))
+    ).toBe('tok')
+  })
+
+  it('refuses a token in the query string, where URLs get logged', () => {
+    expect(extractHandshakeToken(req({}, '/api/v1/ws?token=tok'))).toBeNull()
+  })
+})
+
+describe('extractActorParam', () => {
+  it('reads ?actor=', () => {
+    expect(extractActorParam(req({}, '/api/v1/ws?actor=child-1'))).toBe(
+      'child-1'
+    )
+  })
+
+  it('is null when absent', () => {
+    expect(extractActorParam(req({}, '/api/v1/ws'))).toBeNull()
+  })
+})
+
+describe('authenticateHandshake', () => {
+  it('rejects a request with no token', async () => {
+    const result = await authenticateHandshake(req({}))
+    expect(result).toMatchObject({ ok: false, code: 4401 })
+  })
+
+  it('rejects a token with no live session row', async () => {
+    mockDb.session.findUnique.mockResolvedValue(null)
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' })
+    )
+    expect(result).toMatchObject({ ok: false, reason: 'unauthorized' })
+  })
+
+  it('rejects an expired session even though the JWT still verifies', async () => {
+    mockDb.session.findUnique.mockResolvedValue({
+      id: 'session-1',
+      expiresAt: new Date(Date.now() - 1000),
+      user: { id: PARENT, isActive: true },
+    })
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' })
+    )
+    expect(result).toMatchObject({ ok: false, reason: 'unauthorized' })
+  })
+
+  it('rejects a deactivated account', async () => {
+    mockDb.session.findUnique.mockResolvedValue({
+      id: 'session-1',
+      expiresAt: new Date(Date.now() + 60_000),
+      user: { id: PARENT, isActive: false },
+    })
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' })
+    )
+    expect(result).toMatchObject({ ok: false, reason: 'unauthorized' })
+  })
+
+  it('binds a self connection to every topic', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' })
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.auth.streamUserId).toBe(PARENT)
+    expect(result.auth.delegated).toBe(false)
+    expect(result.auth.allowedTopics).toEqual(
+      expect.arrayContaining(['portfolio', 'transactions', 'strategies'])
+    )
+  })
+
+  it('refuses a delegated actor with no grant', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+    mockDb.subAccount.findUnique.mockResolvedValue(null)
+
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' }, `/api/v1/ws?actor=${CHILD}`)
+    )
+    expect(result).toMatchObject({ ok: false, code: 4403 })
+  })
+
+  it('refuses a REVOKED grant', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+    mockDb.subAccount.findUnique.mockResolvedValue({
+      permissions: ['VIEW'],
+      status: 'REVOKED',
+    })
+
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' }, `/api/v1/ws?actor=${CHILD}`)
+    )
+    expect(result).toMatchObject({ ok: false, code: 4403 })
+  })
+
+  it('narrows a VIEW-only parent to the read-only topics', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+    mockDb.subAccount.findUnique.mockResolvedValue({
+      permissions: ['VIEW', 'DEPOSIT'],
+      status: 'ACTIVE',
+    })
+
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' }, `/api/v1/ws?actor=${CHILD}`)
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.auth.delegated).toBe(true)
+    expect(result.auth.streamUserId).toBe(CHILD)
+    expect(result.auth.viewerUserId).toBe(PARENT)
+    expect(result.auth.allowedTopics.sort()).toEqual([
+      'agent',
+      'alerts',
+      'portfolio',
+      'transactions',
+    ])
+    // MANAGE_STRATEGY was not granted, so `strategies` is out of reach.
+    expect(result.auth.allowedTopics).not.toContain('strategies')
+  })
+
+  it('adds strategies only with MANAGE_STRATEGY', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+    mockDb.subAccount.findUnique.mockResolvedValue({
+      permissions: ['VIEW', 'MANAGE_STRATEGY'],
+      status: 'ACTIVE',
+    })
+
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' }, `/api/v1/ws?actor=${CHILD}`)
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.auth.allowedTopics).toContain('strategies')
+  })
+
+  it('treats ?actor= naming yourself as a plain self connection', async () => {
+    mockDb.session.findUnique.mockResolvedValue(activeSession(PARENT))
+
+    const result = await authenticateHandshake(
+      req({ authorization: 'Bearer t' }, `/api/v1/ws?actor=${PARENT}`)
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.auth.delegated).toBe(false)
+    expect(mockDb.subAccount.findUnique).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/ws/connection.test.ts
+++ b/tests/unit/ws/connection.test.ts
@@ -1,0 +1,260 @@
+/**
+ * #316 — per-connection backpressure and coalescing.
+ *
+ * Driven against a fake socket rather than a real one so `bufferedAmount` can
+ * be forced past the bound on demand — the whole point of the backpressure
+ * path is what happens when the kernel buffer is full, which is not something a
+ * loopback socket in a unit test will do for you.
+ */
+
+process.env.NODE_ENV = 'test'
+process.env.STELLAR_NETWORK = 'testnet'
+process.env.STELLAR_RPC_URL = 'https://soroban-testnet.stellar.org'
+process.env.STELLAR_AGENT_SECRET_KEY = 'S' + 'A'.repeat(55)
+process.env.VAULT_CONTRACT_ID = 'C' + 'A'.repeat(55)
+process.env.USDC_TOKEN_ADDRESS = 'C' + 'B'.repeat(55)
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test'
+process.env.JWT_SEED = '0'.repeat(64)
+process.env.WALLET_ENCRYPTION_KEY = '0'.repeat(64)
+process.env.TWILIO_AUTH_TOKEN = '0'.repeat(32)
+process.env.WS_COALESCE_WINDOW_MS = '20'
+
+import type { WebSocket } from 'ws'
+import { StreamConnection } from '../../../src/ws/connection'
+import { deliverToLocalSubscribers, resetHub } from '../../../src/events/hub'
+import { getLatestSeq } from '../../../src/events/store'
+import type { UserEventEnvelope } from '../../../src/events/types'
+import type { AuthenticatedHandshake } from '../../../src/ws/auth'
+
+jest.mock('../../../src/db', () => ({ __esModule: true, default: {} }))
+jest.mock('../../../src/events/store', () => ({
+  getLatestSeq: jest.fn().mockResolvedValue(0),
+  getOldestAvailableSeq: jest.fn().mockResolvedValue(null),
+  readAfterSeq: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('../../../src/ws/auth', () => ({
+  verifySessionToken: jest.fn().mockResolvedValue({
+    ok: true,
+    userId: 'user-1',
+    sessionId: 'session-1',
+  }),
+}))
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+const USER = 'user-1'
+
+const auth: AuthenticatedHandshake = {
+  viewerUserId: USER,
+  streamUserId: USER,
+  sessionId: 'session-1',
+  token: 'token',
+  allowedTopics: ['portfolio', 'transactions', 'agent', 'alerts', 'strategies'],
+  delegated: false,
+}
+
+/** Minimal WebSocket stand-in: records frames, exposes a settable buffer size. */
+class FakeSocket {
+  readonly sent: any[] = []
+  bufferedAmount = 0
+  private handlers = new Map<string, (...args: any[]) => void>()
+
+  on(event: string, handler: (...args: any[]) => void): this {
+    this.handlers.set(event, handler)
+    return this
+  }
+  send(raw: string): void {
+    this.sent.push(JSON.parse(raw))
+  }
+  ping(): void {}
+  close(): void {
+    this.handlers.get('close')?.()
+  }
+  terminate(): void {}
+  emit(event: string, ...args: any[]): void {
+    this.handlers.get(event)?.(...args)
+  }
+  framesOfType(type: string): any[] {
+    return this.sent.filter((f) => f.type === type)
+  }
+}
+
+function envelope(seq: number, type = 'portfolio.updated'): UserEventEnvelope {
+  return {
+    streamUserId: USER,
+    authorizedViewers: [USER],
+    seq,
+    topic: 'portfolio',
+    type: type as UserEventEnvelope['type'],
+    payload: { reason: 'rebalance' },
+    emittedAt: '2026-08-25T00:00:00.000Z',
+    originId: 'pod-1',
+  }
+}
+
+/** Connections opened by a test, closed in afterEach so no timer outlives it. */
+const opened: StreamConnection[] = []
+
+async function connected(
+  socket: FakeSocket,
+  message: Record<string, unknown> = {
+    type: 'subscribe',
+    topics: ['portfolio'],
+  }
+): Promise<StreamConnection> {
+  const connection = new StreamConnection({
+    ws: socket as unknown as WebSocket,
+    auth,
+    onClosed: () => {},
+  })
+  opened.push(connection)
+  await connection.start()
+  socket.emit('message', Buffer.from(JSON.stringify(message)))
+  // Let the async subscribe handler settle before events are delivered.
+  await new Promise((resolve) => setImmediate(resolve))
+  return connection
+}
+
+afterEach(() => {
+  for (const connection of opened.splice(0)) connection.close(1000, 'test over')
+  resetHub()
+  jest.clearAllMocks()
+  ;(getLatestSeq as jest.Mock).mockResolvedValue(0)
+})
+
+describe('StreamConnection backpressure', () => {
+  it('delivers normally while the socket keeps up', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    deliverToLocalSubscribers(envelope(1))
+    deliverToLocalSubscribers(envelope(2))
+
+    expect(socket.framesOfType('event').map((f) => f.seq)).toEqual([1, 2])
+    expect(socket.framesOfType('gap')).toHaveLength(0)
+  })
+
+  it('gaps with a resumable marker instead of buffering for a slow consumer', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    deliverToLocalSubscribers(envelope(1))
+    socket.bufferedAmount = 999_999_999 // kernel buffer full
+    deliverToLocalSubscribers(envelope(2))
+
+    const gap = socket.framesOfType('gap')
+    expect(gap).toHaveLength(1)
+    expect(gap[0]).toMatchObject({
+      reason: 'backpressure',
+      // The client resumes from the last frame it actually got.
+      afterSeq: 1,
+    })
+    expect(socket.framesOfType('event').map((f) => f.seq)).toEqual([1])
+  })
+
+  it('emits exactly one gap frame however long the consumer stays behind', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    socket.bufferedAmount = 999_999_999
+    for (let seq = 1; seq <= 25; seq++) {
+      deliverToLocalSubscribers(envelope(seq))
+    }
+
+    expect(socket.framesOfType('gap')).toHaveLength(1)
+    expect(socket.framesOfType('event')).toHaveLength(0)
+  })
+
+  it('coalesces same-type bursts to the newest when the client opts in', async () => {
+    const socket = new FakeSocket()
+    await connected(socket, {
+      type: 'subscribe',
+      topics: ['portfolio'],
+      coalesce: true,
+    })
+
+    for (let seq = 1; seq <= 5; seq++) {
+      deliverToLocalSubscribers(envelope(seq))
+    }
+
+    // Nothing sent yet — the window is still open.
+    expect(socket.framesOfType('event')).toHaveLength(0)
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    const events = socket.framesOfType('event')
+    expect(events).toHaveLength(1)
+    expect(events[0].seq).toBe(5)
+  })
+
+  it('keeps distinct event types separate while coalescing', async () => {
+    const socket = new FakeSocket()
+    await connected(socket, {
+      type: 'subscribe',
+      topics: ['portfolio'],
+      coalesce: true,
+    })
+
+    deliverToLocalSubscribers(envelope(1, 'portfolio.updated'))
+    deliverToLocalSubscribers(envelope(2, 'portfolio.updated'))
+    deliverToLocalSubscribers(envelope(3, 'transaction.confirmed'))
+
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    // Latest-wins per (topic, type), emitted in ascending seq.
+    expect(socket.framesOfType('event').map((f) => f.seq)).toEqual([2, 3])
+  })
+
+  it('does not coalesce unless the client asked for it', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    for (let seq = 1; seq <= 4; seq++) {
+      deliverToLocalSubscribers(envelope(seq))
+    }
+
+    expect(socket.framesOfType('event').map((f) => f.seq)).toEqual([1, 2, 3, 4])
+  })
+})
+
+describe('StreamConnection message handling', () => {
+  it('rejects a frame larger than the configured cap', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    socket.emit('message', Buffer.alloc(10_000, 'a'))
+
+    expect(socket.framesOfType('error')[0]).toMatchObject({
+      code: 'bad_request',
+      message: 'Message too large',
+    })
+  })
+
+  it('answers an application ping with a pong', async () => {
+    const socket = new FakeSocket()
+    await connected(socket)
+
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'ping' })))
+
+    expect(socket.framesOfType('pong')).toHaveLength(1)
+  })
+
+  it('stops delivering a topic after unsubscribe', async () => {
+    const socket = new FakeSocket()
+    const connection = await connected(socket)
+
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({ type: 'unsubscribe', topics: ['portfolio'] })
+      )
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+
+    deliverToLocalSubscribers(envelope(1))
+    expect(socket.framesOfType('event')).toHaveLength(0)
+    connection.close(1000, 'done')
+  })
+})

--- a/tests/unit/ws/protocol.test.ts
+++ b/tests/unit/ws/protocol.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #316 — client→server message schemas.
+ *
+ * The receive side is a control channel and nothing else, so the interesting
+ * cases are the refusals: unknown message types, unknown keys, and topics that
+ * are not in the vocabulary.
+ */
+
+import { clientMessageSchema } from '../../../src/ws/protocol'
+
+describe('clientMessageSchema', () => {
+  it('accepts a subscribe with topics', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'subscribe',
+      topics: ['portfolio', 'alerts'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a resume with afterSeq 0 (replay everything retained)', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'resume',
+      topics: ['transactions'],
+      afterSeq: 0,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an unknown topic', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'subscribe',
+      topics: ['admin'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty topic list', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'subscribe',
+      topics: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a negative afterSeq', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'resume',
+      topics: ['portfolio'],
+      afterSeq: -1,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown keys rather than ignoring them', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'subscribe',
+      topics: ['portfolio'],
+      replayEverything: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a write-shaped message — v1 is server→client only', () => {
+    const result = clientMessageSchema.safeParse({
+      type: 'place_order',
+      amount: '100',
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Authenticated Real-Time WebSocket Streaming with Resumable Event Replay

Closes #316

Every user-facing update was pull-based — a live dashboard meant either stale data or polling that burned the rate limit. The platform already produced an ordered event stream and already fanned it out to operator-configured webhooks (`src/services/webhookDispatcher.ts`); this PR exposes the same stream to the **end user** over an authenticated WebSocket, with no message loss across a reconnect.

**Endpoint:** `GET /api/v1/ws` · **Client contract:** [`docs/WEBSOCKET_STREAMING.md`](docs/WEBSOCKET_STREAMING.md) · **Subprotocol spec:** `docs/openapi.yaml`, operation `openRealtimeStream`

---

### 1. Authenticated transport

Mounted on the existing HTTP server with `noServer: true` and a manual `upgrade` handler, so **authentication runs before the protocol switch**: an unauthenticated peer receives an HTTP `401` and never becomes a WebSocket at all. Accepting the upgrade and closing afterwards would mean every rejected probe still cost a full socket, and would hand an unauthenticated caller a live connection however briefly.

The handshake runs the *same* checks as `src/middleware/authenticate.ts` — signature → live session row → expiry → active user — rather than a socket-flavoured variant, because "the WebSocket auth path" is exactly where a second set of rules rots. There is no anonymous fallback.

Token arrives as `Authorization: Bearer <jwt>` or the `Sec-WebSocket-Protocol: bearer, <jwt>` pair (browsers cannot set headers on a WebSocket). **`?token=` is deliberately unsupported** — URLs reach access logs, proxy logs, and referrers, and this token is a live session.

Also here: heartbeat with idle timeout, per-IP handshake rate limiting (a connection flood is a DoS vector even when every handshake fails auth), per-connection message rate limiting, per-user connection cap, and a `4096`-byte client frame cap.

**Revoked sessions kill live sockets.** Logout closes the user's sockets immediately on the handling pod; a periodic re-verification (`WS_SESSION_RECHECK_MS`, 60s) is the backstop that covers every other way a session dies — expiry, deactivation, admin action — and sockets held on other pods, without each of those code paths needing to know sockets exist.

### 2. Sequence-numbered stream with resumable replay

New `user_events` + `user_event_sequences` tables. `seq` is allocated by a single atomic `INSERT … ON CONFLICT DO UPDATE … RETURNING` on the counter row, **inside the same transaction** as the event insert: concurrent publishers for the same user serialise on that row lock, so no duplicate and — because the number is allocated and consumed together — no hole either. A hole is worse than a duplicate; a client waiting for the missing seq would stall forever.

> **Design decision — Postgres, not a Redis Stream.** `src/config/redis.ts` degrades to a no-op when `REDIS_URL` is unset, which is what most environments and the entire test suite actually run. A Redis-backed stream would make `resume afterSeq` silently unavailable exactly where it is hardest to notice, and would put durability on a store we treat everywhere else as a cache. Postgres is already the source of truth for every other domain event and is already covered by the retention job. Redis stays in the design as the cross-pod **transport**, never the store. Justified in code on `model UserEvent`.

`resume afterSeq` replays from the store, buffers live events arriving during the replay, then live-switches with no gap. Stale, ahead-of-server, and page-limited resumes are answered with a `gap` frame carrying `currentSeq`, `oldestAvailableSeq`, and a `snapshotRequired` flag — never an unbounded or silently truncated replay.

**Ordering contract:** within a topic, ascending `seq`. Across topics, no guarantee — all topics share one per-user sequence, so cross-topic order means sorting by `seq`. On-chain events inherit `ProcessedEvent`'s ledger ordering upstream. **Delivery is at-least-once** with a duplication window at reconnect; clients dedupe on `seq`. All documented.

**Bounded two ways** by `cleanupUserEvents` in the existing retention job: by age (`RETENTION_USER_EVENTS_DAYS`, 7d) and by rows per user (`USER_EVENT_STREAM_MAX_PER_USER`, 5000). Both are needed — age alone lets one pathological account grow without limit inside the window.

### 3. Unified emission

```typescript
publishUserEvent(userId, topic, type, payload)
```

Redacts → persists (allocating `seq`) → fans out to sockets locally and across pods → dispatches the operator webhook. Every domain site migrated onto it: `stellar/events`, `agent/loop`, `alertRules`, `strategy/service`, `transaction-controller`, `fiat/service`, `recurringDeposits`, `outbox/dispatcher`. `dispatchWebhookEvent` now has exactly one caller.

The webhook fires **once per domain occurrence** even when the occurrence touches many users (an agent rebalance across a batch), because webhook subscriptions here are operator-scoped, not per-user — fanning it out would duplicate it. Only the socket streams fan out. `publishUserEvent` never throws, preserving the existing fire-and-forget property: a notification problem must not roll back a deposit.

**Redaction.** Socket payloads are projected onto hand-written per-event-type allowlists in `src/utils/api-formatters.ts` — same discipline as the marketplace mappers, never a spread, never a denylist — applied *before* persistence, so a replay cannot hand back a field the live path stripped. No `userId`, wallet address, key, or internal column reaches a client; an unreviewed event type yields `{}` rather than passing through. The webhook leg still receives the full payload: an operator's endpoint is a trusted server, a browser is not.

### 4. Sub-account fan-out

`?actor=<userId>` binds the connection to a child's stream after verifying an ACTIVE `SubAccount` grant. Permissions decide the readable topics (`VIEW` → portfolio/transactions/agent/alerts, `MANAGE_STRATEGY` → strategies); a topic outside the grant is refused **at subscribe time** with a `forbidden` error frame, mirroring REST 403 semantics.

Crucially, authorisation is **also re-resolved by the publisher, from live grants, for every single event** (`resolveAuthorizedViewers`). The socket layer only intersects that set with the identity it authenticated at handshake — it never re-derives permission and never trusts the subscriber. A grant revoked mid-connection therefore stops delivery on the very next event, with no cache to invalidate and no reconnect required. There's an integration test for exactly that.

### 5. Backpressure, scaling, lifecycle

**Backpressure.** Past either bound (`WS_MAX_BUFFERED_EVENTS` frames, `WS_MAX_BUFFERED_BYTES` unflushed socket bytes) the connection stops delivering, emits **one** `gap` frame with the last seq it actually sent, and waits. Nothing is lost — the durable stream still holds everything past that seq. A slow consumer costs its own liveness, never the pod's memory.

**Event storms.** Opt-in per-subscription coalescing (latest-wins per `(topic, type)` within `WS_COALESCE_WINDOW_MS`). Coalescing may drop but never reorders. Its trade-off is stated rather than hidden: suppressed events stay in the store but are *not* redelivered by a later `resume`, because `afterSeq` has moved past them. Off by default — that's the client's call.

**Multi-instance.** Redis pub/sub bridges emits to the pod holding the socket, with the publishing pod's id in the envelope to suppress its own echo. The loss window is documented plainly: pub/sub is fire-and-forget, so live cross-pod delivery is at-most-once, and the durable store — not the transport — closes it via `resume`. **Redis down or unset never drops silently**: the publish still reaches local subscribers, is counted on `ws_bridge_publish_total{outcome="local_only"|"error"}`, and raises one alert through `alertingService` with a stable dedupe key.

**Graceful shutdown.** Sockets drain **before** `httpServer.close()` — an open WebSocket *is* a live HTTP connection, so closing the HTTP server first would block on them until the grace period expired and then cut them without warning. Each client gets a `draining` frame with the seq to resume after, then a 1001 close. Awaited.

**Observability.** Nine metrics on the existing registry: `ws_connections_active`, `ws_handshakes_total`, `ws_messages_sent_total`, `ws_messages_received_total`, `ws_replay_events_total`, `ws_gaps_total`, `ws_dropped_events_total`, `ws_bridge_publish_total`, `ws_publish_failures_total`.

---

### Verification

Beyond the suite, this was exercised against real infrastructure rather than only mocks:

* **Migrations applied to a scratch Postgres** (`prisma migrate deploy` green; `migrate diff` shows no drift for the new models).
* **Store driven against real Postgres**: 50 concurrent `appendUserEvent` calls produced exactly seq 1–50, gapless and unique; topic filtering, page limits, JSON round-trip, the per-user trim (kept the newest 10 of 50), and `ON DELETE CASCADE` all verified.
* **Live end-to-end smoke against the built server** (`node dist/index.js` + real DB + real socket client): unauthenticated upgrade rejected with 401, `hello`, `subscribe`, `resume` replaying seq 2–3 from the database with a redacted payload, `gap` on an ahead-of-server `afterSeq`, error frame on an unknown topic, and a clean SIGTERM exit with the drain step logged.

| Check | Result |
|---|---|
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run build` | pass |
| `npm test` | **1218 passed, 82 suites** (41 new) |
| `redocly lint docs/openapi.yaml` | valid (warnings only, all pre-existing categories) |
| `redocly bundle` | pass |
| `bash scripts/check-migration-rollback.sh` | pass |
| `npm audit --audit-level=high` | 0 vulnerabilities |
| `license-checker` (allowlist) | pass — `ws` and `@types/ws` are MIT |

New tests:

* `tests/integration/websocket.integration.test.ts` — **17 tests** driving a *real* `ws` client against a *real* `WebSocketServer` through the full sequence: handshake → subscribe → live event → disconnect → resume replay → gap. Only Postgres is substituted (by an in-memory store implementing the exact queries the code issues); the JWT is genuinely signed and verified, the handshake genuinely looks up a session, and the publisher genuinely redacts, allocates a seq, and fans out. Covers auth rejection, cross-user isolation, topic isolation, ordered replay + live-switch, both gap reasons, delegated streams, mid-connection revocation, and the shutdown drain.
* `tests/unit/events/publisher.test.ts` (8) — redaction vs. webhook payload, publish-time viewer resolution, fail-closed on grant-lookup error, multi-user fan-out with a single webhook, socket-only types, failure isolation.
* `tests/unit/ws/connection.test.ts` (9) — backpressure gapping and single-marker behaviour, coalescing semantics, message handling.
* `tests/unit/ws/auth.test.ts` (15) — token sources, session rejection paths, delegated topic narrowing.
* `tests/unit/ws/protocol.test.ts` (7), `tests/unit/events/hub.test.ts` (5).

`tests/unit/jobs/alertRules.test.ts` was updated because the module under test changed its dependency from `dispatchWebhookEvent` to `publishUserEvent` — same assertions, new signature.

### Acceptance criteria

| Criterion | Where |
|---|---|
| Authenticated handshake; unauthenticated and revoked-session connections rejected; permission-scoped topics enforced server-side | `src/ws/auth.ts`, `src/ws/server.ts`, `StreamConnection.applyTopics` |
| Monotonic per-user `seq`; `resume` replays without gaps or unbounded replay; stale `afterSeq` returns gap + current seq | `src/events/store.ts`, `StreamConnection.handleResume` |
| One `publishUserEvent` used by both socket and webhook paths | `src/events/publisher.ts` — `dispatchWebhookEvent` now has exactly one caller |
| Sub-account topics delivered to permitted parents with `actingAsUserId` semantics | `?actor=` handshake + publish-time viewer resolution |
| Backpressure bounds a slow consumer; drop-with-marker is resumable | `StreamConnection.enterGap` |
| Multi-instance delivery via Redis pub/sub with a documented loss window closed by resume | `src/events/bridge.ts` |
| Metrics for connections/messages/replay/gaps; sockets drain on shutdown | `src/utils/metrics.ts`, `closeWebSocketServer` |
| Subprotocol documented in `docs/openapi.yaml`; integration tests green | Both ✅ |

### Notes for the reviewer

* **New dependency:** `ws@^8.21.3` + `@types/ws` (both MIT; license gate passes).
* **Migration** `20260825000000_add_user_event_stream` ships with `rollback.sql`. The rollback documents its data loss: dropping the stream means live clients get `currentSeq: 0` and re-fetch a REST snapshot — the already-handled path, but expect a burst of snapshot requests.
* **`handleDepositEvent` / `handleWithdrawEvent` now return the `userId`** they already looked up, so the emit site can address the right stream without a second query.
* **`agent.rebalanced` from `src/stellar/events.ts` publishes with an empty user list** — the contract event is protocol-wide with no user to address, so it reaches the webhook channel alone. The per-user view comes from `src/agent/loop.ts`, which knows whose positions moved.
* **Design decisions and defaults** are recorded in `ASSUMPTIONS.md` under Issue #316 so any of them can be overridden without archaeology.
* No pre-existing issues were touched. A `migrate diff` drift on `portfolio_risk_aggregates` (DECIMAL vs `Float`) exists on `main` and is left alone.
